### PR TITLE
Update actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ One of the most important component trees is the company dashboard. This provide
 
 ### Actions
 
-The OpenCompany web app dispatches *actions* from the UI, often resulting in asynchronous API requests, and dispatches
+The OpenCompany web app dispatches **actions** from the UI, often resulting in asynchronous API requests, and dispatches
 them from asynchronous API request results, often resulting in state changes that cause a new render of
 certain web components of the UI. The list of these actions, the caller that initiates the action, and a
 description of when the action is used is provided in the table below:

--- a/README.md
+++ b/README.md
@@ -179,43 +179,16 @@ One of the most important component trees is the company dashboard. This provide
 
 ![Company Dashboard Diagram](https://cdn.rawgit.com/open-company/open-company-web/mainline/docs/dashboard-viewing-component-tree.svg)
 
+### Actions
 
-## Testing
+The OpenCompany web app dispatches *actions* from the UI, often resulting in asynchronous API requests, and dispatches
+them from asynchronous API request results, often resulting in state changes that cause a new render of
+certain web components of the UI. The list of these actions, the caller that initiates the action, and a
+description of when the action is used is provided in the table below:
 
-Install [PhantomJS](https://http://phantomjs.org/) downloading the latest 2.x binary from [here](https://github.com/eugene1g/phantomjs/releases), the one from their site is currently broken.
-
-Then move the `phantomjs` binary somewhere reachable by your `PATH` so you can run:
-
-```console
-phantomjs -v
-```
-
-Then run:
-
-```console
-boot test!
-```
-
-For more info on testing:
-
-- React simulate wrapper: [bensu/cljs-react-test](https://github.com/bensu/cljs-react-test)
-
-
-## Participation
-
-Please note that this project is released with a [Contributor Code of Conduct](https://github.com/open-company/open-company-web/blob/mainline/CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
-
-
-## License
-
-Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/).
-
-Copyright © 2015-2017 OpenCompany, LLC.
-
-## Actions
-
-|  :add-topic-rollback | UI | Rollback the add topic to the board. User canceled action. |
+|  **Action** | **Caller** | **Description** |
 |  ------ | ------ | ------ |
+|  :add-topic-rollback | UI | Rollback the add topic to the board. User canceled action. |
 |  :add-topic-show | UI | Show the add topic view in the dashboard. |
 |  :auth-settings | API | Read the auth-settings response from the auth server and save the data in the app-state. Usually called together with :entry-point. |
 |  :auth-settings-get | UI | Start the request to load the auth-settings from the auth server. |
@@ -296,4 +269,35 @@ Copyright © 2015-2017 OpenCompany, LLC.
 |  :user-profile-save | UI | Save the edited user data. |
 |  :user-profile-update/failed | API | User profile update request failed. |
 |  :welcome-screen-hide | UI | Remove the welcome screen shown the first time the first org user open the dashboard. |
-|  **Action** | **Caller** | **Description** |
+
+## Testing
+
+Install [PhantomJS](https://http://phantomjs.org/) downloading the latest 2.x binary from [here](https://github.com/eugene1g/phantomjs/releases), the one from their site is currently broken.
+
+Then move the `phantomjs` binary somewhere reachable by your `PATH` so you can run:
+
+```console
+phantomjs -v
+```
+
+Then run:
+
+```console
+boot test!
+```
+
+For more info on testing:
+
+- React simulate wrapper: [bensu/cljs-react-test](https://github.com/bensu/cljs-react-test)
+
+
+## Participation
+
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/open-company/open-company-web/blob/mainline/CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+
+## License
+
+Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/).
+
+Copyright © 2015-2017 OpenCompany, LLC.

--- a/README.md
+++ b/README.md
@@ -181,10 +181,12 @@ One of the most important component trees is the company dashboard. This provide
 
 ### Actions
 
-The OpenCompany web app dispatches **actions** from the UI, often resulting in asynchronous API requests, and dispatches
-them from asynchronous API request results, often resulting in state changes that cause a new render of
-certain web components of the UI. The list of these actions, the caller that initiates the action, and a
-description of when the action is used is provided in the table below:
+The OpenCompany web app dispatches **actions** from the UI, browser events, and API request results. An action often
+results in a new asynchronous API request or in app state changes that trigger a new render cycle of the UI components
+listening to those parts of the app state.
+
+The list of these actions, the caller that initiates the action, and a description of when the action is used is
+provided in the table below:
 
 |  **Action** | **Caller** | **Description** |
 |  ------ | ------ | ------ |

--- a/README.md
+++ b/README.md
@@ -214,86 +214,86 @@ Copyright © 2015-2017 OpenCompany, LLC.
 
 ## Actions
 
-|  **Action** | **Caller** | **Description** |
+|  :add-topic-rollback | UI | Rollback the add topic to the board. User canceled action. |
 |  ------ | ------ | ------ |
-|  :email-domain-team-add | UI | Add an email domain to the user team. |
-|  :email-domain-team-add/finish | API | Request to add an email domain to the team succeeded. |
-|  :slack-team-add | UI | Start the request to add a Slack team to the current team. |
-|  :topic-add | UI | Give a topic and its data add the topic to the current board. |
-|  :topic-archive | UI | Start the archive topic action. Call the API function to archive. |
-|  :topic-archive/success | API | Archive succesfully done, navigate to the board to reload the data without the topic. |
-|  :bot-auth | UI | Start the bot add for a give slack team. |
+|  :add-topic-show | UI | Show the add topic view in the dashboard. |
 |  :auth-settings | API | Read the auth-settings response from the auth server and save the data in the app-state. Usually called together with :entry-point. |
+|  :auth-settings-get | UI | Start the request to load the auth-settings from the auth server. |
 |  :auth-with-token | UI | Given a topic (email reset, invitation etc..) start the token exchange to login the user. |
 |  :auth-with-token/failed | API | Token exchange failed, cleanup the app-state of the token exchange stuff. |
 |  :auth-with-token/success | API | Token exchange succeeded. Show the collect name and password overlay if it was an invitation token, load the orgs associated with the user and redirect. |
 |  :board | API | Read and save the board data from APi. Call the :load-other-boards action if necessary |
-|  :name-pswd-collect | UI | Start the request to save the user name and password. |
-|  :name-pswd-collect/finish | API | Collect name and password request finished. |
-|  :pswd-collect | UI | Start the request to save the new user password on password request. |
-|  :pswd-collect/finish | API | Collect password request finished. |
 |  :board-create | UI | Start the request to create a new board for the current org. |
-|  :org-create | UI | Start the request to create a new org. |
+|  :board-delete | UI | Delete a board of the current org. |
+|  :boards-load-other | UI | Start the request to load the data of all the rest of the org boards, not the one currently shown. |
+|  :bot-auth | UI | Start the bot add for a give slack team. |
+|  :channels-enumerate | UI | Start the request to load the Slack channels give a Slack team. |
+|  :channels-enumerate/success | API | Slack channels loaded, it saves them in the proper place of the app-state. |
 |  :dashboard-select-all | UI | Given a board select all the topics for the share. |
 |  :dashboard-select-topic | UI | When in sharing mode toggle a topic in the selected set. |
 |  :dashboard-share-mode | UI | Toggle the sharing mode. |
 |  :default | - | Default action, never used, it's only a fallback |
-|  :board-delete | UI | Delete a board of the current org. |
+|  :email-domain-team-add | UI | Add an email domain to the user team. |
+|  :email-domain-team-add/finish | API | Request to add an email domain to the team succeeded. |
+|  :entries-loaded | API | The request to load the entries of a certain topic is finished. |
 |  :entry-delete | UI | Start the delete entry action. Call the proper API function. It also takes care of removing the topic from the board if it's the last entry or to replace it with the previous entry if it was the latest. |
 |  :entry-delete/success | API | Entry succesfully deleted, navigate to the board to reload the data without the entry. |
-|  :entries-loaded | API | The request to load the entries of a certain topic is finished. |
 |  :entry-point | API | Read the Api entry point and save the data in the app state. |
-|  :channels-enumerate | UI | Start the request to load the Slack channels give a Slack team. |
-|  :channels-enumerate/success | API | Slack channels loaded, it saves them in the proper place of the app-state. |
+|  :error-banner-show | UI | Given an error message and a time, show the specified error for that time, if the time is 0 stick the message. |
+|  :foce-data-editing-start | UI | Start the data edit for growth and finances topics. |
 |  :foce-input | UI | Save a new data for the current edited entry. |
 |  :foce-save | UI | Call the proper API function to save the topic data collected during FoCE. |
-|  :auth-settings-get | UI | Start the request to load the auth-settings from the auth server. |
-|  :teams-get | UI | Start the request to load the list of teams. |
-|  :udpates-list-get | UI | Start the request to load the list of the prior updates for a certain org. |
-|  :welcome-screen-hide | UI | Remove the welcome screen shown the first time the first org user open the dashboard. |
+|  :foce-start | UI | Setup the app-state for FoCE initializing the data with the given entry data (empty if new entry). |
 |  :input | UI | Generic input action, it's used passing in a path and the value. The value is saved at the specified path of the app-state. |
 |  :invitation-confirmed | API | Confirm invitation request succeeded. |
 |  :invite-by-email | UI | Start the request to invite a user, check if the email is already present and use the resend link if possible. No-op if the user is already an active user of the team. |
 |  :invite-by-email/failed | API | Invitation request failed, add the proper error in the app-state. |
 |  :invite-by-email/success | API | Reload the team data to show the new invited user, reset the app-state for invitation data. |
 |  :jwt | UI | Given the JWT decoded data, save them in the app-state. |
-|  :boards-load-other | UI | Start the request to load the data of all the rest of the org boards, not the one currently shown. |
+|  :login-overlay-show | UI | Set the login overlay type in the app-state to show login, signup, password reset or collect name and password views. |
 |  :login-with-email | UI | Show the login with email overlay. |
 |  :login-with-email/failed | API | Login via email failed, add the proper error message to the app-state. |
 |  :login-with-email/success | API | Login via email succeeded. Save the returned JWT in the cookie and load the entry-point data. |
 |  :login-with-slack | UI | Show the login with slack overlay. |
 |  :logout | UI | Logout action: remove the JWT from the app-state and the jwt cookie. Redirect to /. |
 |  :mobile-menu-toggle | UI | Toggle the menu on mobile device. |
+|  :name-pswd-collect | UI | Start the request to save the user name and password. |
+|  :name-pswd-collect/finish | API | Collect name and password request finished. |
 |  :new-topics-load/finish | API | Read the available new topics and save them in the app-state for later use. |
 |  :org | API | Read and save the org data in the app-state. Redirect the UI to the last seen or the last created board or to the board creation if none is present.  |
+|  :org-create | UI | Start the request to create a new org. |
 |  :password-reset | UI | Start the request to reset the user password. |
 |  :password-reset/finish | API | Password reset request finished. |
 |  :private-board-action | UI | Given a private board, a user of this board and an action perform the action: change role or remove the user. |
 |  :private-board-add | UI | Add a user to a private board with a specific role. |
-|  :slack-token-refresh | UI | Refresh the data of the user signed in with Slack. |
-|  :user-profile-reset | UI | Reset the user profile data edited by the user but not yet saved. |
-|  :add-topic-rollback | UI | Rollback the add topic to the board. User canceled action. |
-|  :user-profile-save | UI | Save the edited user data. |
+|  :pswd-collect | UI | Start the request to save the new user password on password request. |
+|  :pswd-collect/finish | API | Collect password request finished. |
 |  :set-board-cache! | UI | Save some data of the current board, used for example by the growth topic to remember the last focused metric in the UI. |
-|  :add-topic-show | UI | Show the add topic view in the dashboard. |
-|  :error-banner-show | UI | Given an error message and a time, show the specified error for that time, if the time is 0 stick the message. |
-|  :login-overlay-show | UI | Set the login overlay type in the app-state to show login, signup, password reset or collect name and password views. |
-|  :top-menu-show | UI | Toggle the dropdown menu of the topic in the dashboard. |
 |  :signup-with-email | UI | Show the signup with email overlay. |
 |  :signup-with-email/failed | API | Signup with email failed. Add the proper error message to the app-state. |
 |  :signup-with-email/success | API | Signup with email succeeded. Save the JWT received in the cookie and remove the signup overlay. Load the entry point to redirect the user to the proper org/place. |
-|  :foce-start | UI | Setup the app-state for FoCE initializing the data with the given entry data (empty if new entry). |
-|  :foce-data-editing-start | UI | Start the data edit for growth and finances topics. |
+|  :slack-team-add | UI | Start the request to add a Slack team to the current team. |
+|  :slack-token-refresh | UI | Refresh the data of the user signed in with Slack. |
 |  :su-edit | API | When a new update is created it saves the link and the data of the update in the app-state. |
 |  :subscription | API | Save the new subscription data in the app-state. |
 |  :team-loaded | API | Save the team loaded data in the app-state. |
 |  :team-roster-loaded | API | Save the roster in the team data. |
+|  :teams-get | UI | Start the request to load the list of teams. |
 |  :teams-loaded | API | Read and save the list of teams. Start the request to load the team data or the roster if the link is not present for each team returned. |
+|  :top-menu-show | UI | Toggle the dropdown menu of the topic in the dashboard. |
 |  :topic | API | Read and save the content of a topic in the app-state. Async start the load of the list of entries. |
+|  :topic-add | UI | Give a topic and its data add the topic to the current board. |
+|  :topic-archive | UI | Start the archive topic action. Call the API function to archive. |
+|  :topic-archive/success | API | Archive succesfully done, navigate to the board to reload the data without the topic. |
 |  :topic-enty | API | Read and save a topic entry in the proper place of the app-state. |
+|  :udpates-list-get | UI | Start the request to load the list of the prior updates for a certain org. |
 |  :update-loaded | API | Read and save the data of certain update in the app-state |
 |  :updates-list | API | Read and save the list of the prior updates in the app-state given an org. |
 |  :user-action | UI | Start a user action: given a team-id, a user data object, the action and a method make a request to complete the action. Can pass optional payload (if it's not a GET request). |
 |  :user-action/complete | API | Refresh the team data to show the completed user action. |
 |  :user-data | API | Current user data loaded, save them in the app-state. |
+|  :user-profile-reset | UI | Reset the user profile data edited by the user but not yet saved. |
+|  :user-profile-save | UI | Save the edited user data. |
 |  :user-profile-update/failed | API | User profile update request failed. |
+|  :welcome-screen-hide | UI | Remove the welcome screen shown the first time the first org user open the dashboard. |
+|  **Action** | **Caller** | **Description** |

--- a/README.md
+++ b/README.md
@@ -211,3 +211,89 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/).
 
 Copyright © 2015-2017 OpenCompany, LLC.
+
+## Actions
+
+|  **Action** |  | **Caller** | **Description** |
+|  ------ | ------ | ------ | ------ |
+|  :add-email-domain-team | :email-domain-team-add | UI | Add an email domain to the user team. |
+|  :add-email-domain-team/finish | :email-domain-team-add/finish | API | Request to add an email domain to the team succeeded. |
+|  :add-slack-team | :slack-team-add | UI | Start the request to add a Slack team to the current team. |
+|  :add-topic | :topic-add | UI | Give a topic and its data add the topic to the current board. |
+|  :archive-topic | :topic-archive | UI | Start the archive topic action. Call the API function to archive. |
+|  :archive-topic/success | :topic-archive/success | API | Archive succesfully done, navigate to the board to reload the data without the topic. |
+|  :auth-bot | :bot-auth | UI | Start the bot add for a give slack team. |
+|  :auth-settings | :auth-settings | API | Read the auth-settings response from the auth server and save the data in the app-state. Usually called together with :entry-point. |
+|  :auth-with-token | :auth-with-token | UI | Given a topic (email reset, invitation etc..) start the token exchange to login the user. |
+|  :auth-with-token/failed | :auth-with-token/failed | API | Token exchange failed, cleanup the app-state of the token exchange stuff. |
+|  :auth-with-token/success | :auth-with-token/success | API | Token exchange succeeded. Show the collect name and password overlay if it was an invitation token, load the orgs associated with the user and redirect. |
+|  :board | :board | API | Read and save the board data from APi. Call the :load-other-boards action if necessary |
+|  :collect-name-pswd | :name-pswd-collect | UI | Start the request to save the user name and password. |
+|  :collect-name-pswd/finish | :name-pswd-collect/finish | API | Collect name and password request finished. |
+|  :collect-pswd | :pswd-collect | UI | Start the request to save the new user password on password request. |
+|  :collect-pswd/finish | :pswd-collect/finish | API | Collect password request finished. |
+|  :create-board | :board-create | UI | Start the request to create a new board for the current org. |
+|  :create-org | :org-create | UI | Start the request to create a new org. |
+|  :dashboard-select-all | :dashboard-select-all | UI | Given a board select all the topics for the share. |
+|  :dashboard-select-topic | :dashboard-select-topic | UI | When in sharing mode toggle a topic in the selected set. |
+|  :dashboard-share-mode | :dashboard-share-mode | UI | Toggle the sharing mode. |
+|  :default | :default | - | Default action, never used, it's only a fallback |
+|  :delete-board | :board-delete | UI | Delete a board of the current org. |
+|  :delete-entry | :entry-delete | UI | Start the delete entry action. Call the proper API function. It also takes care of removing the topic from the board if it's the last entry or to replace it with the previous entry if it was the latest. |
+|  :delete-entry/success | :entry-delete/success | API | Entry succesfully deleted, navigate to the board to reload the data without the entry. |
+|  :entries-loaded | :entries-loaded | API | The request to load the entries of a certain topic is finished. |
+|  :entry-point | :entry-point | API | Read the Api entry point and save the data in the app state. |
+|  :enumerate-channels | :channels-enumerate | UI | Start the request to load the Slack channels give a Slack team. |
+|  :enumerate-channels/success | :channels-enumerate/success | API | Slack channels loaded, it saves them in the proper place of the app-state. |
+|  :foce-input | :foce-input | UI | Save a new data for the current edited entry. |
+|  :foce-save | :foce-save | UI | Call the proper API function to save the topic data collected during FoCE. |
+|  :get-auth-settings | :auth-settings-get | UI | Start the request to load the auth-settings from the auth server. |
+|  :get-teams | :teams-get | UI | Start the request to load the list of teams. |
+|  :get-updates-list | :udpates-list-get | UI | Start the request to load the list of the prior updates for a certain org. |
+|  :hide-welcome-screen | :welcome-screen-hide | UI | Remove the welcome screen shown the first time the first org user open the dashboard. |
+|  :input | :input | UI | Generic input action, it's used passing in a path and the value. The value is saved at the specified path of the app-state. |
+|  :invitation-confirmed | :invitation-confirmed | API | Confirm invitation request succeeded. |
+|  :invite-by-email | :invite-by-email | UI | Start the request to invite a user, check if the email is already present and use the resend link if possible. No-op if the user is already an active user of the team. |
+|  :invite-by-email/failed | :invite-by-email/failed | API | Invitation request failed, add the proper error in the app-state. |
+|  :invite-by-email/success | :invite-by-email/success | API | Reload the team data to show the new invited user, reset the app-state for invitation data. |
+|  :jwt | :jwt | UI | Given the JWT decoded data, save them in the app-state. |
+|  :load-other-boards | :boards-load-other | UI | Start the request to load the data of all the rest of the org boards, not the one currently shown. |
+|  :login-with-email | :login-with-email | UI | Show the login with email overlay. |
+|  :login-with-email/failed | :login-with-email/failed | API | Login via email failed, add the proper error message to the app-state. |
+|  :login-with-email/success | :login-with-email/success | API | Login via email succeeded. Save the returned JWT in the cookie and load the entry-point data. |
+|  :login-with-slack | :login-with-slack | UI | Show the login with slack overlay. |
+|  :logout | :logout | UI | Logout action: remove the JWT from the app-state and the jwt cookie. Redirect to /. |
+|  :mobile-menu-toggle | :mobile-menu-toggle | UI | Toggle the menu on mobile device. |
+|  :new-topic | :new-topics-load/finish | API | Read the available new topics and save them in the app-state for later use. |
+|  :org | :org | API | Read and save the org data in the app-state. Redirect the UI to the last seen or the last created board or to the board creation if none is present.  |
+|  :password-reset | :password-reset | UI | Start the request to reset the user password. |
+|  :password-reset/finish | :password-reset/finish | API | Password reset request finished. |
+|  :private-board-action | :private-board-action | UI | Given a private board, a user of this board and an action perform the action: change role or remove the user. |
+|  :private-board-add | :private-board-add | UI | Add a user to a private board with a specific role. |
+|  :refresh-slack-user | :slack-token-refresh | UI | Refresh the data of the user signed in with Slack. |
+|  :reset-user-profile | :user-profile-reset | UI | Reset the user profile data edited by the user but not yet saved. |
+|  :rollback-add-topic | :add-topic-rollback | UI | Rollback the add topic to the board. User canceled action. |
+|  :save-user-profile | :user-profile-save | UI | Save the edited user data. |
+|  :set-board-cache! | :set-board-cache! | UI | Save some data of the current board, used for example by the growth topic to remember the last focused metric in the UI. |
+|  :show-add-topic | :add-topic-show | UI | Show the add topic view in the dashboard. |
+|  :show-error-banner | :error-banner-show | UI | Given an error message and a time, show the specified error for that time, if the time is 0 stick the message. |
+|  :show-login-overlay | :login-overlay-show | UI | Set the login overlay type in the app-state to show login, signup, password reset or collect name and password views. |
+|  :show-top-menu | :top-menu-show | UI | Toggle the dropdown menu of the topic in the dashboard. |
+|  :signup-with-email | :signup-with-email | UI | Show the signup with email overlay. |
+|  :signup-with-email/failed | :signup-with-email/failed | API | Signup with email failed. Add the proper error message to the app-state. |
+|  :signup-with-email/success | :signup-with-email/success | API | Signup with email succeeded. Save the JWT received in the cookie and remove the signup overlay. Load the entry point to redirect the user to the proper org/place. |
+|  :start-foce | :foce-start | UI | Setup the app-state for FoCE initializing the data with the given entry data (empty if new entry). |
+|  :start-foce-data-editing | :foce-data-editing-start | UI | Start the data edit for growth and finances topics. |
+|  :su-edit | :su-edit | API | When a new update is created it saves the link and the data of the update in the app-state. |
+|  :subscription | :subscription | API | Save the new subscription data in the app-state. |
+|  :team-loaded | :team-loaded | API | Save the team loaded data in the app-state. |
+|  :team-roster-loaded | :team-roster-loaded | API | Save the roster in the team data. |
+|  :teams-loaded | :teams-loaded | API | Read and save the list of teams. Start the request to load the team data or the roster if the link is not present for each team returned. |
+|  :topic | :topic | API | Read and save the content of a topic in the app-state. Async start the load of the list of entries. |
+|  :topic-entry | :topic-enty | API | Read and save a topic entry in the proper place of the app-state. |
+|  :update-loaded | :update-loaded | API | Read and save the data of certain update in the app-state |
+|  :updates-list | :updates-list | API | Read and save the list of the prior updates in the app-state given an org. |
+|  :user-action | :user-action | UI | Start a user action: given a team-id, a user data object, the action and a method make a request to complete the action. Can pass optional payload (if it's not a GET request). |
+|  :user-action/complete | :user-action/complete | API | Refresh the team data to show the completed user action. |
+|  :user-data | :user-data | API | Current user data loaded, save them in the app-state. |
+|  :user-profile-update/failed | :user-profile-update/failed | API | User profile update request failed. |

--- a/README.md
+++ b/README.md
@@ -214,86 +214,86 @@ Copyright © 2015-2017 OpenCompany, LLC.
 
 ## Actions
 
-|  **Action** |  | **Caller** | **Description** |
-|  ------ | ------ | ------ | ------ |
-|  :add-email-domain-team | :email-domain-team-add | UI | Add an email domain to the user team. |
-|  :add-email-domain-team/finish | :email-domain-team-add/finish | API | Request to add an email domain to the team succeeded. |
-|  :add-slack-team | :slack-team-add | UI | Start the request to add a Slack team to the current team. |
-|  :add-topic | :topic-add | UI | Give a topic and its data add the topic to the current board. |
-|  :archive-topic | :topic-archive | UI | Start the archive topic action. Call the API function to archive. |
-|  :archive-topic/success | :topic-archive/success | API | Archive succesfully done, navigate to the board to reload the data without the topic. |
-|  :auth-bot | :bot-auth | UI | Start the bot add for a give slack team. |
-|  :auth-settings | :auth-settings | API | Read the auth-settings response from the auth server and save the data in the app-state. Usually called together with :entry-point. |
-|  :auth-with-token | :auth-with-token | UI | Given a topic (email reset, invitation etc..) start the token exchange to login the user. |
-|  :auth-with-token/failed | :auth-with-token/failed | API | Token exchange failed, cleanup the app-state of the token exchange stuff. |
-|  :auth-with-token/success | :auth-with-token/success | API | Token exchange succeeded. Show the collect name and password overlay if it was an invitation token, load the orgs associated with the user and redirect. |
-|  :board | :board | API | Read and save the board data from APi. Call the :load-other-boards action if necessary |
-|  :collect-name-pswd | :name-pswd-collect | UI | Start the request to save the user name and password. |
-|  :collect-name-pswd/finish | :name-pswd-collect/finish | API | Collect name and password request finished. |
-|  :collect-pswd | :pswd-collect | UI | Start the request to save the new user password on password request. |
-|  :collect-pswd/finish | :pswd-collect/finish | API | Collect password request finished. |
-|  :create-board | :board-create | UI | Start the request to create a new board for the current org. |
-|  :create-org | :org-create | UI | Start the request to create a new org. |
-|  :dashboard-select-all | :dashboard-select-all | UI | Given a board select all the topics for the share. |
-|  :dashboard-select-topic | :dashboard-select-topic | UI | When in sharing mode toggle a topic in the selected set. |
-|  :dashboard-share-mode | :dashboard-share-mode | UI | Toggle the sharing mode. |
-|  :default | :default | - | Default action, never used, it's only a fallback |
-|  :delete-board | :board-delete | UI | Delete a board of the current org. |
-|  :delete-entry | :entry-delete | UI | Start the delete entry action. Call the proper API function. It also takes care of removing the topic from the board if it's the last entry or to replace it with the previous entry if it was the latest. |
-|  :delete-entry/success | :entry-delete/success | API | Entry succesfully deleted, navigate to the board to reload the data without the entry. |
-|  :entries-loaded | :entries-loaded | API | The request to load the entries of a certain topic is finished. |
-|  :entry-point | :entry-point | API | Read the Api entry point and save the data in the app state. |
-|  :enumerate-channels | :channels-enumerate | UI | Start the request to load the Slack channels give a Slack team. |
-|  :enumerate-channels/success | :channels-enumerate/success | API | Slack channels loaded, it saves them in the proper place of the app-state. |
-|  :foce-input | :foce-input | UI | Save a new data for the current edited entry. |
-|  :foce-save | :foce-save | UI | Call the proper API function to save the topic data collected during FoCE. |
-|  :get-auth-settings | :auth-settings-get | UI | Start the request to load the auth-settings from the auth server. |
-|  :get-teams | :teams-get | UI | Start the request to load the list of teams. |
-|  :get-updates-list | :udpates-list-get | UI | Start the request to load the list of the prior updates for a certain org. |
-|  :hide-welcome-screen | :welcome-screen-hide | UI | Remove the welcome screen shown the first time the first org user open the dashboard. |
-|  :input | :input | UI | Generic input action, it's used passing in a path and the value. The value is saved at the specified path of the app-state. |
-|  :invitation-confirmed | :invitation-confirmed | API | Confirm invitation request succeeded. |
-|  :invite-by-email | :invite-by-email | UI | Start the request to invite a user, check if the email is already present and use the resend link if possible. No-op if the user is already an active user of the team. |
-|  :invite-by-email/failed | :invite-by-email/failed | API | Invitation request failed, add the proper error in the app-state. |
-|  :invite-by-email/success | :invite-by-email/success | API | Reload the team data to show the new invited user, reset the app-state for invitation data. |
-|  :jwt | :jwt | UI | Given the JWT decoded data, save them in the app-state. |
-|  :load-other-boards | :boards-load-other | UI | Start the request to load the data of all the rest of the org boards, not the one currently shown. |
-|  :login-with-email | :login-with-email | UI | Show the login with email overlay. |
-|  :login-with-email/failed | :login-with-email/failed | API | Login via email failed, add the proper error message to the app-state. |
-|  :login-with-email/success | :login-with-email/success | API | Login via email succeeded. Save the returned JWT in the cookie and load the entry-point data. |
-|  :login-with-slack | :login-with-slack | UI | Show the login with slack overlay. |
-|  :logout | :logout | UI | Logout action: remove the JWT from the app-state and the jwt cookie. Redirect to /. |
-|  :mobile-menu-toggle | :mobile-menu-toggle | UI | Toggle the menu on mobile device. |
-|  :new-topic | :new-topics-load/finish | API | Read the available new topics and save them in the app-state for later use. |
-|  :org | :org | API | Read and save the org data in the app-state. Redirect the UI to the last seen or the last created board or to the board creation if none is present.  |
-|  :password-reset | :password-reset | UI | Start the request to reset the user password. |
-|  :password-reset/finish | :password-reset/finish | API | Password reset request finished. |
-|  :private-board-action | :private-board-action | UI | Given a private board, a user of this board and an action perform the action: change role or remove the user. |
-|  :private-board-add | :private-board-add | UI | Add a user to a private board with a specific role. |
-|  :refresh-slack-user | :slack-token-refresh | UI | Refresh the data of the user signed in with Slack. |
-|  :reset-user-profile | :user-profile-reset | UI | Reset the user profile data edited by the user but not yet saved. |
-|  :rollback-add-topic | :add-topic-rollback | UI | Rollback the add topic to the board. User canceled action. |
-|  :save-user-profile | :user-profile-save | UI | Save the edited user data. |
-|  :set-board-cache! | :set-board-cache! | UI | Save some data of the current board, used for example by the growth topic to remember the last focused metric in the UI. |
-|  :show-add-topic | :add-topic-show | UI | Show the add topic view in the dashboard. |
-|  :show-error-banner | :error-banner-show | UI | Given an error message and a time, show the specified error for that time, if the time is 0 stick the message. |
-|  :show-login-overlay | :login-overlay-show | UI | Set the login overlay type in the app-state to show login, signup, password reset or collect name and password views. |
-|  :show-top-menu | :top-menu-show | UI | Toggle the dropdown menu of the topic in the dashboard. |
-|  :signup-with-email | :signup-with-email | UI | Show the signup with email overlay. |
-|  :signup-with-email/failed | :signup-with-email/failed | API | Signup with email failed. Add the proper error message to the app-state. |
-|  :signup-with-email/success | :signup-with-email/success | API | Signup with email succeeded. Save the JWT received in the cookie and remove the signup overlay. Load the entry point to redirect the user to the proper org/place. |
-|  :start-foce | :foce-start | UI | Setup the app-state for FoCE initializing the data with the given entry data (empty if new entry). |
-|  :start-foce-data-editing | :foce-data-editing-start | UI | Start the data edit for growth and finances topics. |
-|  :su-edit | :su-edit | API | When a new update is created it saves the link and the data of the update in the app-state. |
-|  :subscription | :subscription | API | Save the new subscription data in the app-state. |
-|  :team-loaded | :team-loaded | API | Save the team loaded data in the app-state. |
-|  :team-roster-loaded | :team-roster-loaded | API | Save the roster in the team data. |
-|  :teams-loaded | :teams-loaded | API | Read and save the list of teams. Start the request to load the team data or the roster if the link is not present for each team returned. |
-|  :topic | :topic | API | Read and save the content of a topic in the app-state. Async start the load of the list of entries. |
-|  :topic-entry | :topic-enty | API | Read and save a topic entry in the proper place of the app-state. |
-|  :update-loaded | :update-loaded | API | Read and save the data of certain update in the app-state |
-|  :updates-list | :updates-list | API | Read and save the list of the prior updates in the app-state given an org. |
-|  :user-action | :user-action | UI | Start a user action: given a team-id, a user data object, the action and a method make a request to complete the action. Can pass optional payload (if it's not a GET request). |
-|  :user-action/complete | :user-action/complete | API | Refresh the team data to show the completed user action. |
-|  :user-data | :user-data | API | Current user data loaded, save them in the app-state. |
-|  :user-profile-update/failed | :user-profile-update/failed | API | User profile update request failed. |
+|  **Action** | **Caller** | **Description** |
+|  ------ | ------ | ------ |
+|  :email-domain-team-add | UI | Add an email domain to the user team. |
+|  :email-domain-team-add/finish | API | Request to add an email domain to the team succeeded. |
+|  :slack-team-add | UI | Start the request to add a Slack team to the current team. |
+|  :topic-add | UI | Give a topic and its data add the topic to the current board. |
+|  :topic-archive | UI | Start the archive topic action. Call the API function to archive. |
+|  :topic-archive/success | API | Archive succesfully done, navigate to the board to reload the data without the topic. |
+|  :bot-auth | UI | Start the bot add for a give slack team. |
+|  :auth-settings | API | Read the auth-settings response from the auth server and save the data in the app-state. Usually called together with :entry-point. |
+|  :auth-with-token | UI | Given a topic (email reset, invitation etc..) start the token exchange to login the user. |
+|  :auth-with-token/failed | API | Token exchange failed, cleanup the app-state of the token exchange stuff. |
+|  :auth-with-token/success | API | Token exchange succeeded. Show the collect name and password overlay if it was an invitation token, load the orgs associated with the user and redirect. |
+|  :board | API | Read and save the board data from APi. Call the :load-other-boards action if necessary |
+|  :name-pswd-collect | UI | Start the request to save the user name and password. |
+|  :name-pswd-collect/finish | API | Collect name and password request finished. |
+|  :pswd-collect | UI | Start the request to save the new user password on password request. |
+|  :pswd-collect/finish | API | Collect password request finished. |
+|  :board-create | UI | Start the request to create a new board for the current org. |
+|  :org-create | UI | Start the request to create a new org. |
+|  :dashboard-select-all | UI | Given a board select all the topics for the share. |
+|  :dashboard-select-topic | UI | When in sharing mode toggle a topic in the selected set. |
+|  :dashboard-share-mode | UI | Toggle the sharing mode. |
+|  :default | - | Default action, never used, it's only a fallback |
+|  :board-delete | UI | Delete a board of the current org. |
+|  :entry-delete | UI | Start the delete entry action. Call the proper API function. It also takes care of removing the topic from the board if it's the last entry or to replace it with the previous entry if it was the latest. |
+|  :entry-delete/success | API | Entry succesfully deleted, navigate to the board to reload the data without the entry. |
+|  :entries-loaded | API | The request to load the entries of a certain topic is finished. |
+|  :entry-point | API | Read the Api entry point and save the data in the app state. |
+|  :channels-enumerate | UI | Start the request to load the Slack channels give a Slack team. |
+|  :channels-enumerate/success | API | Slack channels loaded, it saves them in the proper place of the app-state. |
+|  :foce-input | UI | Save a new data for the current edited entry. |
+|  :foce-save | UI | Call the proper API function to save the topic data collected during FoCE. |
+|  :auth-settings-get | UI | Start the request to load the auth-settings from the auth server. |
+|  :teams-get | UI | Start the request to load the list of teams. |
+|  :udpates-list-get | UI | Start the request to load the list of the prior updates for a certain org. |
+|  :welcome-screen-hide | UI | Remove the welcome screen shown the first time the first org user open the dashboard. |
+|  :input | UI | Generic input action, it's used passing in a path and the value. The value is saved at the specified path of the app-state. |
+|  :invitation-confirmed | API | Confirm invitation request succeeded. |
+|  :invite-by-email | UI | Start the request to invite a user, check if the email is already present and use the resend link if possible. No-op if the user is already an active user of the team. |
+|  :invite-by-email/failed | API | Invitation request failed, add the proper error in the app-state. |
+|  :invite-by-email/success | API | Reload the team data to show the new invited user, reset the app-state for invitation data. |
+|  :jwt | UI | Given the JWT decoded data, save them in the app-state. |
+|  :boards-load-other | UI | Start the request to load the data of all the rest of the org boards, not the one currently shown. |
+|  :login-with-email | UI | Show the login with email overlay. |
+|  :login-with-email/failed | API | Login via email failed, add the proper error message to the app-state. |
+|  :login-with-email/success | API | Login via email succeeded. Save the returned JWT in the cookie and load the entry-point data. |
+|  :login-with-slack | UI | Show the login with slack overlay. |
+|  :logout | UI | Logout action: remove the JWT from the app-state and the jwt cookie. Redirect to /. |
+|  :mobile-menu-toggle | UI | Toggle the menu on mobile device. |
+|  :new-topics-load/finish | API | Read the available new topics and save them in the app-state for later use. |
+|  :org | API | Read and save the org data in the app-state. Redirect the UI to the last seen or the last created board or to the board creation if none is present.  |
+|  :password-reset | UI | Start the request to reset the user password. |
+|  :password-reset/finish | API | Password reset request finished. |
+|  :private-board-action | UI | Given a private board, a user of this board and an action perform the action: change role or remove the user. |
+|  :private-board-add | UI | Add a user to a private board with a specific role. |
+|  :slack-token-refresh | UI | Refresh the data of the user signed in with Slack. |
+|  :user-profile-reset | UI | Reset the user profile data edited by the user but not yet saved. |
+|  :add-topic-rollback | UI | Rollback the add topic to the board. User canceled action. |
+|  :user-profile-save | UI | Save the edited user data. |
+|  :set-board-cache! | UI | Save some data of the current board, used for example by the growth topic to remember the last focused metric in the UI. |
+|  :add-topic-show | UI | Show the add topic view in the dashboard. |
+|  :error-banner-show | UI | Given an error message and a time, show the specified error for that time, if the time is 0 stick the message. |
+|  :login-overlay-show | UI | Set the login overlay type in the app-state to show login, signup, password reset or collect name and password views. |
+|  :top-menu-show | UI | Toggle the dropdown menu of the topic in the dashboard. |
+|  :signup-with-email | UI | Show the signup with email overlay. |
+|  :signup-with-email/failed | API | Signup with email failed. Add the proper error message to the app-state. |
+|  :signup-with-email/success | API | Signup with email succeeded. Save the JWT received in the cookie and remove the signup overlay. Load the entry point to redirect the user to the proper org/place. |
+|  :foce-start | UI | Setup the app-state for FoCE initializing the data with the given entry data (empty if new entry). |
+|  :foce-data-editing-start | UI | Start the data edit for growth and finances topics. |
+|  :su-edit | API | When a new update is created it saves the link and the data of the update in the app-state. |
+|  :subscription | API | Save the new subscription data in the app-state. |
+|  :team-loaded | API | Save the team loaded data in the app-state. |
+|  :team-roster-loaded | API | Save the roster in the team data. |
+|  :teams-loaded | API | Read and save the list of teams. Start the request to load the team data or the roster if the link is not present for each team returned. |
+|  :topic | API | Read and save the content of a topic in the app-state. Async start the load of the list of entries. |
+|  :topic-enty | API | Read and save a topic entry in the proper place of the app-state. |
+|  :update-loaded | API | Read and save the data of certain update in the app-state |
+|  :updates-list | API | Read and save the list of the prior updates in the app-state given an org. |
+|  :user-action | UI | Start a user action: given a team-id, a user data object, the action and a method make a request to complete the action. Can pass optional payload (if it's not a GET request). |
+|  :user-action/complete | API | Refresh the team data to show the completed user action. |
+|  :user-data | API | Current user data loaded, save them in the app-state. |
+|  :user-profile-update/failed | API | User profile update request failed. |

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -139,7 +139,7 @@
     (assoc-in (dispatcher/org-data-key (:slug org-data)) (utils/fix-org org-data))
     (assoc :updates-list-loading (utils/in? (:route @router/path) "updates-list"))))
 
-(defmethod dispatcher/action :load-other-boards [db [_]]
+(defmethod dispatcher/action :boards-load-other [db [_]]
   (doseq [board (:boards (dispatcher/org-data db))
         :when (not= (:slug board) (router/current-board-slug))]
     (api/get-board board))
@@ -148,7 +148,7 @@
 (defmethod dispatcher/action :board [db [_ board-data]]
  (let [is-currently-shown (= (:slug board-data) (router/current-board-slug))]
     (when is-currently-shown
-      (utils/after 2000 #(dispatcher/dispatch! [:load-other-boards])))
+      (utils/after 2000 #(dispatcher/dispatch! [:boards-load-other])))
     (let [fixed-board-data (utils/fix-board board-data)
           old-board-data (get-in db (dispatcher/board-data-key (router/current-org-slug) (keyword (:slug board-data))))
           with-current-edit (if (and is-currently-shown
@@ -165,18 +165,7 @@
                                  (or (:show-add-topic db) (zero? (count (:topics fixed-board-data))))  ;; Keep add topic if currently shown or show it if the new topics count is 0
                                  (:show-add-topic db)))))))
 
-(defmethod dispatcher/action :company-submit [db _]
-  (api/create-company (:company-editor db))
-  db)
-
-(defmethod dispatcher/action :company-created [db [_ body]]
-  (if (:links body)
-    (let [updated (utils/fix-board body)]
-      (router/redirect! (oc-urls/board (:slug updated)))
-      (assoc-in db (dispatcher/org-data-key (:slug updated)) updated))
-    db))
-
-(defmethod dispatcher/action :new-topic [db [_ body]]
+(defmethod dispatcher/action :new-topics-load/finish [db [_ body]]
   (if body
     ;; signal to the app-state that the new-topics have been loaded
     (-> db
@@ -208,14 +197,6 @@
       (utils/after auth-settings-retry #(api/get-auth-settings))
       (assoc db :auth-settings-retry (* auth-settings-retry 2)))))
 
-(defmethod dispatcher/action :entry [db [_ body]]
-  (if body
-    (let [fixed-topic (utils/fix-topic (:body body) (:topic-slug body) true)
-          assoc-in-coll (dispatcher/entry-key (:org-slug body) (:board-slug body) (:topic-slug body) (:as-of body))
-          next-db (assoc-in db assoc-in-coll true)]
-      next-db)
-    db))
-
 (defmethod dispatcher/action :topic [db [_ {:keys [topic body]}]]
   ;; Refresh topic entries
   (api/load-entries topic (utils/link-for (:links body) "up"))
@@ -244,72 +225,11 @@
         (assoc-in board-key new-board-data)))
     db))
 
-(defmethod dispatcher/action :company [db [_ {:keys [slug success status body]}]]
-  (cond
-    success
-    ;; add topic name inside each topic
-    (let [org (router/current-org-slug)
-          board (router/current-board-slug)
-          updated-body (utils/fix-board body)
-          board-data-key (dispatcher/board-data-key org board)
-          board-topics-key (conj board-data-key :topics)
-          topic-entries-data-key (when (router/current-topic-slug)
-                                      (dispatcher/topic-entries-key org board (keyword (router/current-topic-slug))))
-          board-editing-topic-key (when (:foce-key db) (conj board-data-key (keyword (:foce-key db))))
-          board-already-loaded-key (conj board-data-key :board-data-loaded)
-          already-loaded? (get-in db board-already-loaded-key)
-          with-board-data (assoc-in db board-data-key updated-body)
-          with-open-add-topic (if (and (not (responsive/is-tablet-or-mobile?))
-                                       (zero? (count (:topics updated-body)))
-                                       (not already-loaded?))
-                                (assoc with-board-data :show-add-topic true)
-                                with-board-data)
-          with-welcome-screen (if (and (not (responsive/is-tablet-or-mobile?))
-                                       (not (:foce-key db))
-                                       (zero? (count (:topics updated-body)))
-                                       (zero? (count (:archived updated-body)))
-                                       (not already-loaded?))
-                                (assoc with-open-add-topic :show-welcome-screen true)
-                                with-open-add-topic)
-          keep-topics-edits (if (not (nil? (:foce-key db)))
-                                (assoc-in with-welcome-screen board-topics-key (get-in db board-topics-key))
-                                with-welcome-screen)
-          keep-editing-topic (if (and (not (nil? (:foce-key db)))
-                                        (get-in db board-editing-topic-key))
-                                  (assoc-in keep-topics-edits board-editing-topic-key (get-in db board-editing-topic-key))
-                                  keep-topics-edits)
-          keeping-entries (if (router/current-topic-slug)
-                              (assoc-in keep-editing-topic topic-entries-data-key (get-in db topic-entries-data-key))
-                              keep-editing-topic)
-          with-already-loaded (assoc-in keeping-entries board-already-loaded-key true)]
-      ; async preload the SU list
-      (utils/after 100 #(api/get-updates))
-      (if (or (:read-only updated-body)
-              (pos? (count (:topics updated-body)))
-              (:force-remove-loading with-board-data))
-          (dissoc with-already-loaded :loading :force-remove-loading)
-          with-already-loaded))
-    (= 401 status)
-    (-> db
-        (assoc-in (dispatcher/board-access-error-key (router/current-org-slug) (router/current-board-slug)) :forbidden)
-        (dissoc :loading))
-    (= 404 status)
-    (do
-      (router/redirect-404!)
-      db)
-    (and (>= 500 status)
-         (<= 599 status))
-    (do
-      (router/redirect-500!)
-      db)
-    ;; probably some default failure handling should be added here
-    :else db))
-
 (defn- get-updates [db]
   (api/get-updates)
   (assoc db :updates-list-loading true))
 
-(defmethod dispatcher/action :get-updates-list [db [_ {:keys [slug response]}]]
+(defmethod dispatcher/action :udpates-list-get [db [_ {:keys [slug response]}]]
   (get-updates db))
 
 (defmethod dispatcher/action :updates-list [db [_ {:keys [response]}]]
@@ -372,12 +292,12 @@
       (dissoc :foce-data-editing?))))
 
 ;; Front of Card Edit topic
-(defmethod dispatcher/action :start-foce [db [_ topic-key topic-data]]
+(defmethod dispatcher/action :foce-start [db [_ topic-key topic-data]]
   (if topic-key
     (start-foce db topic-key topic-data)
     (stop-foce db)))
 
-(defmethod dispatcher/action :start-foce-data-editing [db [_ value]]
+(defmethod dispatcher/action :foce-data-editing-start [db [_ value]]
   (assoc db :foce-data-editing? value))
 
 (defmethod dispatcher/action :foce-input [db [_ topic-data-map]]
@@ -391,28 +311,7 @@
 (defmethod dispatcher/action :input [db [_ path value]]
   (assoc-in db path value))
 
-(defmethod dispatcher/action :new-topics [db [_ new-topics]]
-  (let [board-data-key (dispatcher/board-data-key (router/current-org-slug) (router/current-board-slug))]
-    (api/patch-topics new-topics)
-    (assoc-in db (conj board-data-key :topics) new-topics)))
-
 (defmethod dispatcher/action :topic-archive [db [_ topic]]
-  (let [board-data (dispatcher/board-data)
-        old-topics (:topics board-data)
-        new-topics (utils/vec-dissoc old-topics (name topic))
-        old-archived (:archived board-data)
-        new-archived (vec (conj old-archived {:title (:title ((keyword topic) board-data)) :topic (name topic)}))
-        board-key (dispatcher/board-data-key (router/current-org-slug) (router/current-board-slug))]
-    (api/patch-topics new-topics)
-    (-> db
-      (dissoc :foce-key)
-      (dissoc :foce-data)
-      (dissoc :foce-data-editing?)
-      (assoc :show-add-topic (zero? (count new-topics)))
-      (assoc-in (conj board-key :topics) new-topics)
-      (assoc-in (conj board-key :archived) new-archived))))
-
-(defmethod dispatcher/action :archive-topic [db [_ topic]]
   (let [board-data (dispatcher/board-data)
         topic-data ((keyword topic) board-data)
         old-topics (:topics board-data)
@@ -428,12 +327,12 @@
       (assoc-in (conj board-key :topics) new-topics)
       (assoc-in (conj board-key :archived) new-archived))))
 
-(defmethod dispatcher/action :archive-topic/success
+(defmethod dispatcher/action :topic-archive/success
   [db [_]]
   (router/nav! (oc-urls/board))
   (dissoc db :prevent-topic-not-found-navigation))
 
-(defmethod dispatcher/action :delete-entry [db [_ topic as-of]]
+(defmethod dispatcher/action :entry-delete [db [_ topic as-of]]
   (let [board-data (dispatcher/board-data)
         old-topic-data ((keyword topic) board-data)
         entries (dispatcher/topic-entries-data (router/current-org-slug) (router/current-board-slug) topic db)
@@ -457,7 +356,7 @@
       (assoc-in board-data-key with-fixed-topics)
       (assoc-in (dispatcher/topic-entries-key (router/current-org-slug) (router/current-board-slug) topic) new-entries))))
 
-(defmethod dispatcher/action :delete-entry/success
+(defmethod dispatcher/action :entry-delete/success
   [db [_ should-redirect-to-board]]
   (when should-redirect-to-board
     (router/nav! (oc-urls/board)))
@@ -485,28 +384,11 @@
       (assoc-in topic-entries-key sorted-entries)
       (stop-foce))))
 
-(defmethod dispatcher/action :force-fullscreen-edit [db [_ topic]]
-  (if topic
-    (assoc-in db [:force-edit-topic] topic)
-    (dissoc db :force-edit-topic)))
-
 (defn- save-topic [db topic topic-data]
   (let [old-topic-data (get (dispatcher/board-data db) (keyword topic))
         new-data (dissoc (merge old-topic-data topic-data) :placeholder)]
     (api/partial-update-topic topic (dissoc topic-data :placeholder))
     (assoc-in db (conj (dispatcher/board-data-key (router/current-org-slug) (router/current-board-slug)) (keyword topic)) new-data)))
-
-(defmethod dispatcher/action :save-topic [db [_ topic topic-data]]
-  (save-topic db topic topic-data))
-
-(defmethod dispatcher/action :save-topic-data [db [_ topic topic-data]]
-  ;; save topic data for the company
-  (save-topic db topic topic-data)
-  ;; update topic data for the still in-progress FoCE
-  (assoc db :foce-data (merge (:foce-data db) topic-data)))
-
-(defmethod dispatcher/action :su-share/reset [db _]
-  (dissoc db :su-share))
 
 ;; Store JWT in App DB so it can be easily accessed in actions etc.
 
@@ -529,7 +411,7 @@
     (assoc-in db [:subscription uuid] data)
     (assoc db :subscription nil)))
 
-(defmethod dispatcher/action :show-login-overlay
+(defmethod dispatcher/action :login-overlay-show
  [db [_ show-login-overlay]]
  (cond
     (= show-login-overlay :login-with-email)
@@ -556,7 +438,7 @@
     (router/redirect! (:href auth-url)))
   db)
 
-(defmethod dispatcher/action :auth-bot
+(defmethod dispatcher/action :bot-auth
   [db [_]]
   (let [current (router/get-token)
         org-data (dispatcher/org-data db)
@@ -568,10 +450,6 @@
     (cook/set-cookie! :login-redirect current (* 60 60) "/" ls/jwt-cookie-domain ls/jwt-cookie-secure)
     (router/redirect! fixed-auth-url))
   db)
-
-(defmethod dispatcher/action :login-with-email-change
-  [db [_ k v]]
-  (assoc-in db [:login-with-email k] v))
 
 (defmethod dispatcher/action :login-with-email
   [db [_]]
@@ -609,10 +487,6 @@
     (cook/set-cookie! :show-login-overlay "collect-password"))
   (assoc db :first-org-redirect true))
 
-(defmethod dispatcher/action :signup-with-email-change
-  [db [_ k v]]
-  (assoc-in db [:signup-with-email k] v))
-
 (defmethod dispatcher/action :signup-with-email
   [db [_]]
   (api/signup-with-email (:firstname (:signup-with-email db)) (:lastname (:signup-with-email db)) (:email (:signup-with-email db)) (:pswd (:signup-with-email db)))
@@ -631,12 +505,12 @@
       (api/get-entry-point)
       (dissoc db :show-login-overlay))))
 
-(defmethod dispatcher/action :get-auth-settings
+(defmethod dispatcher/action :auth-settings-get
   [db [_]]
   (api/get-auth-settings)
   db)
 
-(defmethod dispatcher/action :get-teams
+(defmethod dispatcher/action :teams-get
   [db [_]]
   (api/get-teams)
   (assoc db :teams-data-requested true))
@@ -666,12 +540,12 @@
       (assoc-in db (dispatcher/team-data-key (:team-id roster-data)) fixed-roster-data))
     db))
 
-(defmethod dispatcher/action :enumerate-channels
+(defmethod dispatcher/action :channels-enumerate
   [db [_ team-id]]
   (api/enumerate-channels team-id)
   (assoc db :enumerate-channels-requested true))
 
-(defmethod dispatcher/action :enumerate-channels/success
+(defmethod dispatcher/action :channels-enumerate/success
   [db [_ team-id channels]]
   (let [channels-key (dispatcher/team-channels-key team-id)]
     (if channels
@@ -748,13 +622,13 @@
     (cook/set-cookie! :show-login-overlay "collect-name-password"))
   (assoc db :email-confirmed (= status 201)))
 
-(defmethod dispatcher/action :collect-name-pswd
+(defmethod dispatcher/action :name-pswd-collect
   [db [_]]
   (let [form-data (:collect-name-pswd db)]
     (api/collect-name-password (:firstname form-data) (:lastname form-data) (:pswd form-data)))
   db)
 
-(defmethod dispatcher/action :collect-name-pswd-finish
+(defmethod dispatcher/action :name-pswd-collect/finish
   [db [_ status]]
   (if (and (>= status 200)
            (<= status 299))
@@ -763,13 +637,13 @@
       (dissoc db :show-login-overlay))
     (assoc db :collect-name-password-error status)))
 
-(defmethod dispatcher/action :collect-pswd
+(defmethod dispatcher/action :pswd-collect
   [db [_]]
   (let [form-data (:collect-pswd db)]
     (api/collect-password (:pswd form-data)))
   db)
 
-(defmethod dispatcher/action :collect-pswd-finish
+(defmethod dispatcher/action :pswd-collect/finish
   [db [_ status]]
   (if (and (>= status 200)
            (<= status 299))
@@ -796,7 +670,7 @@
         sorted-fixed-entries (vec (sort sort-pred fixed-entries))]
     (assoc-in db (dispatcher/topic-entries-key (router/current-org-slug) (router/current-board-slug) topic) sorted-fixed-entries)))
 
-(defmethod dispatcher/action :show-add-topic
+(defmethod dispatcher/action :add-topic-show
   [db [_ active]]
   (if active
     (do
@@ -829,7 +703,7 @@
     (dissoc :show-add-topic)
     (assoc :dashboard-selected-topics [])))
 
-(defmethod dispatcher/action :add-topic
+(defmethod dispatcher/action :topic-add
   [db [_ topic topic-data]]
   (let [board-data (dispatcher/board-data)
         archived-topics (:archived board-data)
@@ -849,7 +723,7 @@
      next-db
      (start-foce next-db topic topic-data))))
 
-(defmethod dispatcher/action :rollback-add-topic
+(defmethod dispatcher/action :add-topic-rollback
   [db [_ topic-kw]]
   (let [board-data-key (dispatcher/board-data-key (router/current-org-slug) (router/current-board-slug))
         board-data (get-in db board-data-key)
@@ -868,14 +742,14 @@
       (assoc-in board-data-key updated-board-data)
       (stop-foce))))
 
-(defmethod dispatcher/action :show-top-menu [db [_ topic]]
+(defmethod dispatcher/action :top-menu-show [db [_ topic]]
   (assoc db :show-top-menu topic))
 
-(defmethod dispatcher/action :hide-welcome-screen
+(defmethod dispatcher/action :welcome-screen-hide
   [db [_]]
   (dissoc db :show-welcome-screen))
 
-(defmethod dispatcher/action :reset-user-profile
+(defmethod dispatcher/action :user-profile-reset
   [db [_]]
   (-> db
     (assoc :edit-user-profile (assoc (:current-user-data db) :password ""))
@@ -888,7 +762,7 @@
       (assoc :edit-user-profile user-data)
       (dissoc :edit-user-profile-failed)))
 
-(defmethod dispatcher/action :save-user-profile
+(defmethod dispatcher/action :user-profile-save
   [db [_]]
   (let [new-password (:password (:edit-user-profile db))
         password-did-change (pos? (count new-password))
@@ -905,14 +779,14 @@
     (api/patch-user-profile (:current-user-data db) with-email))
   db)
 
-(defmethod dispatcher/action :add-email-domain-team
+(defmethod dispatcher/action :email-domain-team-add
   [db [_]]
   (let [domain (:domain (:um-domain-invite db))]
     (when (utils/valid-domain? domain))
       (api/add-email-domain (if (.startsWith domain "@") (subs domain 1) domain)))
   (assoc db :add-email-domain-team-error false))
 
-(defmethod dispatcher/action :add-email-domain-team/finish
+(defmethod dispatcher/action :email-domain-team-add/finish
   [db [_ success]]
   (when success
     (api/get-teams))
@@ -920,7 +794,7 @@
       (assoc-in [:um-domain-invite :domain] (if success "" (:domain (:um-domain-invite db))))
       (assoc :add-email-domain-team-error (if success false true))))
 
-(defmethod dispatcher/action :add-slack-team
+(defmethod dispatcher/action :slack-team-add
   [db [_]]
   (let [org-data (dispatcher/org-data db)
         team-id (:team-id org-data)
@@ -944,14 +818,14 @@
       (update-in db cache-key dissoc k)
       (assoc-in db (conj cache-key k) v))))
 
-(defmethod dispatcher/action :create-org
+(defmethod dispatcher/action :org-create
   [db [_]]
   (let [org-name (:create-org db)]
     (when-not (string/blank? org-name)
       (api/create-org org-name)))
   db)
 
-(defmethod dispatcher/action :create-board
+(defmethod dispatcher/action :board-create
   [db [_]]
   (let [board-name (:create-board db)]
     (when-not (string/blank? board-name)
@@ -1006,12 +880,12 @@
   [db [_ status]]
   (assoc-in db [:password-reset :success] (and (>= status 200) (<= status 299))))
 
-(defmethod dispatcher/action :delete-board
+(defmethod dispatcher/action :board-delete
   [db [_ board-slug]]
   (api/delete-board board-slug)
   db)
 
-(defmethod dispatcher/action :show-error-banner
+(defmethod dispatcher/action :error-banner-show
   [db [_ error-message error-time]]
   (if (empty? error-message)
     (-> db (dissoc :error-banner-message) (dissoc :error-banner-time))
@@ -1021,6 +895,6 @@
        (assoc :error-banner-time error-time))
       db)))
 
-(defmethod dispatcher/action :user-profile-update-failed
+(defmethod dispatcher/action :user-profile-update/failed
   [db [_]]
   (assoc db :edit-user-profile-failed true))

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -116,7 +116,7 @@
           ; If it was a 5xx or a 0 show a banner for network issues
           (when (or (= status 0)
                     (and (>= status 500) (<= status 599)))
-            (dispatcher/dispatch! [:show-error-banner utils/generic-network-error 10000]))
+            (dispatcher/dispatch! [:error-banner-show utils/generic-network-error 10000]))
           (let [report {:response response
                         :path path
                         :method (method-name method)
@@ -203,35 +203,6 @@
           (dispatcher/dispatch! [:board (json->cljs body)])
           ;; Refresh the org data to make sure the list of boards is updated
           (get-org (dispatcher/org-data)))))))
-
-(defn create-company [data]
-  (when data
-    (let [links (:api-entry-point @dispatcher/app-state)
-          create-company-link (utils/link-for links "company-create" "POST")
-          data-with-org-id (assoc data :org-id (first (j/get-key :teams)))
-          post-data (cljs->json data-with-org-id)]
-      (api-post (:href create-company-link)
-        {:json-params post-data}
-        #(dispatch-body :company-created %)))))
-
-(defn patch-company [slug data]
-  (when data
-    (let [company-data (dissoc data :links :read-only :entries :updates-list :updates-list-loaded :entries :topic)
-          json-data (cljs->json company-data)
-          links (:links (dispatcher/board-data))
-          company-link (utils/link-for links "partial-update" "PATCH")]
-      (api-patch (:href company-link)
-        { :json-params json-data
-          :headers {
-            ; required by Chrome
-            "Access-Control-Allow-Headers" "Content-Type"
-            ; custom content type
-            "content-type" (:type company-link)
-          }}
-        (fn [{:keys [success body status]}]
-          (dispatcher/dispatch! [:company {:success success
-                                           :status status
-                                           :body (when success (json->cljs body))}]))))))
 
 (defn patch-org [data]
   (when data
@@ -329,24 +300,6 @@
         (fn [{:keys [success body status]}]
           (dispatcher/dispatch! [:board (when success (json->cljs body))]))))))
 
-(defn patch-stakeholder-update [stakeholder-update]
-  (when stakeholder-update
-    (let [slug (keyword (router/current-board-slug))
-          company-data (dispatcher/board-data)
-          company-patch-link (utils/link-for (:links company-data) "partial-update" "PATCH")
-          json-data (cljs->json {:stakeholder-update stakeholder-update})]
-      (api-patch (:href company-patch-link)
-        { :json-params json-data
-          :headers {
-            ; required by Chrome
-            "Access-Control-Allow-Headers" "Content-Type"
-            ; custom content type
-            "content-type" (:type company-patch-link)}}
-        (fn [{:keys [success body status]}]
-          (dispatcher/dispatch! [:company {:success success
-                                           :status status
-                                           :body (when success (json->cljs body))}]))))))
-
 (defn remove-topic [topic-name]
   (when (and topic-name)
     (let [board-data (dispatcher/board-data)
@@ -368,7 +321,7 @@
         { :headers (headers-for-link add-topic-link)}
         (fn [{:keys [success body]}]
           (let [fixed-body (if body (json->cljs body) {})]
-            (dispatcher/dispatch! [:new-topic {:response fixed-body :slug slug}])))))))
+            (dispatcher/dispatch! [:new-topics-load/finish {:response fixed-body :slug slug}])))))))
 
 (defn create-update [update-data]
   (let [org-data   (dispatcher/org-data)
@@ -515,7 +468,7 @@
           (fn [{:keys [success body status]}]
             (let [fixed-body (if success (json->cljs body) {})]
               (if success
-                (dispatcher/dispatch! [:enumerate-channels/success team-id (-> fixed-body :collection :items)])))))))))
+                (dispatcher/dispatch! [:channels-enumerate/success team-id (-> fixed-body :collection :items)])))))))))
 
 (defn user-action [action-link payload]
   (when action-link
@@ -561,7 +514,7 @@
         (fn [{:keys [status body success]}]
           (when success
             (dispatcher/dispatch! [:user-data (json->cljs body)]))
-          (utils/after 100 #(dispatcher/dispatch! [:collect-name-pswd-finish status])))))))
+          (utils/after 100 #(dispatcher/dispatch! [:name-pswd-collect/finish status])))))))
 
 (defn collect-password [pswd]
   (let [update-link (utils/link-for (:links (:current-user-data @dispatcher/app-state)) "partial-update" "PATCH")]
@@ -573,7 +526,7 @@
         (fn [{:keys [status body success]}]
           (when success
             (dispatcher/dispatch! [:user-data (json->cljs body)]))
-          (utils/after 100 #(dispatcher/dispatch! [:collect-pswd-finish status])))))))
+          (utils/after 100 #(dispatcher/dispatch! [:pswd-collect/finish status])))))))
 
 (defn delete-entry [topic entry-data should-redirect-to-board]
   (when (and topic entry-data)
@@ -583,7 +536,7 @@
         (api-delete (:href delete-link)
           {:headers (headers-for-link delete-link)}
           (fn [_]
-            (dispatcher/dispatch! [:delete-entry/success should-redirect-to-board])))))))
+            (dispatcher/dispatch! [:entry-delete/success should-redirect-to-board])))))))
 
 (defn get-current-user [auth-links]
   (when-let [user-link (utils/link-for (:links auth-links) "user" "GET")]
@@ -601,7 +554,7 @@
          :json-params (cljs->json (dissoc new-user-data :links :updated-at :created-at))}
          (fn [{:keys [status body success]}]
            (if (= status 422)
-              (dispatcher/dispatch! [:user-profile-update-failed])
+              (dispatcher/dispatch! [:user-profile-update/failed])
              (when success
                 (utils/after 1000
                   (fn []
@@ -621,7 +574,7 @@
         {:headers (headers-for-link add-domain-team-link)
          :body domain}
         (fn [{:keys [status body success]}]
-          (dispatcher/dispatch! [:add-email-domain-team/finish (= status 204)]))))))
+          (dispatcher/dispatch! [:email-domain-team-add/finish (= status 204)]))))))
 
 (defn refresh-slack-user []
   (let [refresh-url (utils/link-for (:links (:auth-settings @dispatcher/app-state)) "refresh")]
@@ -779,7 +732,7 @@
       (api-delete (:href archive-link)
         {:headers (headers-for-link archive-link)}
         (fn [{:keys [status success body] :as response}]
-          (dispatcher/dispatch! [:archive-topic/success]))))))
+          (dispatcher/dispatch! [:topic-archive/success]))))))
 
 
 (defn add-private-board

--- a/src/oc/web/components/add_topic.cljs
+++ b/src/oc/web/components/add_topic.cljs
@@ -135,7 +135,7 @@
         [:hr]
         (when (pos? (count topics))
           [:span.close-add-topic
-            {:on-click #(dis/dispatch! [:show-add-topic false])}
+            {:on-click #(dis/dispatch! [:add-topic-show false])}
             (i/icon :simple-remove {:color "rgba(78, 90, 107, 0.8)" :size 16 :stroke 8 :accent-color "rgba(78, 90, 107, 1.0)"})])
         [:div.mxn2.clearfix
           ;; column 1

--- a/src/oc/web/components/board_editor.cljs
+++ b/src/oc/web/components/board_editor.cljs
@@ -29,7 +29,7 @@
         (create-board-alert)
         (do
           (om/set-state! owner :loading true)
-          (dis/dispatch! [:create-board board-name]))))))
+          (dis/dispatch! [:board-create board-name]))))))
 
 (defcomponent board-editor [data owner]
 

--- a/src/oc/web/components/board_settings.cljs
+++ b/src/oc/web/components/board_settings.cljs
@@ -167,7 +167,7 @@
 (defn load-team-data-if-needed [owner]
   (when (and (om/get-props owner :auth-settings)
              (not (om/get-props owner  :teams-data-requested)))
-    (dis/dispatch! [:get-teams])))
+    (dis/dispatch! [:teams-get])))
 
 (defcomponent board-settings-form [data owner]
 

--- a/src/oc/web/components/bot_access_prompt.cljs
+++ b/src/oc/web/components/bot_access_prompt.cljs
@@ -6,7 +6,7 @@
                                {:before-render (fn [s]
                                                  (when (and (:auth-settings @dis/app-state)
                                                             (not (:teams-data-requested @dis/app-state)))
-                                                   (dis/dispatch! [:get-teams]))
+                                                   (dis/dispatch! [:teams-get]))
                                                  s)}
   [s maybe-later-cb]
   [:div.bot-access-prompt.fullscreen-page.group
@@ -19,5 +19,5 @@
           {:on-click maybe-later-cb}
           "MAYBE LATER"]
         [:botton.btn-reset.btn-solid
-          {:on-click #(dis/dispatch! [:auth-bot])}
+          {:on-click #(dis/dispatch! [:bot-auth])}
           "LET’S ADD IT!"]]]])

