### PR TITLE
Slack onboarding

### DIFF
--- a/scss/partials/_company_editor.scss
+++ b/scss/partials/_company_editor.scss
@@ -27,6 +27,7 @@ div.company-editor {
         font-weight: 400;
         font-size: 16px;
         font-family: $oc_headers_font;
+        text-align: left;
       } 
 
       input.company-editor-input {

--- a/scss/partials/_company_editor.scss
+++ b/scss/partials/_company_editor.scss
@@ -9,6 +9,17 @@ div.company-editor {
       border: 2px solid $oc_yellow;
       border-radius: 5px;
       padding: 25px;
+      text-align: center;
+
+      div.slack-disclaimer {
+        margin-bottom: 23px;
+        text-align: center;
+        font-family: $oc_headers_font;
+        font-size: 14px;
+        font-weight: normal;
+        letter-spacing: 0.4px;
+        color: $oc_gray_5;
+      }
 
       label.company-editor-message {
         display: block;

--- a/scss/partials/_login_overlay.scss
+++ b/scss/partials/_login_overlay.scss
@@ -215,8 +215,46 @@ div.login-overlay-container {
       }
     }
 
+    div.login-overlay-content {
+      div.slack-disclaimer {
+        font-family: $oc_headers_font;
+        font-size: 14px;
+        font-weight: normal;
+        letter-spacing: 0.4px;
+        text-align: center;
+        color: $oc_gray_5;
+        padding: 20px 20px 0;
+      }
+    }
+
     button.login-button {
-      margin-top: 50px;
+      margin-top: 37px;
+
+      &.with-slack {
+        height: 40px;
+        font-size: 15px;
+        font-weight: 600;
+        font-family: $oc_headers_font;
+        padding: 5px;
+        border-radius: 5px;
+        border: 1px solid rgba(78,90,107,0.4);
+
+        &:before {
+          content: "";
+          background-image: url("/img/slack.png");
+          background-position: 0px 0px;
+          background-size: 20px 20px;
+          width: 20px;
+          height: 20px;
+          display: inline-block;
+          margin-right: 5px;
+          margin-bottom: -4px;
+        }
+
+        span.slack {
+          font-weight: 700;
+        }
+      }
     }
 
     div.login-overlay-footer {

--- a/scss/partials/_welcome_screen.scss
+++ b/scss/partials/_welcome_screen.scss
@@ -9,8 +9,10 @@ div.welcome-screen{
     margin: 20px auto;
     width: 520px;
     background-color: white;
-    padding: 20px;
+    padding: 25px;
     text-align: center;
+    border: 2px solid $oc_yellow;
+    border-radius: 5px;
 
     span {
       display: block;

--- a/src/open_company_web/actions.cljs
+++ b/src/open_company_web/actions.cljs
@@ -342,7 +342,6 @@
   [db [_]]
   (let [current (router/get-token)
         auth-url (utils/link-for (:links (:auth-settings @dispatcher/app-state)) "bot")]
-    (js/console.log "auth-urls" (:links (:auth-settings @dispatcher/app-state)) "->" auth-url)
     (when (and (not (.startsWith current oc-urls/login))
                (not (.startsWith current oc-urls/sign-up))
                (not (cook/get-cookie :login-redirect)))

--- a/src/open_company_web/components/company_editor.cljs
+++ b/src/open_company_web/components/company_editor.cljs
@@ -50,9 +50,8 @@
   (init-state [_]
     {:loading false
      :skip-bot (or (not (jwt/is-slack-org?))
-                  (not
                    (and (jwt/is-slack-org?)
-                        (map? (:bot (jwt/get-contents))))))})
+                        (map? (:bot (jwt/get-contents)))))})
 
   (did-mount [_]
     (utils/update-page-title "OpenCompany - Setup Your Company")

--- a/src/open_company_web/components/company_editor.cljs
+++ b/src/open_company_web/components/company_editor.cljs
@@ -2,6 +2,7 @@
   (:require [om.core :as om :include-macros true]
             [om-tools.core :as om-core :refer-macros (defcomponent)]
             [om-tools.dom :as dom :include-macros true]
+            [rum.core :as rum]
             [cuerdas.core :as s]
             [open-company-web.lib.jwt :as jwt]
             [open-company-web.lib.oc-colors :as occ]
@@ -30,10 +31,28 @@
           (om/set-state! owner :loading true)
           (dis/dispatch! [:company-submit]))))))
 
