### PR TITLE
Conditional nav

### DIFF
--- a/scss/partials/_company_dashboard.scss
+++ b/scss/partials/_company_dashboard.scss
@@ -15,6 +15,7 @@ div.company-dashboard {
 
     @include mobile(){
       background-color: $oc_gray_8;
+      padding-top: #{$mobile_navbar_height}px;
     }
 
     div.empty-dashboard {

--- a/scss/partials/_oc_switch.scss
+++ b/scss/partials/_oc_switch.scss
@@ -1,6 +1,5 @@
 div.oc-switch {
   width: 100%;
-  padding-top: #{$mobile_navbar_height}px;
   box-shadow: 0 2px 2px -2px rgba(0, 0, 0, 0.2);
   position: relative;
   background-color: white;

--- a/scss/partials/_topics_mobile_layout.scss
+++ b/scss/partials/_topics_mobile_layout.scss
@@ -1,5 +1,10 @@
+div.company-dashboard.has-oc-switch{
+  div.topics-mobile-layout {
+    margin-top: 22px;
+  }
+}
+
 div.topics-mobile-layout {
-  margin-top: 22px;
   display: flex;
   // flex-direction: row;
   flex-wrap: wrap;

--- a/scss/partials/_topics_mobile_layout.scss
+++ b/scss/partials/_topics_mobile_layout.scss
@@ -1,10 +1,5 @@
-div.company-dashboard.has-oc-switch{
-  div.topics-mobile-layout {
-    margin-top: 22px;
-  }
-}
-
 div.topics-mobile-layout {
+  margin-top: 22px;
   display: flex;
   // flex-direction: row;
   flex-wrap: wrap;

--- a/src/open_company_web/actions.cljs
+++ b/src/open_company_web/actions.cljs
@@ -154,10 +154,15 @@
 
 (defmethod dispatcher/action :su-edit [db [_ {:keys [slug su-date su-slug]}]]
   (let [su-url   (oc-urls/stakeholder-update slug (utils/su-date-from-created-at su-date) su-slug)
-        latest-su-key (dispatcher/latest-stakeholder-update-key slug)]
+        latest-su-key (dispatcher/latest-stakeholder-update-key slug)
+        company-data-links (:links (dispatcher/company-data))
+        updates-list-link (utils/link-for company-data-links "stakeholder-updates")
+        updated-link (assoc updates-list-link :count (inc (:count updates-list-link)))
+        new-links (conj (utils/vec-dissoc company-data-links updates-list-link) updated-link)]
     (-> db
       (assoc-in latest-su-key su-url)
       (dissoc :loading)
+      (assoc-in (conj (dispatcher/company-data-key slug) :links) new-links)
       ; refresh the su list
       (get-su-list))))
 

--- a/src/open_company_web/components/company_dashboard.cljs
+++ b/src/open_company_web/components/company_dashboard.cljs
@@ -88,7 +88,8 @@
                                 :mobile-menu-open (:mobile-menu-open data)
                                 :auth-settings (:auth-settings data)
                                 :active :dashboard})
-              (when (responsive/is-mobile-size?)
+              (when (and (responsive/is-mobile-size?)
+                         (pos? (:count (utils/link-for (:links company-data) "stakeholder-updates"))))
                 (oc-switch :dashboard))
               (if (and (empty? (:sections company-data)) (responsive/is-mobile-size?))
                 (dom/div {:class "empty-dashboard"}

--- a/src/open_company_web/components/ui/navbar.cljs
+++ b/src/open_company_web/components/ui/navbar.cljs
@@ -76,7 +76,9 @@
                                           (not (:read-only company-data))            ; it's not a read-only cmp
                                           (if (contains? data :show-share-su-button) ; the including component
                                             show-share-su-button                     ; wants to
-                                            true))]
+                                            true))
+          should-show-left-links (and (router/current-company-slug)
+                                      (pos? (:count (utils/link-for (:links company-data) "stakeholder-updates"))))]
       (dom/nav {:class (utils/class-set {:oc-navbar true
                                          :group true
                                          :su-navbar su-navbar
@@ -115,14 +117,14 @@
             (dom/div {:class "oc-navbar-bottom group"
                       :style {:width (str header-width "px")}}
               (dom/div {:class "left"}
-                (when (router/current-company-slug)
+                (when should-show-left-links
                   (dom/a {:class (when (= active :dashboard) "active")
                           :href (oc-urls/company)
                           :on-click #(do
                                        (utils/event-stop %)
                                        (router/nav! (oc-urls/company)))}
                     "Dashboard"))
-                (when (router/current-company-slug)
+                (when should-show-left-links
                   (dom/a {:class (when (= active :updates) "active")
                           :href (oc-urls/stakeholder-update-list)
                           :on-click (fn [e]


### PR DESCRIPTION
card: https://trello.com/c/3BhPUZqU

Show the Dashboard and Updates links only if there is at least one update shared. When the user creates a new update increase the count in the link for `stakeholder-updates` rel of the company so the links appear.