### PR TITLE
Multi-medium support in prior updates

### DIFF
--- a/scss/partials/_prior_updates.scss
+++ b/scss/partials/_prior_updates.scss
@@ -87,6 +87,7 @@ div.prior-updates {
 
         div.medium {
           display: inline;
+          padding-right: 2px;
         }
       }
     }

--- a/src/open_company_web/components/prior_updates.cljs
+++ b/src/open_company_web/components/prior_updates.cljs
@@ -112,4 +112,6 @@
                     [:div.update-title.domine
                       [:a {:href link :on-click #(when-not standalone-component (.preventDefault %))}
                         title]]
-                    [:div.update-details.domine author " shared by " medium " on " human-date]]))])]])))
+                    [:div.update-details.domine author " shared"
+                                                (when-not (empty? medium) " by ") medium
+                                                " on " human-date]]))])]])))

--- a/src/open_company_web/components/prior_updates.cljs
+++ b/src/open_company_web/components/prior_updates.cljs
@@ -2,6 +2,7 @@
   (:require [rum.core :as rum]
             [cljs-time.format :as f]
             [org.martinklepsch.derivatives :as drv]
+            [defun.core :refer (defun-)]
             [open-company-web.urls :as oc-urls]
             [open-company-web.components.ui.icon :as i]
             [open-company-web.components.ui.popover :as popover]
@@ -29,6 +30,26 @@
              (not (:su-list-loading @dispatcher/app-state))
              (not (:su-list-loaded @dispatcher/app-state)))
     (dispatcher/dispatch! [:get-su-list])))
+
+(defun- medium-for
+  ;; one possible initial case, just one medium
+  ([medium :guard string?] (medium-for [medium] []))
+
+  ;; another possible initial case, multiple mediums
+  ([mediums :guard sequential?] (medium-for mediums []))
+
+  ;; completion case
+  ([mediums :guard empty? html] html)
+
+  ;; progress cases
+  ([mediums :guard #(= "email" (first %)) html] 
+    (medium-for (rest mediums) (conj html [:div.medium (i/icon :email-84 {:size 13 :class "inline"})])))
+  ([mediums :guard #(= "slack" (first %)) html] 
+    (medium-for (rest mediums) (conj html [:div.medium [:i {:class "fa fa-slack"}]])))
+  ([mediums :guard #(= "link" (first %)) html] 
+    (medium-for (rest mediums) (conj html [:div.medium (i/icon :link-72 {:size 13 :class "inline"})])))
+  ([mediums html] ; legacy, unknown?
+    (medium-for (rest mediums) html)))
 
 (rum/defcs prior-updates
   < (drv/drv :su-list)
@@ -84,15 +105,11 @@
                               (str (:name (dispatcher/company-data)) " Update")
                               (:title update))
                       author (if same-user? "You" (-> update :author :name))
-                      medium (case (keyword (:medium update))
-                                  :email [:div.medium "by " (i/icon :email-84 {:size 13 :class "inline"})]
-                                  :slack [:span "to " [:i {:class "fa fa-slack"}]]
-                                  :legacy ""
-                                  [:div.medium "a " (i/icon :link-72 {:size 13 :class "inline"})])]
+                      medium (medium-for (:medium update))]
                   [:div.update {:key update-slug
                                 :class (when (= current-update update-slug) "active")
                                 :on-click #(when-not standalone-component (update-click list-link %))}
                     [:div.update-title.domine
                       [:a {:href link :on-click #(when-not standalone-component (.preventDefault %))}
                         title]]
-                    [:div.update-details.domine author " shared " medium " on " human-date]]))])]])))
+                    [:div.update-details.domine author " shared by " medium " on " human-date]]))])]])))

--- a/src/open_company_web/components/su_preview_dialog.cljs
+++ b/src/open_company_web/components/su_preview_dialog.cljs
@@ -271,25 +271,22 @@
                         (dis/dispatch! [:enumerate-channels])))
                     s)}
   [prompt-cb]
