### PR TITLE
Minor ui issues

### DIFF
--- a/scss/partials/_category_nav.scss
+++ b/scss/partials/_category_nav.scss
@@ -8,7 +8,6 @@ div.company-dashboard {
     z-index: 2;
     margin: 0px;
     padding: 2px 0px;
-    width: 100%;
     height: 46px;
     -webkit-backface-visibility: hidden;
     text-align: center;

--- a/scss/partials/_stakeholder_update.scss
+++ b/scss/partials/_stakeholder_update.scss
@@ -69,7 +69,7 @@ div.stakeholder-update {
         background-color: white;
 
         div.update-intro {
-          max-width: 930px;
+          max-width: 650px;
           margin: 0 auto;
         }
 
@@ -93,6 +93,8 @@ div.stakeholder-update {
       }
 
       div.update-topic {
+
+        max-width: 650px;
 
         div.topic-title {
           margin-top: 26px;

--- a/scss/partials/_stakeholder_update.scss
+++ b/scss/partials/_stakeholder_update.scss
@@ -69,7 +69,7 @@ div.stakeholder-update {
         background-color: white;
 
         div.update-intro {
-          width: 930px;
+          max-width: 930px;
           margin: 0 auto;
         }
 
@@ -79,7 +79,7 @@ div.stakeholder-update {
           div.update-sections-internal{
             background-color: white;
             padding: 10px;
-            width: 930px;
+            max-width: 930px;
             margin: 8px auto;
           }
         }

--- a/scss/partials/_stakeholder_update.scss
+++ b/scss/partials/_stakeholder_update.scss
@@ -51,23 +51,46 @@ div.stakeholder-update {
 
   div.stakeholder-update {
 
-    div.stakeholder-update-drawer {
-      padding-top: 60px;
-      position: relative;
+    div.company-header {
+      border-bottom: 1px solid $oc_gray_2;
+      padding-bottom: 46px;
     }
 
-    div.company-header-internal {
-      padding: 0 0;
-      width: 930px;
-      margin: 0 auto;
+    div.stakeholder-update-drawer {
+      position: relative;
+
+      div.drawer-toggler {
+        margin-top: -5px;
+      }
     }
   
     div.update-internal {
-      width: 930px;
-      margin: 0 auto;
 
       div.sections {
-        padding: 0 0;
+        @include mobile(){
+          background-color: #d9d9d9;
+        }
+
+        @include big_web(){
+          background-color: $oc_gray_1;
+        }
+
+        div.update-intro {
+          width: 930px;
+          margin: 0 auto;
+        }
+
+        div.update-sections {
+          padding: 10px 0px;
+
+          div.update-sections-internal{
+            box-shadow: 1px 1px 1px 0 #bababa;
+            background-color: white;
+            padding: 10px;
+            width: 930px;
+            margin: 8px auto;
+          }
+        }
       }
 
       div.intro-title,

--- a/scss/partials/_stakeholder_update.scss
+++ b/scss/partials/_stakeholder_update.scss
@@ -52,7 +52,6 @@ div.stakeholder-update {
   div.stakeholder-update {
 
     div.company-header {
-      border-bottom: 1px solid $oc_gray_2;
       padding-bottom: 46px;
     }
 
@@ -67,13 +66,7 @@ div.stakeholder-update {
     div.update-internal {
 
       div.sections {
-        @include mobile(){
-          background-color: #d9d9d9;
-        }
-
-        @include big_web(){
-          background-color: $oc_gray_1;
-        }
+        background-color: white;
 
         div.update-intro {
           width: 930px;
@@ -84,7 +77,6 @@ div.stakeholder-update {
           padding: 10px 0px;
 
           div.update-sections-internal{
-            box-shadow: 1px 1px 1px 0 #bababa;
             background-color: white;
             padding: 10px;
             width: 930px;
@@ -115,7 +107,7 @@ div.stakeholder-update {
 
         @include big_web(){
           margin-left: 0px;
-          width: 650px;
+          width: 100%;
         }
 
         @include mobile(){

--- a/src/open_company_web/components/company_header.cljs
+++ b/src/open_company_web/components/company_header.cljs
@@ -109,7 +109,7 @@
 
   (render [_]
     ;; add the scroll listener if the logo is not present and not stakeholder update
-    (when (and (not stakeholder-update) company-data (clojure.string/blank? (:logo company-data)))
+    (when (and company-data (clojure.string/blank? (:logo company-data)))
       (.setTimeout js/window #(watch-scroll owner) 500))
 
     (dom/div #js {:className "company-header"
@@ -136,9 +136,9 @@
             (dom/div {:class "company-logo-container"}
               (dom/img #js {:src (:logo company-data)
                             ;; add scroll listener when the logo is loaded unless stakeholder update
-                            :onLoad (when-not stakeholder-update #(logo-on-load owner))
+                            :onLoad #(logo-on-load owner)
                             ;; or add listener if logo errors on loading unless stakeholder update
-                            :onError (when-not stakeholder-update #(watch-scroll owner))
+                            :onError #(watch-scroll owner)
                             :className "company-logo"
                             :title (:name company-data)
                             :ref "company-logo"}))


### PR DESCRIPTION
card: https://trello.com/c/YbilftjA/378-minor-ui-issues

To test:
- switch btw dashboard and stakeholder update, the upper part of the page should remain almost unchanged

NB: there is a little jump when you switch, that's due to a calculation needed to center the company logo in the company header. For example in buffer it applies a top margin of 25px to the logo container. We can remove this calculation and avoid the jump but the logo won't be centred.
The problem is that we don't know the logo size until it is loaded. We could also avoid to show the page until the logo is loaded but that's not advisable since the logo is a url field so it could be everywhere and it could take a long time to load.