### PR TITLE
medium editor toolbar changes (color, buttons)

### DIFF
--- a/resources/public/css/medium-editor/default.css
+++ b/resources/public/css/medium-editor/default.css
@@ -1,5 +1,5 @@
 .medium-toolbar-arrow-under:after {
-  border-color: #242424 transparent transparent transparent;
+  border-color: #4E5A6B transparent transparent transparent;
   top: 50px; }
 
 .medium-toolbar-arrow-over:before {
@@ -7,16 +7,16 @@
   top: -8px; }
 
 .medium-editor-toolbar {
-  background-color: #242424;
-  background: -webkit-linear-gradient(top, #242424, rgba(36, 36, 36, 0.75));
-  background: linear-gradient(to bottom, #242424, rgba(36, 36, 36, 0.75));
-  border: 1px solid #000;
+  background-color: #4E5A6B;
+  background: -webkit-linear-gradient(top, #4E5A6B, rgba(78, 90, 107, 0.75));
+  background: linear-gradient(to bottom, #4E5A6B, rgba(78, 90, 107, 0.75));
+  border: 1px solid #4E5A6B;
   border-radius: 5px;
-  box-shadow: 0 0 3px #000; }
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.5); }
   .medium-editor-toolbar li button {
-    background-color: #242424;
-    background: -webkit-linear-gradient(top, #242424, rgba(36, 36, 36, 0.89));
-    background: linear-gradient(to bottom, #242424, rgba(36, 36, 36, 0.89));
+    background-color: #4E5A6B;
+    background: -webkit-linear-gradient(top, #4E5A6B, rgba(78, 90, 107, 0.89));
+    background: linear-gradient(to bottom, #4E5A6B, rgba(78, 90, 107, 0.89));
     border: 0;
     border-right: 1px solid #000;
     border-left: 1px solid #333;

--- a/src/open_company_web/components/topic_overlay_edit.cljs
+++ b/src/open_company_web/components/topic_overlay_edit.cljs
@@ -311,8 +311,7 @@
             finances-placeholder-data (get (:sections (get (:categories (slug @caches/new-sections)) 2)) 0)
             med-ed (new js/MediumEditor body-el (clj->js
                                                  (->  (utils/medium-editor-options (:note finances-placeholder-data))
-                                                      (editor/inject-extension editor/file-upload)
-                                                      (editor/inject-button "highlight" editor/hl-btn))))]
+                                                      (editor/inject-extension editor/file-upload))))]
         (.subscribe med-ed "editableInput" (fn [event editable]
                                              (om/set-state! owner :has-changes true)))
         (om/set-state! owner :initial-body (.-innerHTML body-el))

--- a/src/open_company_web/lib/utils.cljs
+++ b/src/open_company_web/lib/utils.cljs
@@ -674,7 +674,7 @@
              (.-offsetParent el)))))
 
 (defn medium-editor-options [placeholder]
-  {:toolbar #js {:buttons #js ["bold" "italic" "underline" "strikethrough" "h2" "orderedlist" "unorderedlist" "highlight"]}
+  {:toolbar #js {:buttons #js ["bold" "italic" "strikethrough" "h2" "orderedlist" "unorderedlist"]}
    :buttonLabels "fontawesome"
    :anchorPreview #js {:hideDelay 500, :previewValueSelector "a"}
    :anchor #js {;; These are the default options for anchor form,


### PR DESCRIPTION
![screenshot 2016-05-13 12 43 09](https://cloud.githubusercontent.com/assets/97496/15245733/b03a4f30-1908-11e6-9148-8c1580d724cf.png)

To test:
- run locally
- check that underline and highlight buttons are gone
- check that background color of toolbar is `#4E5A6B`