--- a/src/oc/web/components/bw_boards_list.cljs
+++ b/src/oc/web/components/bw_boards_list.cljs
@@ -18,7 +18,7 @@
                 :height "130px"
                 :success-title "DELETE"
                 :success-cb #(do
-                                (dis/dispatch! [:delete-board board-slug])
+                                (dis/dispatch! [:board-delete board-slug])
                                 (hide-popover nil "delete-board-alert"))
                 :cancel-title "KEEP IT"
                 :cancel-cb #(hide-popover nil "delete-board-alert")}))
@@ -91,6 +91,6 @@
                           :on-key-up (fn [e]
                                           (cond
                                             (= "Enter" (.-key e))
-                                            (dis/dispatch! [:create-board])
+                                            (dis/dispatch! [:board-create])
                                             (= "Escape" (.-key e))
                                             (dis/dispatch! [:input [:create-board] nil])))}))))))))

--- a/src/oc/web/components/create_update.cljs
+++ b/src/oc/web/components/create_update.cljs
@@ -55,12 +55,12 @@
 (defn load-team-data [data]
   (when (and (:auth-settings data)
              (not (:teams-data-requested data)))
-    (dis/dispatch! [:get-teams])))
+    (dis/dispatch! [:teams-get])))
 
 (defcomponent create-update [data owner]
 
   (init-state [_]
-    (dis/dispatch! [:start-foce nil])
+    (dis/dispatch! [:foce-start nil])
     (load-team-data data)
     {:columns-num (responsive/columns-num)
      :card-width (responsive/calc-card-width)

--- a/src/oc/web/components/edit_user_profile.cljs
+++ b/src/oc/web/components/edit_user_profile.cljs
@@ -26,7 +26,7 @@
   (let [url    (googobj/get res "url")
         node   (gdom/createDom "img")]
     (if-not url
-      (dis/dispatch! [:show-error-banner "An error has occurred while processing the image URL. Please try again." 5000])
+      (dis/dispatch! [:error-banner-show "An error has occurred while processing the image URL. Please try again." 5000])
       (do
         (set! (.-onload node) #(img-on-load owner node))
         (gdom/append (.-body js/document) node)
@@ -37,7 +37,7 @@
 (defn progress-cb [owner res progress])
 
 (defn error-cb [owner res error]
-  (dis/dispatch! [:show-error-banner "An error has occurred while processing the image URL. Please try again." 5000]))
+  (dis/dispatch! [:error-banner-show "An error has occurred while processing the image URL. Please try again." 5000]))
 
 (defn change! [owner k v]
   (dis/dispatch! [:input [:edit-user-profile k] v])
@@ -45,13 +45,13 @@
 
 (defn reset-user-profile-data [owner e]
   (.preventDefault e)
-  (dis/dispatch! [:reset-user-profile])
+  (dis/dispatch! [:user-profile-reset])
   (om/set-state! owner {:has-changes false}))
 
 (defn save-user-profile-data [owner e]
   (.preventDefault e)
   (om/set-state! owner :will-save true)
-  (dis/dispatch! [:save-user-profile (om/get-state owner :email-did-change)]))
+  (dis/dispatch! [:user-profile-save (om/get-state owner :email-did-change)]))
 
 (def initial-state
   {:email-did-change false
@@ -64,7 +64,7 @@
 (defcomponent edit-user-profile [data owner]
 
   (init-state [_]
-    (dis/dispatch! [:reset-user-profile])
+    (dis/dispatch! [:user-profile-reset])
     initial-state)
 
   (did-mount [_]
@@ -78,7 +78,7 @@
   (will-receive-props [_ next-props]
     (when (and (not (utils/is-test-env?))
                (om/get-state owner :will-save))
-      (dis/dispatch! [:reset-user-profile])
+      (dis/dispatch! [:user-profile-reset])
       (om/update-state! owner #(merge % initial-state {:show-save-successful (not (:edit-user-profile-failed next-props))
                                                        :show-save-failed (:edit-user-profile-failed next-props)}))
       (utils/after 2000 (fn [] (om/update-state! owner #(merge % {:show-save-successful false

--- a/src/oc/web/components/error_banner.cljs
+++ b/src/oc/web/components/error_banner.cljs
@@ -24,7 +24,7 @@
                                   (when (pos? showing-time)
                                     (utils/after showing-time
                                      (fn []
-                                      (dis/dispatch! [:show-error-banner nil 0])
+                                      (dis/dispatch! [:error-banner-show nil 0])
                                       (reset! (::showing s) false))))))
                              s)}
   [s]

--- a/src/oc/web/components/finances/finances_sparklines.cljs
+++ b/src/oc/web/components/finances/finances_sparklines.cljs
@@ -152,7 +152,7 @@
            :data-container "body"
            :data-toggle "tooltip"
            :title "Edit chart"
-           :on-click #(dis/dispatch! [:start-foce-data-editing true])}
+           :on-click #(dis/dispatch! [:foce-data-editing-start true])}
           (dom/i {:class "fa fa-pencil"}))
         (dom/button
           {:class "btn-reset"

--- a/src/oc/web/components/growth/growth_sparklines.cljs
+++ b/src/oc/web/components/growth/growth_sparklines.cljs
@@ -63,7 +63,7 @@
            :data-container "body"
            :data-toggle "tooltip"
            :title "Edit chart"
-           :on-click #(dis/dispatch! [:start-foce-data-editing (:slug metric-metadata)])}
+           :on-click #(dis/dispatch! [:foce-data-editing-start (:slug metric-metadata)])}
           (dom/i {:class "fa fa-pencil"}))
         (dom/button
           {:class "btn-reset"

--- a/src/oc/web/components/oc_wall.cljs
+++ b/src/oc/web/components/oc_wall.cljs
@@ -25,9 +25,9 @@
                         :logout
                         (router/redirect! oc-urls/logout)
                         :signup
-                        (dis/dispatch! [:show-login-overlay :signup-with-email])
+                        (dis/dispatch! [:login-overlay-show :signup-with-email])
                         ;; else
-                        (dis/dispatch! [:show-login-overlay :login-with-email]))}
+                        (dis/dispatch! [:login-overlay-show :login-with-email]))}
           (case button-type
             :logout
             "LOG OUT"

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -97,7 +97,7 @@
                                                  (when (and (:show-top-menu @dis/app-state)
                                                             (not (utils/event-inside? e (sel1 [(str "div.topic[data-topic=" (name (:show-top-menu @dis/app-state)) "]")]))))
                                                    (utils/event-stop e)
-                                                   (dis/dispatch! [:show-top-menu nil])))))
+                                                   (dis/dispatch! [:top-menu-show nil])))))
     ; (when (pos? (:count (utils/link-for (:links (dis/board-data data)) "stakeholder-updates")))
     ;   (om/set-state! owner :share-tooltip-dismissed (t/tooltip-already-shown? (share-tooltip-id (:slug (dis/board-data data))))))
     (refresh-board-data)

--- a/src/oc/web/components/org_editor.cljs
+++ b/src/oc/web/components/org_editor.cljs
@@ -29,7 +29,7 @@
         (create-org-alert owner)
         (do
           (om/set-state! owner :loading true)
-          (dis/dispatch! [:create-org]))))))
+          (dis/dispatch! [:org-create]))))))
 
 (defn setup-org-name [owner data]
   (when-let [team-data (first (:teams (:teams-data data)))]

--- a/src/oc/web/components/org_logo_setup.cljs
+++ b/src/oc/web/components/org_logo_setup.cljs
@@ -22,7 +22,7 @@
           logo-width (om/get-state owner :logo-width)
           logo-height (om/get-state owner :logo-height)]
       (if (empty? logo-url)
-        (dis/dispatch! [:show-error-banner "Please insert a logo image" 5000])
+        (dis/dispatch! [:error-banner-show "Please insert a logo image" 5000])
         (do
           (om/set-state! owner :redirect-to-org true)
           (api/patch-org {:logo-width (js/parseInt logo-width)

--- a/src/oc/web/components/org_settings.cljs
+++ b/src/oc/web/components/org_settings.cljs
@@ -82,7 +82,7 @@
     ; there was an error loading the logo, could be an invalid URL
     ; or the link doesn't contain an image
     (do
-      (dis/dispatch! [:show-error-banner "Invalid image url." 5000])
+      (dis/dispatch! [:error-banner-show "Invalid image url." 5000])
       (om/set-state! owner :logo-url (om/get-state owner :initial-logo))
       (om/set-state! owner :loading false))
     (save-org-data data (om/get-state owner :logo-url) (.-width img) (.-height img))))
@@ -124,7 +124,7 @@
                                        :state-logo url}))))
 
 (defn- error-cb [owner res error]
-  (dis/dispatch! [:show-error-banner "An error occurred while uploading the image. Please retry." 5000])
+  (dis/dispatch! [:error-banner-show "An error occurred while uploading the image. Please retry." 5000])
   (om/update-state! owner #(merge % {:file-upload-state nil
                                      :file-upload-progress nil})))
 

