### PR TITLE
ensure filestack is required

### DIFF
--- a/src/open_company_web/components/topic_overlay_edit.cljs
+++ b/src/open_company_web/components/topic_overlay_edit.cljs
@@ -19,8 +19,8 @@
             [goog.dom.classlist :as cl]
             [goog.history.EventType :as EventType]
             [cljs-dynamic-resources.core :as cdr]
-            [cljsjs.medium-editor]
-            [cljsjs.filestack]
+            [cljsjs.medium-editor] ; pulled in for cljsjs externs
+            [cljsjs.filestack] ; pulled in for cljsjs externs
             [cuerdas.core :as s]))
 
 (defn change-value [owner k e]

--- a/src/open_company_web/components/topic_overlay_edit.cljs
+++ b/src/open_company_web/components/topic_overlay_edit.cljs
@@ -20,6 +20,7 @@
             [goog.history.EventType :as EventType]
             [cljs-dynamic-resources.core :as cdr]
             [cljsjs.medium-editor]
+            [cljsjs.filestack]
             [cuerdas.core :as s]))
 
 (defn change-value [owner k e]


### PR DESCRIPTION
@belucid dull mistake. CLJSJS libs aren't added to the build unless they're explicitly required. 