### PR TITLE
Company not found fix

### DIFF
--- a/src/open_company_web/components/list_companies.cljs
+++ b/src/open_company_web/components/list_companies.cljs
@@ -21,4 +21,6 @@
         (if (> (count company-list) 0)
           (dom/ul
             (om/build-all list-page-item company-list))
-          (dom/h2 "No companies found."))))))
+          (if (:loading data)
+            (dom/h4 "Loading companies...")
+            (dom/h2 "No companies found.")))))))

--- a/src/open_company_web/core.cljs
+++ b/src/open_company_web/core.cljs
@@ -59,6 +59,7 @@
       (utils/clean-company-caches)
       ; save route
       (router/set-route! ["companies"] {})
+      (swap! app-state assoc :loading true)
       ; load data from api
       (api/get-companies)
       ; render component

--- a/src/open_company_web/dispatcher.cljs
+++ b/src/open_company_web/dispatcher.cljs
@@ -25,7 +25,9 @@
     companies
     (fn [body]
       (when body
-        (swap! app-state assoc :companies (:companies (:collection body)))))))
+        (swap! app-state assoc :companies (:companies (:collection body)))
+        ; remove loading key
+        (swap! app-state dissoc :loading)))))
 
 (def company-dispatch
   (flux/register

--- a/src/open_company_web/dispatcher.cljs
+++ b/src/open_company_web/dispatcher.cljs
@@ -32,42 +32,42 @@
     company
     (fn [body]
       (when body
-        ; remove loading key
-        (swap! app-state dissoc :loading)
         ; add section name inside each section
         (let [updated-body (utils/fix-sections body)]
-          (swap! app-state assoc (keyword (:slug updated-body)) updated-body))))))
+          (swap! app-state assoc (keyword (:slug updated-body)) updated-body)
+          ; remove loading key
+          (swap! app-state dissoc :loading))))))
 
 (def section-dispatch
   (flux/register
     section
     (fn [body]
       (when body
-        ; remove loading key
-        (swap! app-state dissoc :loading)
         (let [fixed-section (utils/fix-section (:body body) (:section body))]
-          (swap! app-state assoc-in [(:slug body) (:section body)] fixed-section))))))
+          (swap! app-state assoc-in [(:slug body) (:section body)] fixed-section)
+          ; remove loading key
+          (swap! app-state dissoc :loading))))))
 
 (def revision-dispatch
   (flux/register
     revision
     (fn [body]
       (when body
-        ; remove loading key
-        (swap! app-state dissoc :loading)
         (let [fixed-section (utils/fix-section (:body body) (:section body) true)
               assoc-in-coll [(:slug body) (:section body) (:updated-at fixed-section)]]
-          (swap! revisions assoc-in assoc-in-coll fixed-section))))))
+          (swap! revisions assoc-in assoc-in-coll fixed-section)
+          ; remove loading key
+          (swap! app-state dissoc :loading))))))
 
 (def auth-settings-dispatch
   (flux/register
     auth-settings
     (fn [body]
       (when body
-        ; remove loading key
-        (swap! app-state dissoc :loading)
         ; add auth-settings data
-        (swap! app-state assoc :auth-settings body)))))
+        (swap! app-state assoc :auth-settings body)
+        ; remove loading key
+        (swap! app-state dissoc :loading)))))
 
 (def new-section-dispatch
   (flux/register


### PR DESCRIPTION
card: https://trello.com/c/orcBRl0X

I wasn't able to reproduce the case of the _company not found_ message as it appears to be timing issue with random factors but this should help to avoid that situation.

To test:
- load the companies list
- select a company
- go back
- select another company
- repeat with some more companies
- if you see the _company not found_ message before the company page is rendered please report the exact steps
- if not merge this and hope that it will never happen again :)