### PR TITLE
fix logger failures

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -32,7 +32,8 @@
     [perun "0.3.0" :scope "test"]
     [compojure "1.5.0" :scope "test"]
     [pandeiro/boot-http "0.7.3" :scope "test"]
-    [deraen/boot-sass "0.2.1" :scope "test"]])
+    [deraen/boot-sass "0.2.1" :scope "test"]
+    [org.slf4j/slf4j-nop "1.7.13" :scope "test"]])
 
 (set-env!
   :source-paths   #{"src" "scss" "site"}


### PR DESCRIPTION
fixes the following
```
Compiling {sass}... 58 changed files.
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
To test: run `boot dev` and check that the above SLF4J lines are not printed