### PR TITLE
Handle auth settings call failure

### DIFF
--- a/src/open_company_web/actions.cljs
+++ b/src/open_company_web/actions.cljs
@@ -77,9 +77,12 @@
 
 (defmethod dispatcher/action :auth-settings [db [_ body]]
   (if body
+    ; auth settings loaded
     (when (and (utils/in? (:route @router/path) "confirm-invitation")
                  (contains? (:query-params @router/path) :token))
-        (utils/after 100 #(api/confirm-invitation (:token (:query-params @router/path)))))
+      ; call confirm-invitation if needed
+      (utils/after 100 #(api/confirm-invitation (:token (:query-params @router/path)))))
+    ; if the auth-settings call failed retry it in 2 seconds
     (utils/after 2000 #(api/get-auth-settings)))
   (assoc db :auth-settings body))
 

--- a/src/open_company_web/actions.cljs
+++ b/src/open_company_web/actions.cljs
@@ -77,12 +77,11 @@
 
 (defmethod dispatcher/action :auth-settings [db [_ body]]
   (if body
-    (do
-      (when (and (utils/in? (:route @router/path) "confirm-invitation")
+    (when (and (utils/in? (:route @router/path) "confirm-invitation")
                  (contains? (:query-params @router/path) :token))
         (utils/after 100 #(api/confirm-invitation (:token (:query-params @router/path)))))
-      (assoc db :auth-settings body))
-    db))
+    (utils/after 2000 #(api/get-auth-settings)))
+  (assoc db :auth-settings body))
 
 (defmethod dispatcher/action :revision [db [_ body]]
   (if body

--- a/src/open_company_web/api.cljs
+++ b/src/open_company_web/api.cljs
@@ -180,7 +180,7 @@
   (auth-get "/"
     {:headers {"content-type" "application/json"}}
     (fn [response]
-      (let [body (if (:success response) (:body response) {})]
+      (let [body (if (:success response) (:body response) false)]
         (dispatcher/dispatch! [:auth-settings body])))))
 
 (defn save-or-create-section [section-data]


### PR DESCRIPTION
This automatically retries every 2 seconds to load the auth-settings from the auth server in case it fails.
Also disable all the auth buttons while the settings aren't loaded.

To test:
- stop your local auth server or the staging service
- logout from the web app
- go to /
- try to login/signup
- [x] is the login/signup button disabled? good
- [x] do you see the auth-settings call retry every 2 seconds in the console? good
- merge