--- a/src/oc/web/components/prior_updates.cljs
+++ b/src/oc/web/components/prior_updates.cljs
@@ -29,7 +29,7 @@
   (when (and (dispatcher/org-data)
              (not (:updates-list-loading @dispatcher/app-state))
              (not (:updates-list-loaded @dispatcher/app-state)))
-    (dispatcher/dispatch! [:get-updates-list])))
+    (dispatcher/dispatch! [:udpates-list-get])))
 
 (defun- medium-for
   ;; one possible initial case, just one medium

--- a/src/oc/web/components/sign_up.cljs
+++ b/src/oc/web/components/sign_up.cljs
@@ -32,7 +32,7 @@
                                               :type "submit"
                                               :onClick #(do
                                                           (.preventDefault %)
-                                                          (dis/dispatch! [:show-login-overlay :signup-with-slack]))}
+                                                          (dis/dispatch! [:login-overlay-show :signup-with-slack]))}
                         "Get Started →"]]]]]]]]
 
         [:div.sub-tag

--- a/src/oc/web/components/su_preview_dialog.cljs
+++ b/src/oc/web/components/su_preview_dialog.cljs
@@ -281,7 +281,6 @@
 (rum/defcs link-dialog < (rum/local false ::copied)
                          (rum/local false ::clipboard)
                          (clipboard-mixin ".js-copy-btn")
-                         {:will-unmount (fn [s] (dis/dispatch! [:su-share/reset]) s)}
   [{:keys [::copied] :as _state} link]
   [:div
    (modal-title  "Share a Link" :link-72)
@@ -316,7 +315,7 @@
                                  (some #(not (nil? (:token %))) (get (:slack-bots jwt) team-id-k)) ; with an installed Slack bot
                                  (not (:enumerate-channels-requested @dis/app-state))) ; haven't already requested
                         ;; Ask for public Slack channels
-                        (dis/dispatch! [:enumerate-channels team-id])))
+                        (dis/dispatch! [:channels-enumerate team-id])))
                     s)}
   [s prompt-cb]
   [:div
@@ -357,7 +356,6 @@
         "Send")])])
 
 (rum/defc confirmation < rum/static
-                         {:will-unmount (fn [s] (dis/dispatch! [:su-share/reset]) s)}
   [type back-to-dashboard-cb cancel-fn share-link]
   [:div
    (case type
@@ -411,7 +409,6 @@
     (setup-scroll-height))
 
   (will-unmount [_]
-    (dis/dispatch! [:su-share/reset])
     (reset-scroll-height))
 
   (will-receive-props [_ next-props]

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -28,7 +28,7 @@
                              {:before-render (fn [s]
                                                (when (and (:auth-settings @dis/app-state)
                                                           (not (:teams-data-requested @dis/app-state)))
-                                                 (dis/dispatch! [:get-teams]))
+                                                 (dis/dispatch! [:teams-get]))
                                                (when (and (nil? (:user-type (:um-invite @(drv/get-ref s :team-management))))
                                                           (utils/valid-email? (:email (:um-invite @(drv/get-ref s :team-management)))))
                                                   (dis/dispatch! [:input [:um-invite :user-type] :viewer]))
@@ -125,12 +125,12 @@
                     (when (utils/link-for (:links team-data) "authenticate" "GET" {:auth-source "slack"})
                       (if (zero? (count (:slack-orgs team-data)))
                         [:button.btn-reset.mt2.add-slack-team.slack-button
-                            {:on-click #(dis/dispatch! [:add-slack-team])}
+                            {:on-click #(dis/dispatch! [:slack-team-add])}
                             "Add "
                             [:span.slack "Slack"]
                             " Team"]
                         [:button.btn-reset.btn-link.another-slack-team
-                          {:on-click #(dis/dispatch! [:add-slack-team])}
+                          {:on-click #(dis/dispatch! [:slack-team-add])}
                           "Add another Slack team"]))
                     (when (not (empty? (:access query-params)))
                       [:div#result-message
@@ -170,7 +170,7 @@
                       {:disabled (not valid-domain-email?)
                        :on-click #(let [domain (:domain (:um-domain-invite ro-user-man))]
                                     (if (utils/valid-domain? domain)
-                                      (dis/dispatch! [:add-email-domain-team])
+                                      (dis/dispatch! [:email-domain-team-add])
                                       (dis/dispatch! [:input [:add-email-domain-team-error] true])))}
                      "ADD"]
                     (when add-email-domain-team-error

--- a/src/oc/web/components/topic.cljs
+++ b/src/oc/web/components/topic.cljs
@@ -33,7 +33,7 @@
 (defn start-foce-click [owner]
   (let [topic-kw (keyword (om/get-props owner :topic))
         topic-data (om/get-props owner :topic-data)]
-    (dis/dispatch! [:start-foce topic-kw (assoc topic-data :topic (name topic-kw))])))
+    (dis/dispatch! [:foce-start topic-kw (assoc topic-data :topic (name topic-kw))])))
 
 (defn get-author-string
   "Return the a formatted string that shows the topic creator and the last editor."
@@ -61,7 +61,7 @@
                 :height "160px"
                 :success-title "Ok, got it"
                 :success-cb #(do
-                              (dis/dispatch! [:show-top-menu nil])
+                              (dis/dispatch! [:top-menu-show nil])
                               (hide-popover nil "assign-topic-wip"))
                 :cancel-title nil
                 :cancel-cb nil}))
@@ -124,7 +124,7 @@
                                                :left-column (not= fixed-column columns-num)
                                                :right-column (= fixed-column columns-num)})}
               (dom/button {:class "topic-top-menu-btn btn-reset"
-                           :on-click #(dis/dispatch! [:start-foce topic-kw {:placeholder true
+                           :on-click #(dis/dispatch! [:foce-start topic-kw {:placeholder true
                                                                             :topic (name topic-kw)
                                                                             :title (:title topic-data)
                                                                             :data (:data topic-data)
@@ -132,7 +132,7 @@
                                                                             :links (:links topic-data)}])}
                 (dom/i {:class "fa fa-plus"})" New entry")
               (dom/button {:class "topic-top-menu-btn btn-reset"
-                           :on-click #(dis/dispatch! [:start-foce topic-kw topic-data])}
+                           :on-click #(dis/dispatch! [:foce-start topic-kw topic-data])}
                 (dom/i {:class "fa fa-pencil"}) " Edit")
               ; Assign action, disabled for now
               (dom/button {:class "topic-top-menu-btn btn-reset"
@@ -204,7 +204,7 @@
             (dom/button {:class "top-right-button topic-top-menu-button btn-reset"
                          :on-click #(do
                                       (utils/event-stop %)
-                                      (dis/dispatch! [:show-top-menu (if showing-menu nil topic)]))}
+                                      (dis/dispatch! [:top-menu-show (if showing-menu nil topic)]))}
               (dom/i {:class "fa fa-ellipsis-v"}))))
 
         ;; Topic image for dashboard

