### PR TITLE
use auth-url instead of `full-url`

### DIFF
--- a/src/open_company_web/components/ui/login_button.cljs
+++ b/src/open_company_web/components/ui/login_button.cljs
@@ -10,12 +10,12 @@
 
 (defcomponent login-button [data owner]
   (render [_]
-    (let [full-url (:full-url (:auth-settings data))
+    (let [auth-url (:auth-url (:auth-settings data))
           current-token (router/get-token)]
       (dom/button {:class "login-button"
                    :on-click (fn [e]
                     (.preventDefault e)
                     (when-not (.startsWith current-token oc-urls/login)
                       (cook/set-cookie! :login-redirect current-token (* 60 60) "/" ls/jwt-cookie-domain ls/jwt-cookie-secure))
-                    (set! (.-location js/window) full-url))}
+                    (set! (.-location js/window) auth-url))}
         "Sign in / Sign up"))))

--- a/test/test/open_company_web/components/login.cljs
+++ b/test/test/open_company_web/components/login.cljs
@@ -14,10 +14,9 @@
 
 (def test-atom {
   :auth-settings {
-    :full-url "https://slack.com/oauth/authorize?client_id=&redirect_uri=/slack-oauth&state=open-company-auth&scope=identify,read,post"
+    :auth-url "https://slack.com/oauth/authorize?client_id=&redirect_uri=/slack-oauth&state=open-company-auth&scope=identify,read,post"
     :redirectURI "/slack-oauth"
     :state "open-company-auth"
-    :scope "identify,read,post"
     }
 })
 


### PR DESCRIPTION
when we want to have auth and bot adding separate we'll need
different URLs for each flow. This PR uses the new `auth-url`
field which replaces `full-url` (same value, more descriptive name).