### PR TITLE
avoid getDOMNode, use the react component node directly

### DIFF
--- a/src/open_company_web/components/ui/cell.cljs
+++ b/src/open_company_web/components/ui/cell.cljs
@@ -24,7 +24,7 @@
   (when (= state :edit)
     (.setTimeout js/window #(let [input (om/get-ref owner "edit-field")]
                               (when input
-                                (.focus (.getDOMNode input)))) 10)))
+                                (.focus input))) 10)))
 
 (defn- initial-cell-state
   "Get the initial state for the cell.
@@ -116,7 +116,7 @@
             (dom/input #js {
                        :ref "edit-field"
                        :value value
-                       :onFocus #(let [input (.getDOMNode (om/get-ref owner "edit-field"))]
+                       :onFocus #(let [input (om/get-ref owner "edit-field")]
                                    (set! (.-value input) (.-value input)))
                        :onChange #(om/set-state! owner :value (.. % -target -value))
                        :onBlur #(exit-cell % owner data)

--- a/src/open_company_web/components/ui/charts.cljs
+++ b/src/open_company_web/components/ui/charts.cljs
@@ -75,9 +75,8 @@
 
 (defn check-scrolls-and-draw [owner chart-data initial-check]
   (when-not (om/get-state owner :animated)
-    (when-let [chart-ref (om/get-ref owner "charts")]
-      (let [chart-node (.getDOMNode chart-ref)
-            $chart-node (.$ js/window chart-node)
+    (when-let [chart-node (om/get-ref owner "charts")]
+      (let [$chart-node (.$ js/window chart-node)
             chart-offset-top (.-top (.offset $chart-node))
             $window (.$ js/window js/window)
             window-scroll-top (.scrollTop $window)
@@ -91,7 +90,7 @@
                       (:pattern chart-data)
                       (:values chart-data)
                       (get-column-thickness chart-data)
-                      (.getDOMNode (om/get-ref owner "column-chart")))
+                      (om/get-ref owner "column-chart"))
           (om/set-state! owner :animated true))))))
 
 (defn draw-chart-when-visible [owner chart-data]

--- a/src/open_company_web/components/ui/uncontrolled_content_editable.cljs
+++ b/src/open_company_web/components/ui/uncontrolled_content_editable.cljs
@@ -27,9 +27,8 @@
     (let [hallo-loaded (om/get-state owner :hallo-loaded)
           did-mount (om/get-state owner :did-mount)]
       (when (and hallo-loaded did-mount)
-        (when-let [editor-ref (om/get-ref owner "div-content-editable")]
-          (let [editor-node (.getDOMNode editor-ref)
-                hallo-opts (clj->js hallo-format)
+        (when-let [editor-node (om/get-ref owner "div-content-editable")]
+          (let [hallo-opts (clj->js hallo-format)
                 jquery-node (.$ js/window editor-node)]
             (.hallo jquery-node hallo-opts)
             (om/set-state! owner :hallo-initialized true)))))))
@@ -38,8 +37,7 @@
 (def change-counter (atom 0))
 
 (defn div-node [owner]
-  (when-let [div-ref (om/get-ref owner "div-content-editable")]
-    (.getDOMNode div-ref)))
+  (om/get-ref owner "div-content-editable"))
 
 (defn div-inner-html [owner]
   (when-let [dnode (div-node owner)]


### PR DESCRIPTION
card: https://trello.com/c/5ef7Ucz3

this leave out a couple of other warnings, like:
`Warning: React.render is deprecated. Please use ReactDOM.render from require('react-dom') instead.`
and
`Warning: React.unmountComponentAtNode is deprecated. Please use ReactDOM.unmountComponentAtNode from require('react-dom') instead.`
but i can't do nothing about it since they are internally to om.

to test:
- run the local figwheel
- check the site
- the warning were fired simply scrolling the company page down
- if you don't see any warning about getDOMNode deprecated you can merge this