### PR TITLE
Update cljs http

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,9 @@ lein deps
 
 ## Usage
 
-To get an interactive development environment, you need to install a customized version of [cljs-http](https://github.com/bago2k4/cljs-http):
+To get an interactive development environment run:
 
 ```console
-cd ..
-git clone https://github.com/bago2k4/cljs-http
-cd cljs-http
-git checkout alternative-headers-temp
-lein install
-```
-
-Then go back to this repository folder and run:
-
-```console
-cd ../open-company-web
-lein clean
 lein figwheel
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
     [org.clojure/clojurescript "1.7.28"] ; Cljs compiler https://github.com/clojure/clojurescript
     [org.clojure/core.async "0.1.346.0-17112a-alpha"] ; Async library https://github.com/clojure/core.async
     [org.omcljs/om "0.9.0" :exclusions [cljsjs/react]] ; Cljs interface to React https://github.com/omcljs/om
-    [cljs-http "0.1.35"] ; Http for cljs https://github.com/r0man/cljs-http
+    [cljs-http "0.1.36"] ; Http for cljs https://github.com/r0man/cljs-http
     [prismatic/om-tools "0.3.11"] ; Tools for Om https://github.com/Prismatic/om-tools
     [sablono "0.3.5" :exclusions [cljsjs/react]] ; Hiccup templating for Om/React https://github.com/r0man/sablono
     [secretary "1.2.3"] ; Client-side router https://github.com/gf3/secretary

--- a/src/open_company_web/api.cljs
+++ b/src/open_company_web/api.cljs
@@ -75,7 +75,7 @@
         (apiput
           (str ticker "/" year "/" period)
           { :json-params json-data
-            :alternative-headers {
+            :headers {
               ; required by Chrome
               "Access-Control-Allow-Headers" "Content-Type"
               ; custom content type


### PR DESCRIPTION
card: https://trello.com/c/5GlIPmYK

since this has been merged https://github.com/r0man/cljs-http/pull/71 we can update our client to use the latest version of cljs-http.

test:
- update a report
- check the PUT request if it's done with the correct "content-type"