--- a/src/oc/web/components/topic_edit.cljs
+++ b/src/oc/web/components/topic_edit.cljs
@@ -109,7 +109,7 @@
   (let [url    (googobj/get res "url")
         node   (gdom/createDom "img")]
     (if-not url
-      (dis/dispatch! [:show-error-banner "An error has occurred while processing the image URL. Please try again." 5000])
+      (dis/dispatch! [:error-banner-show "An error has occurred while processing the image URL. Please try again." 5000])
       (do
         (set! (.-onload node) #(img-on-load owner node))
         (gdom/append (.-body js/document) node)
@@ -120,7 +120,7 @@
                                                       :has-changes true}))))
 
 (defn img-upload-error-cb [owner res error]
-  (dis/dispatch! [:show-error-banner "An error has occurred while processing the image URL. Please try again." 5000])
+  (dis/dispatch! [:error-banner-show "An error has occurred while processing the image URL. Please try again." 5000])
   (om/update-state! owner #(merge % {:file-upload-state nil
                                      :file-upload-progress nil
                                      :has-changes true})))
@@ -132,7 +132,7 @@
 (defn attachment-upload-success-cb [owner res]
   (let [url    (googobj/get res "url")]
     (if-not url
-      (dis/dispatch! [:show-error-banner "An error has occurred while processing the file URL. Please try again." 5000])
+      (dis/dispatch! [:error-banner-show "An error has occurred while processing the file URL. Please try again." 5000])
       (let [current-foce-data (dis/foce-topic-data)
             attachments (or (:attachments current-foce-data) [])
             attachment-data {:file-name (googobj/get res "filename")
@@ -143,10 +143,10 @@
         (dis/dispatch! [:foce-input {:attachments (conj attachments attachment-data)}])))))
 
 (defn attachment-upload-error-cb [owner res error]
-  (dis/dispatch! [:show-error-banner "An error has occurred while processing the file. Please try again." 5000]))
+  (dis/dispatch! [:error-banner-show "An error has occurred while processing the file. Please try again." 5000]))
 
 (defn- dismiss-editing [topic]
-  (dis/dispatch! [:rollback-add-topic (keyword topic)]))
+  (dis/dispatch! [:add-topic-rollback (keyword topic)]))
 
 (defn handle-navigate-event [current-token owner e]
     ;; only when the URL is changing
@@ -169,7 +169,7 @@
                                     ;; cancel any FoCE
                                     (if (:new (dis/foce-topic-data))
                                       (dismiss-editing (dis/foce-topic-key))
-                                      (dis/dispatch! [:start-foce nil]))
+                                      (dis/dispatch! [:foce-start nil]))
                                     ;; Dispatch the current url
                                     (@router/route-dispatcher (router/get-token)))})
         