-  (let [jwt (:jwt @dis/app-state)
-        slack-share? (and (= (:auth-source jwt) "slack") ; auth'd w/ Slack
-                          (not (nil? (-> jwt :bot :token))))] ; with an installed Slack bot
-    [:div
-     (modal-title "Share Update" nil)
-     [:div.p3
-      (when slack-share?
-        [:div.group
-         [:button.btn-reset {:on-click #(prompt-cb :slack)}
-          [:div.circle50.left [:img {:src "/img/Slack_Icon.png" :style {:width "20px" :height "20px"}}]]
-          [:span.left.ml1.gray5.h6 {} "SHARE TO SLACK"]]])
+  [:div
+   (modal-title "Share Update" nil)
+   [:div.p3
+    (when (utils/slack-share?)
       [:div.group
-       [:button.btn-reset {:on-click #(prompt-cb :email)}
-        [:div.circle50.left (i/icon :email-84 {:color "rgba(78,90,107,0.6)" :accent-color "rgba(78,90,107,0.6)" :size 20})]
-        [:span.left.ml1.gray5.h6 {} "SHARE BY EMAIL"]]]
-      [:div.group
-       [:button.btn-reset {:on-click #(prompt-cb :link)}
-        [:div.circle50.left (i/icon :link-72 {:color "rgba(78,90,107,0.6)" :accent-color "rgba(78,90,107,0.6)" :size 20})]
-        [:span.left.ml1.gray5.h6 {} "SHARE A LINK"]]]]]))
+       [:button.btn-reset {:on-click #(prompt-cb :slack)}
+        [:div.circle50.left [:img {:src "/img/Slack_Icon.png" :style {:width "20px" :height "20px"}}]]
+        [:span.left.ml1.gray5.h6 {} "SHARE TO SLACK"]]])
+    [:div.group
+     [:button.btn-reset {:on-click #(prompt-cb :email)}
+      [:div.circle50.left (i/icon :email-84 {:color "rgba(78,90,107,0.6)" :accent-color "rgba(78,90,107,0.6)" :size 20})]
+      [:span.left.ml1.gray5.h6 {} "SHARE BY EMAIL"]]]
+    [:div.group
+     [:button.btn-reset {:on-click #(prompt-cb :link)}
+      [:div.circle50.left (i/icon :link-72 {:color "rgba(78,90,107,0.6)" :accent-color "rgba(78,90,107,0.6)" :size 20})]
+      [:span.left.ml1.gray5.h6 {} "SHARE A LINK"]]]]])
 
 (rum/defcs modal-actions < rum/reactive (drv/drv :su-share)
   [s send-fn cancel-fn type]

--- a/src/open_company_web/components/ui/navbar.cljs
+++ b/src/open_company_web/components/ui/navbar.cljs
@@ -59,10 +59,10 @@
       (scroll-listener nil)
       (om/set-state! owner :scroll-listener
         (events/listen js/window EventType/SCROLL scroll-listener)))
-
-    (when-not (and (responsive/is-tablet-or-mobile?)
-                   (not su-navbar))
-      (.tooltip (js/$ "[data-toggle=\"tooltip\"]"))))
+    (when-not (utils/is-test-env?)
+      (when-not (and (responsive/is-tablet-or-mobile?)
+                     (not su-navbar))
+        (.tooltip (js/$ "[data-toggle=\"tooltip\"]")))))
 
   (will-unmount [_]
     (when-let [scroll-listener (om/get-state owner :scroll-listener)]

--- a/src/open_company_web/components/ui/navbar.cljs
+++ b/src/open_company_web/components/ui/navbar.cljs
@@ -28,6 +28,16 @@
       (dommy/add-class! (sel1 [:body]) "fixed-navbar")
       (dommy/remove-class! (sel1 [:body]) "fixed-navbar"))))
 
+(defn- share-new-tooltip []
+  (if (utils/slack-share?)
+    "Select topics to share by Slack, email or link."
+    "Select topics to share by email or link."))
+
+(defn- share-tooltip []
+  (if (utils/slack-share?)
+    "Share this update by Slack, email or link."
+    "Share this update by email or link."))
+
 (defcomponent navbar [{:keys [company-data
                               columns-num
                               card-width
@@ -48,7 +58,11 @@
                    (not su-navbar))
       (scroll-listener nil)
       (om/set-state! owner :scroll-listener
-        (events/listen js/window EventType/SCROLL scroll-listener))))
+        (events/listen js/window EventType/SCROLL scroll-listener)))
+
+    (when-not (and (responsive/is-tablet-or-mobile?)
+                   (not su-navbar))
+      (.tooltip (js/$ "[data-toggle=\"tooltip\"]"))))
 
   (will-unmount [_]
     (when-let [scroll-listener (om/get-state owner :scroll-listener)]
@@ -119,10 +133,18 @@
                 (when fixed-show-share-su-button
                   (dom/div {:class "sharing-button-container"}
                     (dom/a {:class "btn-reset sharing-button right"
+                            :title (share-new-tooltip)
+                            :data-toggle "tooltip"
+                            :data-container "body"
+                            :data-placement "left"
                             :on-click #(router/nav! (oc-urls/stakeholder-update-preview))}
                       "Share new update")))
                 (when create-update-share-button-cb
                   (dom/div {:class "sharing-button-container"}
                     (dom/button {:class "btn-reset btn-solid"
+                                 :title (share-tooltip)
+                                 :data-toggle "tooltip"
+                                 :data-container "body"
+                                 :data-placement "left"
                                  :on-click create-update-share-button-cb
                                  :disabled create-update-share-button-disabled} "SHARE")))))))))))

--- a/src/open_company_web/lib/utils.cljs
+++ b/src/open_company_web/lib/utils.cljs
@@ -11,6 +11,7 @@
             [goog.string :as gstring]
             [goog.i18n.NumberFormat :as nf]
             [goog.object :as gobj]
+            [open-company-web.dispatcher :as dis]
             [open-company-web.router :as router]
             [open-company-web.caches :as caches]
             [open-company-web.lib.cookies :as cook]
@@ -776,3 +777,8 @@
   (let [protocol (.. js/document -location -protocol)
         host     (.. js/document -location -host)]
     (str protocol "//" host relative-su-url)))
+
+(defn slack-share? []
+  (if-let [jwt (:jwt @dis/app-state)]
+    (and (= (:auth-source jwt) "slack") ; auth'd w/ Slack
+         (not (nil? (-> jwt :bot :token)))))) ; with an installed Slack bot


### PR DESCRIPTION
Supporting UI PR for: https://github.com/open-company/open-company-api/pull/67

In addition to the multi-medium support (see test steps in above PR) this PR adds back tooltips to the share actions. To test:

* Login w/ Slack. Hover over the share link and share buttons in the navbar. Do you get a tooltip that mentions Slack?
* Login w/ Email. Hover over the share link and share buttons in the navbar. Do you get a tooltip that **doesn't** mention Slack?