+(rum/defcs bot-access-prompt < rum/static
+  [s maybe-later-cb]
+  [:div.company-editor-box.group.navbar-offset
+    [:div
+      [:div.slack-disclaimer "OpenCompany has a " [:span.bold "Slack bot"] " to make your life easier."]
+      [:div.slack-disclaimer "The bot makes it easy to " [:span.bold "share updates to Slack"] ", and " [:span.bold "invite Slack teammates"] "that haven’t signed up."]
+      [:div.slack-disclaimer "The bot will " [:span.bold "never"] " do anything without your permission."]
+      [:botton.btn-reset.btn-link
+        {:on-click maybe-later-cb}
+        "MAYBE LATER"]
+      [:botton.btn-reset.btn-solid
+        {:on-click #(dis/dispatch! [:auth-bot])}
+        "LET’S ADD IT!"]]])
+
 (defcomponent company-editor [data owner]
 
   (init-state [_]
-    {:loading false})
+    {:loading false
+     :skip-bot (or (not (jwt/is-slack-org?))
+                  (not
+                   (and (jwt/is-slack-org?)
+                        (map? (:bot (jwt/get-contents))))))})
 
   (did-mount [_]
     (utils/update-page-title "OpenCompany - Setup Your Company")
@@ -43,24 +62,26 @@
       ;; and does not have these limitations
       (utils/after 1 #(dis/dispatch! [:input [:company-editor :name] (jwt/get-key :org-name)]))))
 
-  (render-state [_ {:keys [loading]}]
+  (render-state [_ {:keys [loading skip-bot]}]
     (dom/div {:class "company-editor"}
       (dom/div {:class "fullscreen-page group"}
         (om/build navbar {:hide-right-menu true :show-navigation-bar true})
-        (dom/div {:class "company-editor-box group navbar-offset"}
-          (dom/form {:on-submit (partial create-company-clicked owner)}
-            (dom/div {:class "form-group"}
-              (dom/label {:class "company-editor-message"} (str "Hi" (when (jwt/jwt) (str " " (s/capital (jwt/get-key :name)))) "!"))
-              (dom/label {:class "company-editor-message"} "What’s the name of your company?")
-              (dom/input {:type "text"
-                          :class "company-editor-input domine h4"
-                          :style #js {:width "100%"}
-                          :placeholder "Simple name without the Inc., LLC, etc."
-                          :value (-> data :company-editor :name)
-                          :on-change #(dis/dispatch! [:input [:company-editor :name] (.. % -target -value)])})))
-            (dom/div {:class "center"}
-              (dom/button {:class "btn-reset btn-solid get-started-button"
-                           :on-click (partial create-company-clicked owner)}
-                          (when loading
-                            (loading/small-loading {:class "left mt1"}))
-                          (dom/label {:class (str "pointer mt1" (when loading " ml2"))} "OK, LET’S GO"))))))))
+        (if (not skip-bot)
+          (bot-access-prompt #(om/set-state! owner :skip-bot true))
+          (dom/div {:class "company-editor-box group navbar-offset"}
+            (dom/form {:on-submit (partial create-company-clicked owner)}
+              (dom/div {:class "form-group"}
+                (dom/label {:class "company-editor-message"} (str "Hi" (when (jwt/jwt) (str " " (s/capital (jwt/get-key :name)))) "!"))
+                (dom/label {:class "company-editor-message"} "What’s the name of your company?")
+                (dom/input {:type "text"
+                            :class "company-editor-input domine h4"
+                            :style #js {:width "100%"}
+                            :placeholder "Simple name without the Inc., LLC, etc."
+                            :value (-> data :company-editor :name)
+                            :on-change #(dis/dispatch! [:input [:company-editor :name] (.. % -target -value)])})))
+              (dom/div {:class "center"}
+                (dom/button {:class "btn-reset btn-solid get-started-button"
+                             :on-click (partial create-company-clicked owner)}
+                            (when loading
+                              (loading/small-loading {:class "left mt1"}))
+                            (dom/label {:class (str "pointer mt1" (when loading " ml2"))} "OK, LET’S GO")))))))))

--- a/src/open_company_web/components/company_editor.cljs
+++ b/src/open_company_web/components/company_editor.cljs
@@ -70,8 +70,9 @@
           (dom/div {:class "company-editor-box group navbar-offset"}
             (dom/form {:on-submit (partial create-company-clicked owner)}
               (dom/div {:class "form-group"}
-                (dom/label {:class "company-editor-message"} (str "Hi" (when (jwt/jwt) (str " " (s/capital (jwt/get-key :name)))) "!"))
-                (dom/label {:class "company-editor-message"} "What’s the name of your company?")
+                (when (and (jwt/jwt) (jwt/get-key :first-name))
+                  (dom/label {:class "company-editor-message"} (str "Hi " (s/capital (jwt/get-key :first-name)) "!")))
+                (dom/label {:class "company-editor-message"} "What's the name of your company?")
                 (dom/input {:type "text"
                             :class "company-editor-input domine h4"
                             :style #js {:width "100%"}

--- a/src/open_company_web/components/ui/login_overlay.cljs
+++ b/src/open_company_web/components/ui/login_overlay.cljs
@@ -71,7 +71,7 @@
         [:div.login-overlay-content.pt2.pl3.pr3.group.center
           (if @(::sign-up-slack-clicked state)
             [:div
-              [:div.slack-disclaimer "If you’re not signed in on the Web, Slack will prompt you to " [:span.bold "sign in"] ", or if your correct team doesn’t appear in the team list, choose the " [:span.bold "“sign in to another team link”"] "."]
+              [:div.slack-disclaimer "If you’re not signed in to Slack " [:span.bold "on the Web"] ", Slack will prompt you to " [:span.bold "sign in first"] "."]
               (when (:slack-access (rum/react dis/app-state)) slack-error)
               [:button.btn-reset.btn-solid.login-button
                 {:on-click #(do
@@ -81,7 +81,7 @@
                  :disabled (not (:auth-settings (rum/react dis/app-state)))}
                 "GOT IT"]]
             [:div
-              [:div.slack-disclaimer "Sign up with Slack and your teammates can also easily signup to view your OpenCompany dashboard."]
+              [:div.slack-disclaimer [:span.bold "Slack sign up"] " makes it " [:span.bold "easy for your teammates"] " to signup to view your OpenCompany dashboard."]
               (when (:slack-access (rum/react dis/app-state)) slack-error)
               [:button.btn-reset.mt2.login-button.with-slack
                 {:on-click #(reset! (::sign-up-slack-clicked state) true)}

--- a/src/open_company_web/components/ui/login_overlay.cljs
+++ b/src/open_company_web/components/ui/login_overlay.cljs
@@ -56,59 +56,57 @@
       (i/icon :simple-remove {:class "inline mr1" :stroke "4" :color close-color :accent-color close-color}))])
 
 (rum/defcs login-signup-with-slack < rum/reactive
+                                     (rum/local false ::sign-up-slack-clicked)
                                      dont-scroll
   [state]
-  [:div.login-overlay-container.group
-    {:on-click (partial close-overlay)}
-    (close-button)
-    [:div.login-overlay.login-with-slack
-      {:on-click #(utils/event-stop %)}
-      [:div.login-overlay-cta.pl2.pr2.group
-        (cond
-          (= (:show-login-overlay (rum/react dis/app-state)) :signup-with-slack)
-          [:div.sign-in-cta.left "Sign Up"]
-          :else
-          [:div.sign-in-cta.left "Sign In"])]
-      [:div.pt2.pl3.pr3.group.center
-        (cond
-          (= (:slack-access (rum/react dis/app-state)) "denied")
-          [:div.block.red
-            "OpenCompany requires verification with your Slack team. Please allow access."
-            [:p.my2.h5 "If Slack did not allow you to authorize OpenCompany, try "
-              [:button.p0.btn-reset.underline
-                {:on-click #(do (utils/event-stop %)
-                                (dis/dispatch! [:login-with-slack false]))}
-                "this link instead."]]]
-          (:slack-access (rum/react dis/app-state))
-          [:span.block.red
-            "There is a temporary error validating with Slack. Please try again later."])
-        [:button.btn-reset.mt2.login-button
-          {:on-click #(do
-                        (.preventDefault %)
-                        (when (:auth-settings @dis/app-state)
-                          (dis/dispatch! [:login-with-slack true])))
-           :disabled (not (:auth-settings (rum/react dis/app-state)))}
-          [:img {:src "https://api.slack.com/img/sign_in_with_slack.png"}]
-          (when-not (:auth-settings (rum/react dis/app-state))
-            (small-loading))]
-        [:div.login-with-email.domine.underline.bold
-          [:a {:on-click #(do (utils/event-stop %)
-                              (dis/dispatch! [:show-login-overlay (if (= (:show-login-overlay @dis/app-state) :signup-with-slack) :signup-with-email :login-with-email)]))}
+  (let [action-title (if (= (:show-login-overlay (rum/react dis/app-state)) :signup-with-slack) "Sign Up" "Sign In")
+        slack-error [:span.block.red "There is a temporary error validating with Slack. Please try again later."]]
+    [:div.login-overlay-container.group
+      {:on-click (partial close-overlay)}
+      (close-button)
+      [:div.login-overlay.login-with-slack
+        {:on-click #(utils/event-stop %)}
+        [:div.login-overlay-cta.pl2.pr2.group
+          [:div.sign-in-cta.left action-title]]
+        [:div.login-overlay-content.pt2.pl3.pr3.group.center
+          (if @(::sign-up-slack-clicked state)
+            [:div
+              [:div.slack-disclaimer "If you’re not signed in on the Web, Slack will prompt you to " [:span.bold "sign in"] ", or if your correct team doesn’t appear in the team list, choose the " [:span.bold "“sign in to another team link”"] "."]
+              (when (:slack-access (rum/react dis/app-state)) slack-error)
+              [:button.btn-reset.btn-solid.login-button
+                {:on-click #(do
+                              (.preventDefault %)
+                              (when (:auth-settings @dis/app-state)
+                                (dis/dispatch! [:login-with-slack])))
+                 :disabled (not (:auth-settings (rum/react dis/app-state)))}
+                "GOT IT"]]
+            [:div
+              [:div.slack-disclaimer "Sign up with Slack and your teammates can also easily signup to view your OpenCompany dashboard."]
+              (when (:slack-access (rum/react dis/app-state)) slack-error)
+              [:button.btn-reset.mt2.login-button.with-slack
+                {:on-click #(reset! (::sign-up-slack-clicked state) true)}
+                (str action-title " with ")
+                [:span.slack "Slack"]
+                (when-not (:auth-settings (rum/react dis/app-state))
+                  (small-loading))]])
+          [:div.login-with-email.domine.underline.bold
+            [:a {:on-click #(do (utils/event-stop %)
+                                (dis/dispatch! [:show-login-overlay (if (= (:show-login-overlay @dis/app-state) :signup-with-slack) :signup-with-email :login-with-email)]))}
+              (cond
+                (= (:show-login-overlay (rum/react dis/app-state)) :signup-with-slack)
+                "OR SIGN UP VIA EMAIL"
+                :else
+                "OR SIGN IN VIA EMAIL")]]]
+          [:div.login-overlay-footer.py2.px3.mt1.group
             (cond
-              (= (:show-login-overlay (rum/react dis/app-state)) :signup-with-slack)
-              "OR SIGN UP VIA EMAIL"
-              :else
-              "OR SIGN IN VIA EMAIL")]]]
-        [:div.login-overlay-footer.py2.px3.mt1.group
-          (cond
-              (= (:show-login-overlay (rum/react dis/app-state)) :signup-with-slack)
-              [:a.left {:on-click #(dis/dispatch! [:show-login-overlay :login-with-email])}
-                "Already have an account? "
-                 [:span.underline "SIGN IN NOW."]]
-              :else
-              [:a.left {:on-click #(dis/dispatch! [:show-login-overlay :signup-with-email])}
-                "Don't have an account? "
-                 [:span.underline "SIGN UP NOW."]])]]])
+                (= (:show-login-overlay (rum/react dis/app-state)) :signup-with-slack)
+                [:a.left {:on-click #(dis/dispatch! [:show-login-overlay :login-with-email])}
+                  "Already have an account? "
+                   [:span.underline "SIGN IN NOW."]]
+                :else
+                [:a.left {:on-click #(dis/dispatch! [:show-login-overlay :signup-with-email])}
+                  "Don't have an account? "
+                   [:span.underline "SIGN UP NOW."]])]]]))
 
 (rum/defcs login-with-email < rum/reactive
                               (merge dont-scroll


### PR DESCRIPTION
Card: https://trello.com/c/6PkVVGeU
___
#### NB: review with this https://github.com/open-company/open-company-auth/pull/13
___

The Slack authentication now asks only for the basic user info. When the create company view is shown it checks if the bot is already present in the jwt. If not and the user's org is a Slack org it asks if he wants to onboard the bot. If so the user is redirected to the link with `bot` rel that asks to add our bot to their Slack organization.