### PR TITLE
Fix layout algorithm

### DIFF
--- a/src/open_company_web/lib/utils.cljs
+++ b/src/open_company_web/lib/utils.cljs
@@ -748,3 +748,6 @@
       (.moveToElementText rg content-editable-element)
       (.collapse rg false)
       (.select rg))))
+
+(defn aspect-ration-image-height [original-width original-height final-width]
+  (* (/ original-height original-width) final-width))


### PR DESCRIPTION
card: https://trello.com/c/uzJtyaPV

To test simply check the layout on some companies that have different number and type of topics. There are still problems with the data topics but they need to change again with [this card](https://trello.com/c/1KJzTPZz/430-return-of-the-finance-and-growth) so i didn't spent much time fixing them.
If you want to make sure the height of topics is exact you need to put this line:
`(println "topic" topic "height" final-height)`
at line 90 (for data topics) and 96 (for default and custom topics) of src/open_company_web/components/topics_columns.cljs and then check that the printed height correspond to the real height with the inspector (use the div with class _topic_ know the real height of the section).
Ask me if you need more info.