@@ -185,7 +185,7 @@
                 :success-title "DELETE"
                 :success-cb #(let [topic (dis/foce-topic-key)
                                    entries (dis/topic-entries-data topic)]
-                               (dis/dispatch! [:delete-entry topic (:created-at (dis/foce-topic-data))])
+                               (dis/dispatch! [:entry-delete topic (:created-at (dis/foce-topic-data))])
                                (hide-popover nil "delete-entry-confirm"))}))
 
 (defn- add-image-tooltip [image-header]
@@ -246,7 +246,7 @@
     (utils/to-end-of-content-editable headline-el)))
 
 (defn- data-editing-cb [owner value]
-  (dis/dispatch! [:start-foce-data-editing value])) ; global atom state
+  (dis/dispatch! [:foce-data-editing-start value])) ; global atom state
 
 ; (defn show-edit-tt [owner]
 ;   (let [board-data (dis/board-data)]
@@ -296,7 +296,7 @@
       (when (and (dis/foce-topic-key)
                  (or (:new (dis/foce-topic-data))
                      (:was-archvied (dis/foce-topic-data))))
-        (dis/dispatch! [:rollback-add-topic (dis/foce-topic-key)]))
+        (dis/dispatch! [:add-topic-rollback (dis/foce-topic-key)]))
       ; ; hide FoCE editing tooltip
       ; (t/hide (str "first-foce-" (:slug (dis/board-data))))
       ; re enable the route dispatcher
@@ -522,7 +522,7 @@
                            :data-container "body"
                            :data-placement "top"
                            :style {:display (if (or (and (= is-data? :finances) no-data?) (= is-data? :growth)) "block" "none")}
-                           :on-click #(dis/dispatch! [:start-foce-data-editing (if (= is-data? :growth) growth-utils/new-metric-slug-placeholder :new)])}
+                           :on-click #(dis/dispatch! [:foce-data-editing-start (if (= is-data? :growth) growth-utils/new-metric-slug-placeholder :new)])}
                 (dom/i {:class "fa fa-line-chart"})))
             
             ;; Hidden (initially) file upload progress
@@ -550,7 +550,7 @@
                                         (do
                                           (dismiss-editing topic)
                                           (router/nav! (oc-urls/board)))
-                                        (dis/dispatch! [:start-foce nil]))} "CANCEL")
+                                        (dis/dispatch! [:foce-start nil]))} "CANCEL")
               ;; Topic archive button
             (when (:show-delete-entry-button data)
               (dom/button {:class "btn-reset archive-button right"

--- a/src/oc/web/components/topic_view.cljs
+++ b/src/oc/web/components/topic_view.cljs
@@ -24,7 +24,7 @@
                 :success-title "ARCHIVE"
                 :success-cb (fn []
                               (let [topic (router/current-topic-slug)]
-                                (dis/dispatch! [:archive-topic topic])
+                                (dis/dispatch! [:topic-archive topic])
                                 (hide-popover nil "archive-topic-confirm")))}))
 
 (defn load-entries [owner]
@@ -62,7 +62,7 @@
               (if (and new-topic
                        (contains? new-topic :links)
                        (not is-archived?))
-                (dis/dispatch! [:add-topic topic-kw new-topic-data])
+                (dis/dispatch! [:topic-add topic-kw new-topic-data])
                 (router/redirect! (oc-urls/board (router/current-org-slug) (:slug board-data)))))))))))
 
 (defcomponent topic-view [{:keys [card-width
@@ -76,7 +76,7 @@
     {:entries-requested false})
 
   (did-mount [_]
-    (dis/dispatch! [:show-add-topic false])
+    (dis/dispatch! [:add-topic-show false])
     (load-entries-if-needed owner)
     (om/set-state! owner :entries-reload-interval (js/setInterval #(load-entries owner) (* 60 1000)))
     (let [props (om/get-props owner)]
@@ -153,7 +153,7 @@
                           with-data (if (#{:growth :finances} topic-kw) (assoc initial-data :data (:data topic-data)) initial-data)
                           with-metrics (if (= :growth topic-kw) (assoc with-data :metrics (:metrics topic-data)) with-data)]
                       (dom/div {:class "fake-textarea-internal"
-                                :on-click #(dis/dispatch! [:start-foce topic-kw with-metrics])}
+                                :on-click #(dis/dispatch! [:foce-start topic-kw with-metrics])}
                         (:title topic-data)
                         (dom/br)
                         (dom/span {:class "new-entry"} "Start a new entry...")))

--- a/src/oc/web/components/topics_columns.cljs
+++ b/src/oc/web/components/topics_columns.cljs
@@ -126,7 +126,7 @@
                                             :new (not (:was-archived topic-data))
                                             :loading (:was-archived topic-data)})
         new-topics (conj (:topics board-data) new-topic)]
-    (dis/dispatch! [:add-topic new-topic-kw fixed-topic-data])
+    (dis/dispatch! [:topic-add new-topic-kw fixed-topic-data])
     ; delay switch to topic view to make sure the FoCE data are in when loading the view
     (when (:was-archived topic-data)
       (router/nav! (oc-urls/topic (router/current-org-slug) (:slug board-data) new-topic)))))

--- a/src/oc/web/components/topics_list.cljs
+++ b/src/oc/web/components/topics_list.cljs
@@ -44,7 +44,7 @@
   (will-receive-props [_ next-props]
     (when-let* [new-topic-foce (om/get-state owner :new-topic-foce)
                 new-topic-data (-> next-props :board-data new-topic-foce)]
-      (dispatcher/dispatch! [:start-foce new-topic-foce new-topic-data]))
+      (dispatcher/dispatch! [:foce-start new-topic-foce new-topic-data]))
     (when (om/get-state owner :redirect-to-preview)
       (utils/after 100 #(router/nav! (oc-urls/update-preview))))
     (when-not (= (:board-data next-props) (:board-data data))

--- a/src/oc/web/components/ui/floating_add_topic.cljs
+++ b/src/oc/web/components/ui/floating_add_topic.cljs
@@ -6,4 +6,4 @@
   []
   [:div.floating-add-topic
     [:button.btn-reset.floating-add-topic-btn
-      {:on-click #(dis/dispatch! [:show-add-topic true])}]])
+      {:on-click #(dis/dispatch! [:add-topic-show true])}]])

--- a/src/oc/web/components/ui/login_button.cljs
+++ b/src/oc/web/components/ui/login_button.cljs
@@ -7,16 +7,16 @@
                           rum/reactive
                           {:will-mount (fn [s]
                                         (when-not (utils/is-test-env?)
-                                          (dis/dispatch! [:get-auth-settings]))
+                                          (dis/dispatch! [:auth-settings-get]))
                                         s)}
   [s {:keys [button-classes]}]
   [:div.login-button
     [:button
       {:class (str "btn-reset signup-signin " (when button-classes button-classes))
-       :on-click #(dis/dispatch! [:show-login-overlay :login-with-slack])}
+       :on-click #(dis/dispatch! [:login-overlay-show :login-with-slack])}
       "Sign In"]
     [:span.signup-signin " / "]
     [:button
       {:class (str "btn-reset signup-signin " (when button-classes button-classes))
-       :on-click #(dis/dispatch! [:show-login-overlay :signup-with-slack])}
+       :on-click #(dis/dispatch! [:login-overlay-show :signup-with-slack])}
       "Sign Up"]])

--- a/src/oc/web/components/ui/login_overlay.cljs
+++ b/src/oc/web/components/ui/login_overlay.cljs
@@ -16,12 +16,12 @@
 
 (defn close-overlay [e]
   (utils/event-stop e)
-  (dis/dispatch! [:show-login-overlay false]))
+  (dis/dispatch! [:login-overlay-show false]))
 
 (def dont-scroll
   {:will-mount (fn [s]
                 (when-not (contains? @dis/app-state :auth-settings)
-                  (utils/after 100 #(dis/dispatch! [:get-auth-settings])))
+                  (utils/after 100 #(dis/dispatch! [:auth-settings-get])))
                 s)
    :before-render (fn [s]
                     (if (responsive/is-mobile-size?)
@@ -91,7 +91,7 @@
                   (small-loading))]])
           [:div.login-with-email.domine.underline.bold
             [:a {:on-click #(do (utils/event-stop %)
-                                (dis/dispatch! [:show-login-overlay (if (= (:show-login-overlay @dis/app-state) :signup-with-slack) :signup-with-email :login-with-email)]))}
+                                (dis/dispatch! [:login-overlay-show (if (= (:show-login-overlay @dis/app-state) :signup-with-slack) :signup-with-email :login-with-email)]))}
               (cond
                 (= (:show-login-overlay (rum/react dis/app-state)) :signup-with-slack)
                 "OR SIGN UP VIA EMAIL"
@@ -100,11 +100,11 @@
           [:div.login-overlay-footer.py2.px3.mt1.group
             (cond
                 (= (:show-login-overlay (rum/react dis/app-state)) :signup-with-slack)
-                [:a.left {:on-click #(dis/dispatch! [:show-login-overlay :login-with-email])}
+                [:a.left {:on-click #(dis/dispatch! [:login-overlay-show :login-with-email])}
                   "Already have an account? "
                    [:span.underline "SIGN IN NOW."]]
                 :else
-                [:a.left {:on-click #(dis/dispatch! [:show-login-overlay :signup-with-email])}
+                [:a.left {:on-click #(dis/dispatch! [:login-overlay-show :signup-with-email])}
                   "Don't have an account? "
                    [:span.underline "SIGN UP NOW."]])]]]))
 
@@ -132,7 +132,7 @@
               "The email or password you entered is incorrect."
               [:br]
               "Please try again, or "
-              [:a.underline.red {:on-click #(dis/dispatch! [:show-login-overlay :password-reset])} "reset your password"]
+              [:a.underline.red {:on-click #(dis/dispatch! [:login-overlay-show :password-reset])} "reset your password"]
               "."]
             :else
             [:span.small-caps.red
@@ -148,7 +148,7 @@
           [:div.sign-in-field-container
             [:input.sign-in-field.email
               {:value (:email (:login-with-email (rum/react dis/app-state)))
-               :on-change #(dis/dispatch! [:login-with-email-change :email (.-value (sel1 [:input.email]))])
+               :on-change #(dis/dispatch! [:input [:login-with-email :email] (.-value (sel1 [:input.email]))])
                :type "email"
                :id "sign-in-email"
                :auto-focus true
@@ -160,14 +160,14 @@
           [:div.sign-in-field-container
             [:input.sign-in-field.pswd
               {:value (:pswd (:login-with-email (rum/react dis/app-state)))
-               :on-change #(dis/dispatch! [:login-with-email-change :pswd (.-value (sel1 [:input.pswd]))])
+               :on-change #(dis/dispatch! [:input [:login-with-email :pswd] (.-value (sel1 [:input.pswd]))])
                :type "password"
                :id "sign-in-pswd"
                :tabIndex 2
                :name "pswd"}]]
           [:div.group.pb3.mt3
             [:div.left.forgot-password
-              [:a {:on-click #(dis/dispatch! [:show-login-overlay :password-reset])} "FORGOT PASSWORD?"]]
+              [:a {:on-click #(dis/dispatch! [:login-overlay-show :password-reset])} "FORGOT PASSWORD?"]]
             [:div.right
               [:button.btn-reset.btn-solid
                 {:disabled (or (not (:auth-settings (rum/react dis/app-state)))
@@ -177,7 +177,7 @@
                               (dis/dispatch! [:login-with-email]))}
                 "SIGN IN"]]]]]
       [:div.login-overlay-footer.py2.px3.mt1.group
-        [:a.left {:on-click #(do (utils/event-stop %) (dis/dispatch! [:show-login-overlay :signup-with-slack]))}
+        [:a.left {:on-click #(do (utils/event-stop %) (dis/dispatch! [:login-overlay-show :signup-with-slack]))}
           "Don't have an account? "
           [:span.underline "SIGN UP NOW."]]]]])
 
@@ -203,10 +203,10 @@
             (= (:signup-with-email-error (rum/react dis/app-state)) 409)
             [:span.small-caps.red
               "This email address already has an account. "
-              [:a.underline.red {:on-click #(dis/dispatch! [:show-login-overlay :login-with-email])} "Would you like to sign in with that account?"]
+              [:a.underline.red {:on-click #(dis/dispatch! [:login-overlay-show :login-with-email])} "Would you like to sign in with that account?"]
               [:br]
               "Please try again, or "
-              [:a.underline.red {:on-click #(dis/dispatch! [:show-login-overlay :password-reset])} "reset your password"]
+              [:a.underline.red {:on-click #(dis/dispatch! [:login-overlay-show :password-reset])} "reset your password"]
               "."]
             (= (:signup-with-email-error (rum/react dis/app-state)) 400)
             [:span.small-caps.red
@@ -229,7 +229,7 @@
               {:value (:firstname (:signup-with-email (rum/react dis/app-state)))
                :id "sign-up-firstname"
                :auto-focus true
-               :on-change #(dis/dispatch! [:signup-with-email-change :firstname (.-value (sel1 [:input.firstname]))])
+               :on-change #(dis/dispatch! [:input [:signup-with-email :firstname] (.-value (sel1 [:input.firstname]))])
                :placeholder "First name"
                :type "text"
                :tabIndex 1
@@ -237,7 +237,7 @@
             [:input.sign-in-field.lastname.half.right
               {:value (:lastname (:signup-with-email (rum/react dis/app-state)))
                :id "sign-up-lastname"
-               :on-change #(dis/dispatch! [:signup-with-email-change :lastname (.-value (sel1 [:input.lastname]))])
+               :on-change #(dis/dispatch! [:input [:signup-with-email :lastname] (.-value (sel1 [:input.lastname]))])
                :placeholder "Last name"
                :type "text"
                :tabIndex 2
@@ -248,7 +248,7 @@
             [:input.sign-in-field.email
               {:value (:email (:signup-with-email (rum/react dis/app-state)))
                :id "sign-up-email"
-               :on-change #(dis/dispatch! [:signup-with-email-change :email (.-value (sel1 [:input.email]))])
+               :on-change #(dis/dispatch! [:input [:signup-with-email :email] (.-value (sel1 [:input.email]))])
                :pattern "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$"
                :placeholder "email@example.com"
                :type "email"
@@ -261,7 +261,7 @@
             [:input.sign-in-field.pswd
               {:value (:pswd (:signup-with-email (rum/react dis/app-state)))
                :id "sign-up-pswd"
-               :on-change #(dis/dispatch! [:signup-with-email-change :pswd (.-value (sel1 [:input.pswd]))])
+               :on-change #(dis/dispatch! [:input [:signup-with-email :pswd] (.-value (sel1 [:input.pswd]))])
                :pattern ".{4,}"
                :placeholder "at least 5 characters"
                :type "password"
@@ -269,7 +269,7 @@
                :name "pswd"}]]
           [:div.group.pb3.mt3
             [:div.left.forgot-password
-              [:a {:on-click #(dis/dispatch! [:show-login-overlay :password-reset])} "FORGOT PASSWORD?"]]
+              [:a {:on-click #(dis/dispatch! [:login-overlay-show :password-reset])} "FORGOT PASSWORD?"]]
             [:div.right
               [:button.btn-reset.btn-solid
                 {:disabled (or (not (:auth-settings (rum/react dis/app-state)))
@@ -282,7 +282,7 @@
                               (dis/dispatch! [:signup-with-email]))}
                 "SIGN UP"]]]]]
       [:div.login-overlay-footer.py2.px3.mt1.group
-        [:a.left {:on-click #(do (utils/event-stop %) (dis/dispatch! [:show-login-overlay :login-with-slack]))}
+        [:a.left {:on-click #(do (utils/event-stop %) (dis/dispatch! [:login-overlay-show :login-with-slack]))}
           "Already have an account? "
           [:span.underline "SIGN IN NOW."]]]]])
 
@@ -322,7 +322,7 @@
             [:div.group.pb3.mt3
               [:div.right
                 [:dubtton.btn-reset.btn-solid
-                  {:on-click #(dis/dispatch! [:show-login-overlay nil])}
+                  {:on-click #(dis/dispatch! [:login-overlay-show nil])}
                   "DONE"]]]
             [:div.group.pb3.mt3
               [:div.right.ml1
@@ -332,7 +332,7 @@
                   "RESET PASSWORD"]]
               [:div.right
                 [:button.btn-reset.btn-outline
-                  {:on-click #(dis/dispatch! [:show-login-overlay nil])
+                  {:on-click #(dis/dispatch! [:login-overlay-show nil])
                    :disabled (not (:auth-settings (rum/react dis/app-state)))}
                   "CANCEL"]]])]]]])
 
@@ -450,7 +450,7 @@
                 {:disabled (< (count (:pswd (:collect-pswd (rum/react dis/app-state)))) 5)
                  :on-click #(do
                               (utils/event-stop %)
-                              (dis/dispatch! [:collect-pswd]))}
+                              (dis/dispatch! [:pswd-collect]))}
                 "LET ME IN"]]]]]]])
 
 (rum/defcs login-overlays-handler < rum/static

--- a/src/oc/web/components/ui/menu.cljs
+++ b/src/oc/web/components/ui/menu.cljs
@@ -60,7 +60,7 @@
 (defn sign-in-sign-up-click [e]
   (dis/dispatch! [:mobile-menu-toggle])
   (.preventDefault e)
-  (dis/dispatch! [:show-login-overlay :login-with-slack]))
+  (dis/dispatch! [:login-overlay-show :login-with-slack]))
 
 (defn list-boards-click [e]
   (dis/dispatch! [:mobile-menu-toggle])

--- a/src/oc/web/components/updates.cljs
+++ b/src/oc/web/components/updates.cljs
@@ -30,7 +30,7 @@
              (not (:updates-list-loaded data))
              (not (om/get-state owner :updates-list-loading)))
     (om/set-state! owner :updates-list-loading true)
-    (dis/dispatch! [:get-updates-list])))
+    (dis/dispatch! [:udpates-list-get])))
 
 (defcomponent updates [data owner]
 
@@ -125,7 +125,7 @@
 (defcomponent updates-responsive-switcher [data owner]
 
   (init-state [_]
-    (dis/dispatch! [:start-foce nil])
+    (dis/dispatch! [:foce-start nil])
     {:columns-num (responsive/columns-num)
      :card-width (responsive/calc-card-width)})
 

--- a/src/oc/web/components/welcome_screen.cljs
+++ b/src/oc/web/components/welcome_screen.cljs
@@ -9,5 +9,5 @@
     [:div.welcome-screen-box
       [:span "This is your dashboard, the place for key information you want everyone to know."]
       [:button.choose-first-topic-button.btn-reset.btn-solid
-        {:on-click #(dis/dispatch! [:hide-welcome-screen])}
+        {:on-click #(dis/dispatch! [:welcome-screen-hide])}
         [:label.pointer.mt1 "Choose Your First Topic"]]]])


### PR DESCRIPTION
No trello card, this came out from a suggestion of @belucid 

The actions (`oc.web.dispatcher/actions`) in the Web app are pretty confused right now so with this PR I tried to put some order in it.
The structure of the action name now is this:
`noun-action[/result]`

The `noun` is the the object of the action (or the context), for example an org or a board or the list of users. The `action` is the action on the object, can be a get or an update or whatever (no need to be an HTTP method, it's just an action).
The result is optional and is used when the action is called by the API ns in result of an action with the Storage or Auth service. This can express the result (`/success` or `/failed`) or just that the action finished (`/finish`).

The list of the updated actions now is in the main README file and they are sorted alphabetically so it's easier to group them by object.