### PR TITLE
Slack invite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pom.xml
 /out/
 /target/
 resources/public/js/compiled/
+resources/public/css/main.css
 .lein-*
 .repl
 .nrepl-*

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ pom.xml
 /out/
 /target/
 resources/public/js/compiled/
-resources/public/css/main.css
 .lein-*
 .repl
 .nrepl-*

--- a/build.boot
+++ b/build.boot
@@ -178,6 +178,7 @@
         (reload :asset-path "/public"
                 :on-jsload 'oc.web.core/on-js-reload)
         (cljs :optimizations :none
+              :source-map true
               :compiler-options {:source-map-timestamp true
                                  :preloads '[devtools.preload]})))
 

--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -58,6 +58,7 @@ var Tooltip = function(){};
 var OCWebPrintAppState = function(){};
 var OCWebPrintOrgData = function(){};
 var OCWebPrintTeamData = function(){};
+var OCWebPrintTeamRoster = function(){};
 var OCWebPrintBoardData = function(){};
 var OCWebPrintEntriesData = function(){};
 var OCWebPrintJWTContents = function(){};

--- a/resources/public/lib/print_ascii.js
+++ b/resources/public/lib/print_ascii.js
@@ -1,17 +1,20 @@
 function OCWebHelp(){
   console.log(`
 OpenCompany Web help:
-OCWebHelp(): print this help,
 OCWebPrintAppState(): print the whole app-state,
-OCWebPrintRouterPath(): to print the current router setup.
 OCWebPrintOrgData(): to print the current org data,
-OCWebPrintUpdatesListData(): to print the current loaded list of updates,
-OCWebPrintUpdateData(): to print the current update data,
+OCWebPrintTeamData(): to print the current team data,
+OCWebPrintTeamRoster(): to print the current team roster of users,
 OCWebPrintBoardData(): to print the current board data,
 OCWebPrintEntriesData(): to print all the entries loaded,
 OCWebPrintJWTContents(): to print the content of the JWT.
-OCWebConfigLogLevel("debug"): to change log level.`)
-}
+OCWebHelp(): print this help,
+OCWebPrintAsciiArt(): print beautiful ASCII art,
+OCWebConfigLogLevel("debug"): to change log level.
+OCWebPrintUpdatesListData(): to print the current loaded list of updates,
+OCWebPrintUpdateData(): to print the current update data,
+OCWebPrintRouterPath(): to print the current router setup.
+`)}
 
 function printArt(){
   console.group();

--- a/script/images_md5.sh
+++ b/script/images_md5.sh
@@ -3,7 +3,7 @@
 for f in $(find ./target/public/img/ -type f)
 do
   echo $f >> /tmp/partial_$1.txt
-  (stat -c %Y $f; echo $f; cat $f) | md5sum >> /tmp/partial_$1.txt
+  (echo $f; cat $f) | md5sum >> /tmp/partial_$1.txt
 done
 
 cat /tmp/partial_$1.txt | md5sum

--- a/script/images_md5.sh
+++ b/script/images_md5.sh
@@ -2,7 +2,6 @@
 
 for f in $(find ./target/public/img/ -type f)
 do
-  echo $f >> /tmp/partial_$1.txt
   (echo $f; cat $f) | md5sum >> /tmp/partial_$1.txt
 done
 

--- a/script/images_md5.sh
+++ b/script/images_md5.sh
@@ -2,6 +2,7 @@
 
 for f in $(find ./target/public/img/ -type f)
 do
+  echo $f >> /tmp/partial_$1.txt
   (stat -c %Y $f; echo $f; cat $f) | md5sum >> /tmp/partial_$1.txt
 done
 

--- a/scss/partials/_team_disclaimer_popover.scss
+++ b/scss/partials/_team_disclaimer_popover.scss
@@ -8,7 +8,7 @@ div.oc-popover-container-internal{
     margin-left: -211px;
   }
 
-  div.team-disclaimer-popover.oc-popover {
+  div.role-explainer-popover.oc-popover {
     width: 422px;
     height: 230px;
     font-family: $oc_main_font;
@@ -18,7 +18,7 @@ div.oc-popover-container-internal{
     background-color: white;
     text-align: left;
 
-    div.team-disclaimer-row {
+    div.role-explainer-row {
       margin-bottom: 20px;
       display: inline-block;
 

--- a/scss/partials/_team_management.scss
+++ b/scss/partials/_team_management.scss
@@ -50,6 +50,10 @@ div.company-settings-container {
     }
 
     div.um-invite {
+      div.invite-from {
+        margin-bottom: 1rem;
+      }
+
       div.um-invite-label {
         font-size: 14px;
         font-weight: 700;
@@ -152,7 +156,7 @@ div.company-settings-container {
       }
 
       input.um-invite-field, select.um-invite-field {
-        width: 200px;
+        width: 180px;
         height: 36px;
         margin: 0px;
         padding: .5rem;
@@ -163,7 +167,7 @@ div.company-settings-container {
         font-weight: 400;
         border-radius: 3px;
         border: solid 1px #979797;
-        margin-right: 1rem;
+        margin-right: 1.5rem;
 
         @include mobile(){
           width: 240px;

--- a/scss/partials/_team_management.scss
+++ b/scss/partials/_team_management.scss
@@ -50,8 +50,14 @@ div.company-settings-container {
     }
 
     div.um-invite {
-      div.invite-from {
+      div.invite-from, div.invite-from label {
         margin-bottom: 1rem;
+        font-family: $oc_main_font;
+        font-size: 14px;
+        font-weight: normal;
+        line-height: 1.5;
+        letter-spacing: 1.2px;
+        color: $oc_gray_5;
       }
 
       div.um-invite-label {

--- a/scss/partials/_team_management.scss
+++ b/scss/partials/_team_management.scss
@@ -1,6 +1,10 @@
 div.company-settings-container {
   min-height: calc(100vh - #{$footer_height}px - 52px);
 
+  div.action-result {
+    width: 580px;
+  }
+
   div.team-management {
     padding: 2rem;
     background-color: rgba(78, 90, 107, 0.05);

--- a/scss/partials/_team_management.scss
+++ b/scss/partials/_team_management.scss
@@ -151,7 +151,7 @@ div.company-settings-container {
         }
       }
 
-      input.um-invite-field {
+      input.um-invite-field, select.um-invite-field {
         width: 200px;
         height: 36px;
         margin: 0px;
@@ -162,8 +162,6 @@ div.company-settings-container {
         font-family: $oc_main_font;
         font-weight: 400;
         border-radius: 3px;
-        background-color: #ffffff;
-        box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.5);
         border: solid 1px #979797;
         margin-right: 1rem;
 
@@ -179,6 +177,11 @@ div.company-settings-container {
         &:active, &:focus {
           outline: none;
         }
+      }
+
+      input.um-invite-field {
+        background-color: #ffffff;
+        box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.5);
       }
 
       button.um-invite-send {

--- a/scss/partials/_user_type_picker.scss
+++ b/scss/partials/_user_type_picker.scss
@@ -33,7 +33,7 @@ div.user-type-picker {
       letter-spacing: 1.2px;
       color: rgba(78, 90, 107, 1);
       position: absolute;
-      top: -28px;
+      top: -20px;
       cursor: pointer;
       width: 100px;
       height: 28px;

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -702,7 +702,7 @@
         new-user-type (:user-type invite-data)]
     ;; Send the invitation only if the user is not part of the team already
     ;; or if it's still pending, ie resend the invitation email
-    (when (or (not user)
+    (if (or (not user)
               (and user
                    (= (string/lower-case (:status user)) "pending")))
       (let [splitted-name (string/split email-name #"\s")
@@ -723,7 +723,8 @@
                   (not= old-user-type new-user-type))
           (api/switch-user-type old-user-type new-user-type user (utils/get-author (:user-id user) (:authors org-data))))
         (api/send-invitation (if (= invite-from "email") email-address (:slack-id slack-user)) invite-from user-type first-name last-name)
-        (update-in db [:um-invite] dissoc :error)))))
+        (update-in db [:um-invite] dissoc :error))
+      db)))
 
 (defmethod dispatcher/action :invite-user/success
   [db [_]]

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -661,8 +661,8 @@
   [db [_ roster-data]]
   (if roster-data
     (let [fixed-roster-data {:team-id (:team-id roster-data)
-                             :links (:links (:collection roster-data))
-                             :users (:items (:collection roster-data))}]
+                             :links (-> roster-data :collection :links)
+                             :users (-> roster-data :collection :items)}]
       (assoc-in db (dispatcher/team-data-key (:team-id roster-data)) fixed-roster-data))
     db))
 

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -646,7 +646,7 @@
   (doseq [team teams
           :let [team-link (utils/link-for (:links team) "item" "GET")
                 roster-link (utils/link-for (:links team) "roster" "GET")]]
-    (if team-link
+    (if team-link ; team link may not be present for non-admins, if so they can still get team users from the roster
       (api/get-team team-link)
       (api/get-team roster-link)))
   (assoc-in db [:teams-data :teams] teams))

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -960,9 +960,9 @@
 
 (defmethod dispatcher/action :create-org
   [db [_]]
-  (let [org-name (:create-org db)]
-    (when-not (string/blank? org-name)
-      (api/create-org org-name)))
+  (let [org-data (:create-org db)]
+    (when-not (string/blank? (:name org-data))
+      (api/create-org (:name org-data) (:logo-url org-data))))
   db)
 
 (defmethod dispatcher/action :create-board

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -646,8 +646,10 @@
   (doseq [team teams
           :let [team-link (utils/link-for (:links team) "item" "GET")
                 roster-link (utils/link-for (:links team) "roster" "GET")]]
-    (if team-link ; team link may not be present for non-admins, if so they can still get team users from the roster
-      (api/get-team team-link)
+    ; team link may not be present for non-admins, if so they can still get team users from the roster
+    (when team-link
+      (api/get-team team-link))
+    (when roster-link
       (api/get-team roster-link)))
   (assoc-in db [:teams-data :teams] teams))
 
@@ -663,7 +665,7 @@
     (let [fixed-roster-data {:team-id (:team-id roster-data)
                              :links (-> roster-data :collection :links)
                              :users (-> roster-data :collection :items)}]
-      (assoc-in db (dispatcher/team-data-key (:team-id roster-data)) fixed-roster-data))
+      (assoc-in db (dispatcher/team-roster-key (:team-id roster-data)) fixed-roster-data))
     db))
 
 (defmethod dispatcher/action :enumerate-channels

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -703,8 +703,8 @@
     ;; Send the invitation only if the user is not part of the team already
     ;; or if it's still pending, ie resend the invitation email
     (if (or (not user)
-              (and user
-                   (= (string/lower-case (:status user)) "pending")))
+            (and user
+                 (= (string/lower-case (:status user)) "pending")))
       (let [splitted-name (string/split email-name #"\s")
             name-size (count splitted-name)
             splittable-name? (= name-size 2)
@@ -724,7 +724,10 @@
           (api/switch-user-type old-user-type new-user-type user (utils/get-author (:user-id user) (:authors org-data))))
         (api/send-invitation (if (= invite-from "email") email-address (:slack-id slack-user)) invite-from user-type first-name last-name)
         (update-in db [:um-invite] dissoc :error))
-      db)))
+      (if (and user
+               (not= (string/lower-case (:status user)) "pending"))
+        (assoc-in db [:um-invite :error] "User already active.")
+        db))))
 
 (defmethod dispatcher/action :invite-user/success
   [db [_]]

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -729,19 +729,27 @@
         (assoc-in db [:um-invite :error] "User already active.")
         db))))
 
+(defmethod dispatcher/action :invite-user-reset
+  [db [_]]
+  (update-in db [:um-invite] dissoc :last-action-success))
+
 (defmethod dispatcher/action :invite-user/success
   [db [_]]
   ; refresh the users list once the invitation succeded
   (api/get-teams)
   (assoc db :um-invite {:email ""
                         :user-type nil
+                        :invite-from "email"
+                        :last-action-success true
                         :error nil}))
 
 (defmethod dispatcher/action :invite-user/failed
   [db [_ email]]
   ; refresh the users list once the invitation succeded
   (api/get-teams)
-  (assoc-in db [:um-invite :error] true))
+  (-> db
+      (assoc-in [:um-invite :error] true)
+      (assoc-in [:um-invite :last-action-success] false)))
 
 (defmethod dispatcher/action :user-action
   [db [_ team-id invitation action method other-link-params payload]]

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -722,7 +722,7 @@
         (when (and user
                   (not= old-user-type new-user-type))
           (api/switch-user-type old-user-type new-user-type user (utils/get-author (:user-id user) (:authors org-data))))
-        (api/send-invitation (if (= invite-from "email") email-address (:slack-id slack-user)) invite-from user-type first-name last-name)
+        (api/send-invitation (if (= invite-from "email") email-address slack-user) invite-from user-type first-name last-name)
         (update-in db [:um-invite] dissoc :error))
       (if (and user
                (not= (string/lower-case (:status user)) "pending"))

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -718,8 +718,8 @@
           with-invited-user (if (= invite-from "slack")
                               (merge json-params {:slack-id (:slack-id invited-user) :slack-org-id (:slack-org-id invited-user)})
                               (assoc json-params :email invited-user))
-          with-company-name (merge with-user-id {:org-name (:name org-data)
-                                                 :logo-url (:logo-url org-data)})]
+          with-company-name (merge with-invited-user {:org-name (:name org-data)
+                                                      :logo-url (:logo-url org-data)})]
       (auth-post (:href invitation-link)
         {:json-params (cljs->json with-company-name)
          :headers (headers-for-link invitation-link)}

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -645,13 +645,17 @@
                    (not (s/blank? redirect-url)))
           (router/redirect! redirect-url))))))
 
-(defn create-org [org-name]
+(defn create-org [org-name logo-url]
   (let [create-org-link (utils/link-for (dispatcher/api-entry-point) "create")
-        team-id (first (j/get-key :teams))]
+        team-id (first (j/get-key :teams))
+        org-data {:name org-name :team-id team-id}
+        with-logo (if-not (empty? logo-url)
+                    (assoc org-data :logo-url logo-url)
+                    org-data)]
     (when (and org-name create-org-link)
       (api-post (:href create-org-link)
         {:headers (headers-for-link create-org-link)
-         :json-params (cljs->json {:name org-name :team-id team-id})}
+         :json-params (cljs->json with-logo)}
         (fn [{:keys [success status body]}]
           (when-let [org-data (if success (json->cljs body) {})]
             (dispatcher/dispatch! [:org org-data])

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -705,8 +705,8 @@
   "Give a user email and type of user send an invitation to the team.
    If the team has only one company, checked via API entry point links, send the company name of that.
    Add the logo of the company if possible"
-  [user-id invite-from user-type first-name last-name]
-  (when (and user-id invite-from user-type)
+  [invited-user invite-from user-type first-name last-name]
+  (when (and invited-user invite-from user-type)
     (let [org-data (dispatcher/org-data)
           team-data (dispatcher/team-data)
           invitation-link (utils/link-for (:links team-data) "add" "POST" {:content-type "application/vnd.open-company.team.invite.v1"})
@@ -715,9 +715,9 @@
           json-params {:first-name first-name
                        :last-name last-name
                        :admin (= user-type :admin)}
-          with-user-id (if (= invite-from "slack")
-                          (assoc json-params :slack-id user-id)
-                          (assoc json-params :email user-id))
+          with-invited-user (if (= invite-from "slack")
+                              (merge json-params {:slack-id (:slack-id invited-user) :slack-org-id (:slack-org-id invited-user)})
+                              (assoc json-params :email invited-user))
           with-company-name (merge with-user-id {:org-name (:name org-data)
                                                  :logo-url (:logo-url org-data)})]
       (auth-post (:href invitation-link)

--- a/src/oc/web/components/board_settings.cljs
+++ b/src/oc/web/components/board_settings.cljs
@@ -125,7 +125,11 @@
   (let [org-data (drv/react s :org-data)
         board-data (drv/react s :board-data)
         {:keys [teams-data]} (drv/react s :team-management)
-        all-users (get-in teams-data [(:team-id org-data) :data :users])]
+        team-users (get-in teams-data [(:team-id org-data) :data :users])
+        roster-users (get-in teams-data [(:team-id org-data) :roster :users])
+        all-users (if (empty? team-users)
+                    (filter #(not= (:status %) "uninvited") roster-users)
+                    team-users)]
     [:div.private-board-users-list
       [:table
         [:thead

--- a/src/oc/web/components/board_settings.cljs
+++ b/src/oc/web/components/board_settings.cljs
@@ -18,7 +18,7 @@
             [oc.web.components.ui.footer :as footer]
             [oc.web.components.ui.small-loading :as loading]
             [oc.web.components.ui.login-required :refer (login-required)]
-            [oc.web.components.ui.user-type-picker :refer (user-type-picker user-type-dropdown show-team-disclaimer-popover)]
+            [oc.web.components.ui.user-type-picker :refer (user-type-picker user-type-dropdown show-role-explainer-popover)]
             [oc.web.components.ui.back-to-dashboard-btn :refer (back-to-dashboard-btn)]
             [goog.events :as events]
             [goog.fx.dom :refer (Fade)]
@@ -131,7 +131,7 @@
         [:thead
           [:tr
             [:th.pointer
-              {:on-click #(show-team-disclaimer-popover % true)}
+              {:on-click #(show-role-explainer-popover % true)}
             "ACCESS "
             [:i.fa.fa-question-circle]]
             [:th "NAME"]

--- a/src/oc/web/components/board_settings.cljs
+++ b/src/oc/web/components/board_settings.cljs
@@ -51,7 +51,7 @@
   (let [{:keys [teams-data private-board-invite]} (drv/react s :team-management)
         org-data (drv/react s :org-data)
         board-data (drv/react s :board-data)
-        users (filter :user-id (get-in teams-data [(:team-id org-data) :data :users])) ; filter Slack only users
+        users (get-in teams-data [(:team-id org-data) :data :users])
         selected-user-id (:selected-user-id private-board-invite)
         selected-user-type (:selected-user-type private-board-invite)
         selected-user (when selected-user-id (some #(when (= (:user-id %) selected-user-id) %) users))
@@ -125,7 +125,7 @@
   (let [org-data (drv/react s :org-data)
         board-data (drv/react s :board-data)
         {:keys [teams-data]} (drv/react s :team-management)
-        all-users (filter :user-id (get-in teams-data [(:team-id org-data) :data :users]))] ; filter Slack only users
+        all-users (get-in teams-data [(:team-id org-data) :data :users])]
     [:div.private-board-users-list
       [:table
         [:thead

--- a/src/oc/web/components/board_settings.cljs
+++ b/src/oc/web/components/board_settings.cljs
@@ -51,7 +51,7 @@
   (let [{:keys [teams-data private-board-invite]} (drv/react s :team-management)
         org-data (drv/react s :org-data)
         board-data (drv/react s :board-data)
-        users (get-in teams-data [(:team-id org-data) :data :users])
+        users (filter :user-id (get-in teams-data [(:team-id org-data) :data :users])) ; filter Slack only users
         selected-user-id (:selected-user-id private-board-invite)
         selected-user-type (:selected-user-type private-board-invite)
         selected-user (when selected-user-id (some #(when (= (:user-id %) selected-user-id) %) users))
@@ -125,7 +125,7 @@
   (let [org-data (drv/react s :org-data)
         board-data (drv/react s :board-data)
         {:keys [teams-data]} (drv/react s :team-management)
-        all-users (get-in teams-data [(:team-id org-data) :data :users])]
+        all-users (filter :user-id (get-in teams-data [(:team-id org-data) :data :users]))] ; filter Slack only users
     [:div.private-board-users-list
       [:table
         [:thead

--- a/src/oc/web/components/org_editor.cljs
+++ b/src/oc/web/components/org_editor.cljs
@@ -24,7 +24,7 @@
   (utils/event-stop e)
   (when-not (om/get-state owner :loading)
     (let [data         (om/get-props owner)
-          org-name (:create-org data)]
+          org-name (:name (:create-org data))]
       (if (clojure.string/blank? org-name)
         (create-org-alert owner)
         (do
@@ -36,7 +36,7 @@
     ;; using utils/after here because we can't dispatch inside another dispatch.
     ;; ultimately we should switch to some event-loop impl that works like a proper queue
     ;; and does not have these limitations
-    (utils/after 1 #(dis/dispatch! [:input [:create-org] (or (:name team-data) "")]))
+    (utils/after 1 #(dis/dispatch! [:input [:create-org] {:name (or (:name team-data) "") :logo-url (or (:logo-url team-data) "")}]))
     (when-not (empty? (:name team-data))
       (om/set-state! owner :message "Is this the organization name you’d like to use?"))))
 
@@ -70,13 +70,13 @@
                           :class "org-editor-input domine h4"
                           :style #js {:width "100%"}
                           :placeholder "Simple name without the Inc., LLC, etc."
-                          :value (or (:create-org data) "")
+                          :value (or (:name (:create-org data)) "")
                           :on-change #(do
                                         (om/set-state! owner :name-did-change true)
-                                        (dis/dispatch! [:input [:create-org] (.. % -target -value)]))})))
+                                        (dis/dispatch! [:input [:create-org :name] (.. % -target -value)]))})))
             (dom/div {:class "center"}
               (dom/button {:class "btn-reset btn-solid get-started-button"
-                           :disabled (not (pos? (count (:create-org data))))
+                           :disabled (not (pos? (count (:name (:create-org data)))))
                            :on-click (partial create-org-clicked owner)}
                           (when loading
                             (loading/small-loading {:class "left mt1"}))

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -111,7 +111,6 @@
                        :on-change (fn [e]
                                     (let [selected-slack-id (.. e -target -value)
                                           selected-slack-user (first (filter #(= (:slack-id %) selected-slack-id) slack-uninvited-users))]
-                                      (js/console.log "selected-slack-id:" selected-slack-id "selected-slack-user" selected-slack-user)
                                       (when selected-slack-user
                                         (dis/dispatch! [:input [:um-invite :slack-user] selected-slack-user]))))
                        :placeholder "Select a Slack user from the list"}

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -79,30 +79,31 @@
             [:div.um-invite-label
               "TEAM MEMBERS"]
             [:div
-              [:div.invite-from
-                "From: "
-                [:span.ml2 "  "]
-                [:input
-                  {:type "radio"
-                   :id "invite-from-email"
-                   :checked (or (not (:invite-from um-invite)) (= invite-from "email"))
-                   :on-click #(dis/dispatch! [:input [:um-invite :invite-from] "email"])
-                   :on-change #(dis/dispatch! [:input [:um-invite :invite-from] "email"])
-                   :value "email"}]
-                [:label.ml1
-                  {:for "invite-from-email"}
-                  "Email"]
-                [:span.ml2 "  "]
-                [:input
-                  {:type "radio"
-                   :id "invite-from-slack"
-                   :checked (= invite-from "slack")
-                   :on-click #(dis/dispatch! [:input [:um-invite :invite-from] "slack"])
-                   :on-change #(dis/dispatch! [:input [:um-invite :invite-from] "slack"])
-                   :value "slack"}]
-                [:label.ml1
-                  {:for "invite-from-slack"}
-                  "Slack"]]
+              (when (jwt/team-has-bot? team-id)
+                [:div.invite-from
+                  "From: "
+                  [:span.ml2 "  "]
+                  [:input
+                    {:type "radio"
+                     :id "invite-from-email"
+                     :checked (or (not (:invite-from um-invite)) (= invite-from "email"))
+                     :on-click #(dis/dispatch! [:input [:um-invite :invite-from] "email"])
+                     :on-change #(dis/dispatch! [:input [:um-invite :invite-from] "email"])
+                     :value "email"}]
+                  [:label.ml1
+                    {:for "invite-from-email"}
+                    "Email"]
+                  [:span.ml2 "  "]
+                  [:input
+                    {:type "radio"
+                     :id "invite-from-slack"
+                     :checked (= invite-from "slack")
+                     :on-click #(dis/dispatch! [:input [:um-invite :invite-from] "slack"])
+                     :on-change #(dis/dispatch! [:input [:um-invite :invite-from] "slack"])
+                     :value "slack"}]
+                  [:label.ml1
+                    {:for "invite-from-slack"}
+                    "Slack"]])
               [:div.group
                 (if (= invite-from "slack")
                   (let [slack-uninvited-users (filter #(= (:status %) "uninvited") (:users team-roster))]

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -44,6 +44,10 @@
                                                           (utils/valid-email? (:email (:um-invite @(drv/get-ref s :team-management)))))
                                                   (dis/dispatch! [:input [:um-invite :user-type] :viewer]))
                                                s)
+                             :after-render (fn [s]
+                                            (when-let [action-finished (js/$ "div#action-finished")]
+                                               (utils/after 2500 #(dis/dispatch! [:invite-user-reset])))
+                                            s)
                              :did-mount (fn [s]
                                           (when (not (empty? (:access (:query-params @router/path))))
                                             (utils/after 5000
@@ -70,204 +74,210 @@
         team-id (:team-id org-data)
         team-data (get-in teams-data [team-id :data])
         team-roster (get-in teams-data [team-id :roster])]
-    [:div.team-management.mx-auto.p3.my4.group
-      (if-not team-data
-        ;; Still loading
-        (rloading {:loading true})
+    [:div
+      (when (contains? um-invite :last-action-success)
+        [:div.action-result.mx-auto
+          {:id "action-finished"
+           :class (if (:last-action-success um-invite) "green" "red")}
+          (if (:last-action-success um-invite) "Action completed." "An error occurred, please retry.")])
+      [:div.team-management.mx-auto.p3.mb4.group
+        {:style {:margin-top (if (contains? um-invite :last-action-success) "0px" "22px")}}
+        (if-not team-data
+          ;; Still loading
+          (rloading {:loading true})
 
-        ;; Render team management UI
-        [:div
-
-          ;; Invite team members, mobile and web
-          [:div.um-invite.group.mb3
-            [:div.um-invite-label
-              "TEAM MEMBERS"]
-            [:div
-              (when (jwt/team-has-bot? team-id)
-                [:div.invite-from
-                  "Invite from: "
-                  [:span.ml2 "  "]
-                  [:input
-                    {:type "radio"
-                     :id "invite-from-email"
-                     :checked (or (not (:invite-from um-invite)) (= invite-from "email"))
-                     :on-click #(dis/dispatch! [:input [:um-invite :invite-from] "email"])
-                     :on-change #(dis/dispatch! [:input [:um-invite :invite-from] "email"])
-                     :value "email"}]
-                  [:label.ml1
-                    {:for "invite-from-email"}
-                    "Email"]
-                  [:span.ml2 "  "]
-                  [:input
-                    {:type "radio"
-                     :id "invite-from-slack"
-                     :checked (= invite-from "slack")
-                     :on-click #(dis/dispatch! [:input [:um-invite :invite-from] "slack"])
-                     :on-change #(dis/dispatch! [:input [:um-invite :invite-from] "slack"])
-                     :value "slack"}]
-                  [:label.ml1
-                    {:for "invite-from-slack"}
-                    "Slack"]])
-              [:div.group
-                (if (= invite-from "slack")
-                  (let [slack-uninvited-users (filter #(= (:status %) "uninvited") (:users team-roster))
-                        all-slack-teams (distinct (map :slack-org-id slack-uninvited-users))
-                        slack-teams (map #(hash-map :slack-org-id % :slack-org-name (slack-org-name % team-data)) all-slack-teams)]
-                    [:select.left.um-invite-field.slack
-                      {:value (str (:slack-org-id (:slack-user um-invite)) "-" (:slack-id (:slack-user um-invite)))
-                       :on-change (fn [e]
-                                    (let [v (.. e -target -value)
-                                          splitted (clojure.string/split v #"-")
-                                          selected-slack-user (first (filter #(and (= (:slack-id %) (second splitted)) (= (:slack-org-id %) (first splitted))) slack-uninvited-users))]
-                                      (when selected-slack-user
-                                        (dis/dispatch! [:input [:um-invite :slack-user] selected-slack-user]))))
-                       :placeholder "Select a Slack member"}
-                       [:option
-                         {:value ""
-                          :key "slack-id-none"}
-                         (if (zero? (count slack-uninvited-users)) "All Slack members have been invited" "Select a Slack member")]
-                       (for [slack-org slack-teams
-                             :let [slack-org-users (filter #(= (:slack-org-id %) (:slack-org-id slack-org)) slack-uninvited-users)]]
-                         [:optgroup
-                           {:key (str "slack-team-" (:slack-org-id slack-org))
-                            :label (if (> (count slack-teams) 1) (:slack-org-name slack-org) "")}
-                           (for [s slack-org-users]
-                             [:option
-                               {:key (str "slack-invite-" (:slack-org-id s) "-" (:slack-id s))
-                                :value (str (:slack-org-id s) "-" (:slack-id s))}
-                               (utils/name-or-email s)])])])
-                  [:input.left.um-invite-field.email
-                    {:name "um-invite"
-                     :type "text"
-                     :autoCapitalize "none"
-                     :value (:email um-invite)
-                     :on-change #(dis/dispatch! [:input [:um-invite :email] (.. % -target -value)])
-                     :placeholder "Email address"}])
-                (user-type-picker user-type (or (and (= invite-from "email") valid-email?)
-                                                (and (= invite-from "slack") valid-slack-user?))
-                                  #(dis/dispatch! [:input [:um-invite :user-type] %]) true)
-                [:button.right.btn-reset.btn-solid.um-invite-send
-                  {:disabled (not (and user-type
-                                       (or (and (= invite-from "email")
-                                                valid-email?)
-                                           (and (= invite-from "slack")
-                                                valid-slack-user?))))
-                   :on-click #(let [email (:email (:um-invite ro-user-man))]
-                                (if (and (or (and (= invite-from "email") valid-email?)
-                                             (and (= invite-from "slack") valid-slack-user?))
-                                         (not (nil? (:user-type (:um-invite ro-user-man)))))
-                                  (dis/dispatch! [:invite-user])
-                                  (dis/dispatch! [:input [:um-invite :error] true])))}
-                 "SEND INVITE"]]
-              (when (:error um-invite)
-                [:div
-                  (cond
-                    (string? (:error um-invite))
-                    [:span.small-caps.red.mt1.left (:error um-invite)]
-                    (and (= (:error um-invite) :user-exists)
-                         (:email um-invite))
-                    [:span.small-caps.red.mt1.left (str (:email um-invite) " is already a user.")]
-                    :else
-                    [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]]
-
-              ;; List of current team members, web only
-              (when-not (responsive/is-mobile-size?)
-                [:div.mb3.um-invite.group
-                  (when team-data
-                    (users-list team-id (:users team-data) (:authors org-data)))])
-
-              ;; Slack team management, web only
-              (when-not (responsive/is-mobile-size?)
-                [:div.mb3.um-invite.group
-                  [:div.um-invite-label
-                      "SLACK TEAMS"]
-                  [:div.um-invite-label-2
-                    "Anyone who signs up with your Slack team can view team boards."]
-                  [:div.team-list
-                    (for [team (:slack-orgs team-data)]
-                      [:div.slack-domain.group
-                        {:key (str "slack-org-" (:slack-org-id team))}
-                        [:img.slack-logo {:src (str ls/cdn-url "/img/slack.png")}]
-                        [:span (:name team)]
-                        (when-not (contains? (jwt/get-key :bot) team-id)
-                          (when-let [add-bot-link (utils/link-for (:links team) "bot" "GET" {:auth-source "slack"})]
-                            (let [fixed-add-bot-link (utils/slack-link-with-state (:href add-bot-link) (:user-id cur-user-data) team-id (oc-urls/org-team-settings (:slug org-data)))]
-                              [:button.btn-reset.btn-link
-                                {:on-click #(router/redirect! fixed-add-bot-link)
-                                 :title "The OpenCompany Slack bot enables Slack invites, assignments and sharing."
-                                 :data-toggle "tooltip"
-                                 :data-placement "top"
-                                 :data-container "body"}
-                                "Add OpenCompany Slack bot"])))
-                        [:button.btn-reset
-                          {:on-click #(api/user-action (utils/link-for (:links team) "remove" "DELETE") nil)
-                           :title (str "Remove " (:name team) " Slack team")
-                           :data-toggle "tooltip"
-                           :data-placement "top"
-                           :data-container "body"}
-                          [:i.fa.fa-trash]]])]
-                  [:div.group
-                    (when (utils/link-for (:links team-data) "authenticate" "GET" {:auth-source "slack"})
-                      (if (zero? (count (:slack-orgs team-data)))
-                        [:button.btn-reset.mt2.add-slack-team.slack-button
-                            {:on-click #(dis/dispatch! [:add-slack-team])}
-                            "Add "
-                            [:span.slack "Slack"]
-                            " Team"]
-                        [:button.btn-reset.btn-link.another-slack-team
-                          {:on-click #(dis/dispatch! [:add-slack-team])}
-                          "Add another Slack team"]))
-                    (when (not (empty? (:access query-params)))
-                      [:div#result-message
-                        (cond
-                          (= (:access query-params) "team-exists")
-                          [:span.small-caps.red.mt1.left "This team was already added."]
-                          (= (:access query-params) "team")
-                          [:span.small-caps.green.mt1.left "Team successfully added."]
-                          (= (:access query-params) "bot")
-                          [:span.small-caps.green.mt1.left "Bot successfully added."]
-                          :else
-                          [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]])
-              
-              ;; Email domains, web only
-              (when-not (responsive/is-mobile-size?)
-                [:div.mb3.um-invite.group
-                  [:div.um-invite-label
-                      "TEAM EMAIL DOMAINS"]
-                  [:div.um-invite-label-2
-                    "Anyone who signs up with this email domain can view team boards."]
-                  [:div.team-list
-                    (for [team (:email-domains team-data)]
-                      [:div.email-domain.group
-                        [:span (str "@" (:domain team))]
-                        [:button.btn-reset
-                          {:on-click #(api/user-action (utils/link-for (:links team) "remove" "DELETE") nil)
-                           :title "Remove email domain team"}
-                          [:i.fa.fa-trash]]])]
-                  [:div.group
+          ;; Render team management UI
+          [:div.group
+            ;; Invite team members, mobile and web
+            [:div.um-invite.group.mb3
+              [:div.um-invite-label
+                "TEAM MEMBERS"]
+              [:div
+                (when (jwt/team-has-bot? team-id)
+                  [:div.invite-from
+                    "Invite from: "
+                    [:span.ml2 "  "]
+                    [:input
+                      {:type "radio"
+                       :id "invite-from-email"
+                       :checked (or (not (:invite-from um-invite)) (= invite-from "email"))
+                       :on-click #(dis/dispatch! [:input [:um-invite :invite-from] "email"])
+                       :on-change #(dis/dispatch! [:input [:um-invite :invite-from] "email"])
+                       :value "email"}]
+                    [:label.ml1
+                      {:for "invite-from-email"}
+                      "Email"]
+                    [:span.ml2 "  "]
+                    [:input
+                      {:type "radio"
+                       :id "invite-from-slack"
+                       :checked (= invite-from "slack")
+                       :on-click #(dis/dispatch! [:input [:um-invite :invite-from] "slack"])
+                       :on-change #(dis/dispatch! [:input [:um-invite :invite-from] "slack"])
+                       :value "slack"}]
+                    [:label.ml1
+                      {:for "invite-from-slack"}
+                      "Slack"]])
+                [:div.group
+                  (if (= invite-from "slack")
+                    (let [slack-uninvited-users (filter #(= (:status %) "uninvited") (:users team-roster))
+                          all-slack-teams (distinct (map :slack-org-id slack-uninvited-users))
+                          slack-teams (map #(hash-map :slack-org-id % :slack-org-name (slack-org-name % team-data)) all-slack-teams)]
+                      [:select.left.um-invite-field.slack
+                        {:value (str (:slack-org-id (:slack-user um-invite)) "-" (:slack-id (:slack-user um-invite)))
+                         :on-change (fn [e]
+                                      (let [v (.. e -target -value)
+                                            splitted (clojure.string/split v #"-")
+                                            selected-slack-user (first (filter #(and (= (:slack-id %) (second splitted)) (= (:slack-org-id %) (first splitted))) slack-uninvited-users))]
+                                        (when selected-slack-user
+                                          (dis/dispatch! [:input [:um-invite :slack-user] selected-slack-user]))))
+                         :placeholder "Select a Slack member"}
+                         [:option
+                           {:value ""
+                            :key "slack-id-none"}
+                           (if (zero? (count slack-uninvited-users)) "All Slack members have been invited" "Select a Slack member")]
+                         (for [slack-org slack-teams
+                               :let [slack-org-users (filter #(= (:slack-org-id %) (:slack-org-id slack-org)) slack-uninvited-users)]]
+                           [:optgroup
+                             {:key (str "slack-team-" (:slack-org-id slack-org))
+                              :label (if (> (count slack-teams) 1) (:slack-org-name slack-org) "")}
+                             (for [s slack-org-users]
+                               [:option
+                                 {:key (str "slack-invite-" (:slack-org-id s) "-" (:slack-id s))
+                                  :value (str (:slack-org-id s) "-" (:slack-id s))}
+                                 (utils/name-or-email s)])])])
                     [:input.left.um-invite-field.email
-                      {:name "um-domain-invite"
+                      {:name "um-invite"
                        :type "text"
                        :autoCapitalize "none"
-                       :value (:domain um-domain-invite)
-                       :pattern "@?[a-z0-9.-]+\\.[a-z]{2,4}$"
-                       :on-change #(dis/dispatch! [:input [:um-domain-invite :domain] (.. % -target -value)])
-                       :placeholder "Domain, e.g. @amc.com"}]
-                    [:button.right.btn-reset.btn-solid.um-invite-send
-                      {:disabled (not valid-domain-email?)
-                       :on-click #(let [domain (:domain (:um-domain-invite ro-user-man))]
-                                    (if (utils/valid-domain? domain)
-                                      (dis/dispatch! [:add-email-domain-team])
-                                      (dis/dispatch! [:input [:add-email-domain-team-error] true])))}
-                     "ADD"]
-                    (when add-email-domain-team-error
-                      [:div
-                        (cond
-                          (and (= add-email-domain-team-error :domain-exists)
-                               (:domain um-domain-invite))
-                          [:span.small-caps.red.mt1.left (str (:domain um-domain-invite) " was already added.")]
-                          :else
-                          [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]])])]))
+                       :value (:email um-invite)
+                       :on-change #(dis/dispatch! [:input [:um-invite :email] (.. % -target -value)])
+                       :placeholder "Email address"}])
+                  (user-type-picker user-type (or (and (= invite-from "email") valid-email?)
+                                                  (and (= invite-from "slack") valid-slack-user?))
+                                    #(dis/dispatch! [:input [:um-invite :user-type] %]) true)
+                  [:button.right.btn-reset.btn-solid.um-invite-send
+                    {:disabled (not (and user-type
+                                         (or (and (= invite-from "email")
+                                                  valid-email?)
+                                             (and (= invite-from "slack")
+                                                  valid-slack-user?))))
+                     :on-click #(let [email (:email (:um-invite ro-user-man))]
+                                  (if (and (or (and (= invite-from "email") valid-email?)
+                                               (and (= invite-from "slack") valid-slack-user?))
+                                           (not (nil? (:user-type (:um-invite ro-user-man)))))
+                                    (dis/dispatch! [:invite-user])
+                                    (dis/dispatch! [:input [:um-invite :error] true])))}
+                   "SEND INVITE"]]
+                (when (:error um-invite)
+                  [:div
+                    (cond
+                      (string? (:error um-invite))
+                      [:span.small-caps.red.mt1.left (:error um-invite)]
+                      (and (= (:error um-invite) :user-exists)
+                           (:email um-invite))
+                      [:span.small-caps.red.mt1.left (str (:email um-invite) " is already a user.")]
+                      :else
+                      [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]]
+
+                ;; List of current team members, web only
+                (when-not (responsive/is-mobile-size?)
+                  [:div.mb3.um-invite.group
+                    (when team-data
+                      (users-list team-id (:users team-data) (:authors org-data)))])
+
+                ;; Slack team management, web only
+                (when-not (responsive/is-mobile-size?)
+                  [:div.mb3.um-invite.group
+                    [:div.um-invite-label
+                        "SLACK TEAMS"]
+                    [:div.um-invite-label-2
+                      "Anyone who signs up with your Slack team can view team boards."]
+                    [:div.team-list
+                      (for [team (:slack-orgs team-data)]
+                        [:div.slack-domain.group
+                          {:key (str "slack-org-" (:slack-org-id team))}
+                          [:img.slack-logo {:src (str ls/cdn-url "/img/slack.png")}]
+                          [:span (:name team)]
+                          (when-not (contains? (jwt/get-key :bot) team-id)
+                            (when-let [add-bot-link (utils/link-for (:links team) "bot" "GET" {:auth-source "slack"})]
+                              (let [fixed-add-bot-link (utils/slack-link-with-state (:href add-bot-link) (:user-id cur-user-data) team-id (oc-urls/org-team-settings (:slug org-data)))]
+                                [:button.btn-reset.btn-link
+                                  {:on-click #(router/redirect! fixed-add-bot-link)
+                                   :title "The OpenCompany Slack bot enables Slack invites, assignments and sharing."
+                                   :data-toggle "tooltip"
+                                   :data-placement "top"
+                                   :data-container "body"}
+                                  "Add OpenCompany Slack bot"])))
+                          [:button.btn-reset
+                            {:on-click #(api/user-action (utils/link-for (:links team) "remove" "DELETE") nil)
+                             :title (str "Remove " (:name team) " Slack team")
+                             :data-toggle "tooltip"
+                             :data-placement "top"
+                             :data-container "body"}
+                            [:i.fa.fa-trash]]])]
+                    [:div.group
+                      (when (utils/link-for (:links team-data) "authenticate" "GET" {:auth-source "slack"})
+                        (if (zero? (count (:slack-orgs team-data)))
+                          [:button.btn-reset.mt2.add-slack-team.slack-button
+                              {:on-click #(dis/dispatch! [:add-slack-team])}
+                              "Add "
+                              [:span.slack "Slack"]
+                              " Team"]
+                          [:button.btn-reset.btn-link.another-slack-team
+                            {:on-click #(dis/dispatch! [:add-slack-team])}
+                            "Add another Slack team"]))
+                      (when (not (empty? (:access query-params)))
+                        [:div#result-message
+                          (cond
+                            (= (:access query-params) "team-exists")
+                            [:span.small-caps.red.mt1.left "This team was already added."]
+                            (= (:access query-params) "team")
+                            [:span.small-caps.green.mt1.left "Team successfully added."]
+                            (= (:access query-params) "bot")
+                            [:span.small-caps.green.mt1.left "Bot successfully added."]
+                            :else
+                            [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]])
+                
+                ;; Email domains, web only
+                (when-not (responsive/is-mobile-size?)
+                  [:div.mb3.um-invite.group
+                    [:div.um-invite-label
+                        "TEAM EMAIL DOMAINS"]
+                    [:div.um-invite-label-2
+                      "Anyone who signs up with this email domain can view team boards."]
+                    [:div.team-list
+                      (for [team (:email-domains team-data)]
+                        [:div.email-domain.group
+                          [:span (str "@" (:domain team))]
+                          [:button.btn-reset
+                            {:on-click #(api/user-action (utils/link-for (:links team) "remove" "DELETE") nil)
+                             :title "Remove email domain team"}
+                            [:i.fa.fa-trash]]])]
+                    [:div.group
+                      [:input.left.um-invite-field.email
+                        {:name "um-domain-invite"
+                         :type "text"
+                         :autoCapitalize "none"
+                         :value (:domain um-domain-invite)
+                         :pattern "@?[a-z0-9.-]+\\.[a-z]{2,4}$"
+                         :on-change #(dis/dispatch! [:input [:um-domain-invite :domain] (.. % -target -value)])
+                         :placeholder "Domain, e.g. @amc.com"}]
+                      [:button.right.btn-reset.btn-solid.um-invite-send
+                        {:disabled (not valid-domain-email?)
+                         :on-click #(let [domain (:domain (:um-domain-invite ro-user-man))]
+                                      (if (utils/valid-domain? domain)
+                                        (dis/dispatch! [:add-email-domain-team])
+                                        (dis/dispatch! [:input [:add-email-domain-team-error] true])))}
+                       "ADD"]
+                      (when add-email-domain-team-error
+                        [:div
+                          (cond
+                            (and (= add-email-domain-team-error :domain-exists)
+                                 (:domain um-domain-invite))
+                            [:span.small-caps.red.mt1.left (str (:domain um-domain-invite) " was already added.")]
+                            :else
+                            [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]])])]]))
 
 (defcomponent team-management-wrapper [data owner]
   (render [_]

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -240,7 +240,7 @@
                        :value (:domain um-domain-invite)
                        :pattern "@?[a-z0-9.-]+\\.[a-z]{2,4}$"
                        :on-change #(dis/dispatch! [:input [:um-domain-invite :domain] (.. % -target -value)])
-                       :placeholder "Domain, e.g. @acme.com"}]
+                       :placeholder "Domain, e.g. @amc.com"}]
                     [:button.right.btn-reset.btn-solid.um-invite-send
                       {:disabled (not valid-domain-email?)
                        :on-click #(let [domain (:domain (:um-domain-invite ro-user-man))]

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -79,7 +79,7 @@
         [:div.action-result.mx-auto
           {:id "action-finished"
            :class (if (:last-action-success um-invite) "green" "red")}
-          (if (:last-action-success um-invite) "Action completed." "An error occurred, please retry.")])
+          (if (:last-action-success um-invite) "Successful!" "An error occurred, please retry.")])
       [:div.team-management.mx-auto.p3.mb4.group
         {:style {:margin-top (if (contains? um-invite :last-action-success) "0px" "22px")}}
         (if-not team-data

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -39,7 +39,7 @@
                              {:before-render (fn [s]
                                                (when (and (:auth-settings @dis/app-state)
                                                           (not (:teams-data-requested @dis/app-state)))
-                                                 (dis/dispatch! [:get-teams]))
+                                                 (dis/dispatch! [:teams-get]))
                                                (when (and (nil? (:user-type (:um-invite @(drv/get-ref s :team-management))))
                                                           (utils/valid-email? (:email (:um-invite @(drv/get-ref s :team-management)))))
                                                   (dis/dispatch! [:input [:um-invite :user-type] :viewer]))

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -114,11 +114,11 @@
                                           selected-slack-user (first (filter #(= (:slack-id %) selected-slack-id) slack-uninvited-users))]
                                       (when selected-slack-user
                                         (dis/dispatch! [:input [:um-invite :slack-user] selected-slack-user]))))
-                       :placeholder "Select a Slack user"}
+                       :placeholder "Select a Slack member"}
                        [:option
                          {:value ""
                           :key "slack-id-none"}
-                         "Select a Slack user"]
+                         "Select a Slack member"]
                        (for [s slack-uninvited-users]
                           [:option
                             {:key (str "slack-invite-" (:slack-id s))

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -149,6 +149,8 @@
               (when (:error um-invite)
                 [:div
                   (cond
+                    (string? (:error um-invite))
+                    [:span.small-caps.red.mt1.left (:error um-invite)]
                     (and (= (:error um-invite) :user-exists)
                          (:email um-invite))
                     [:span.small-caps.red.mt1.left (str (:email um-invite) " is already a user.")]

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -1,4 +1,11 @@
 (ns oc.web.components.team-management
+  "
+  Namespace for two components, `team-management-wrapper` and `team-management`.
+
+  The `team-management-wrapper` component manages the loading state, page layout and exiting action.
+
+  The `team-management` component manages user invites, security and Slack and email domains for teams.
+  "
   (:require [rum.core :as rum]
             [dommy.core :refer-macros (sel1)]
             [om.core :as om :include-macros true]
@@ -54,10 +61,16 @@
         valid-domain-email? (utils/valid-domain? (:domain um-domain-invite))
         team-id (:team-id org-data)
         team-data (get-in teams-data [team-id :data])]
+
     [:div.team-management.mx-auto.p3.my4.group
       (if-not team-data
+        ;; Still loading
         (rloading {:loading true})
+
+        ;; Render team management UI
         [:div
+
+          ;; Invite team members, mobile and web
           [:div.um-invite.group.mb3
             [:div.um-invite-label
               "TEAM MEMBERS"]
@@ -88,10 +101,14 @@
                     [:span.small-caps.red.mt1.left (str (:email um-invite) " is already a user.")]
                     :else
                     [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]]
+
+              ;; List of current team members, web only
               (when-not (responsive/is-mobile-size?)
                 [:div.mb3.um-invite.group
                   (when team-data
                     (users-list team-id (:users team-data) (:authors org-data)))])
+
+              ;; Slack team management, web only
               (when-not (responsive/is-mobile-size?)
                 [:div.mb3.um-invite.group
                   [:div.um-invite-label
@@ -143,6 +160,8 @@
                           [:span.small-caps.green.mt1.left "Bot successfully added."]
                           :else
                           [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]])
+              
+              ;; Email domains, web only
               (when-not (responsive/is-mobile-size?)
                 [:div.mb3.um-invite.group
                   [:div.um-invite-label
@@ -180,19 +199,7 @@
                                (:domain um-domain-invite))
                           [:span.small-caps.red.mt1.left (str (:domain um-domain-invite) " was already added.")]
                           :else
-                          [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]])
-          (comment
-            [:div.my2.um-byemail-container.group
-              [:div.group
-                [:span.left.ml1.um-byemail-anyone-span
-                  "Anyone who signs up with this email domain can view team boards."]]
-              [:div.mt2.um-byemail.group
-                [:span.left.um-byemail-at "@"]
-                [:input.left.um-byemail-email
-                  {:type "text"
-                   :name "um-byemail-email"
-                   :placeholder "your email domain without @"}]
-                [:button.left.um-byemail-save.btn-reset.btn-outline "SAVE"]]])])]))
+                          [:span.small-caps.red.mt1.left "An error occurred, please try again."])])]])])]))
 
 (defcomponent team-management-wrapper [data owner]
   (render [_]

--- a/src/oc/web/components/team_management.cljs
+++ b/src/oc/web/components/team_management.cljs
@@ -85,7 +85,7 @@
             [:div
               (when (jwt/team-has-bot? team-id)
                 [:div.invite-from
-                  "From: "
+                  "Invite from: "
                   [:span.ml2 "  "]
                   [:input
                     {:type "radio"

--- a/src/oc/web/components/ui/role_explainer_popover.cljs
+++ b/src/oc/web/components/ui/role_explainer_popover.cljs
@@ -1,19 +1,20 @@
-(ns oc.web.components.ui.team-disclaimer-popover
+(ns oc.web.components.ui.role-explainer-popover
+  "Modal dialog to explain the 2/3 access control roles available per user."
   (:require [rum.core :as rum]))
 
-(rum/defc team-disclaimer-popover < rum/static
+(rum/defc role-explainer-popover < rum/static
   [{:keys [hide-popover-cb hide-admin] :as data}]
   [:div.oc-popover-container-internal
     {:on-click #(hide-popover-cb)}
     [:button.close-button]
-    [:div.team-disclaimer-popover.oc-popover
+    [:div.role-explainer-popover.oc-popover
       {:style {:width (str (:width data) "px") :height (str (:height data) "px")}}
-      [:div.team-disclaimer-row
+      [:div.role-explainer-row
         [:span.title [:i.fa.fa-user] " View"] "- read only access to the dashboard"]
-      [:div.team-disclaimer-row
+      [:div.role-explainer-row
         [:span.title [:i.fa.fa-pencil] " Edit"] "- edit entries, add new entries, add and archive topics, share company updates"]
       (when-not (true? hide-admin)
-        [:div.team-disclaimer-row
+        [:div.role-explainer-row
           [:span.title [:i.fa.fa-gear] " Admin"] "- company settings, payments, manage team members"])
       [:div.center
         [:button.center.btn-reset.btn-solid.got-it-btn

--- a/src/oc/web/components/ui/user_type_picker.cljs
+++ b/src/oc/web/components/ui/user_type_picker.cljs
@@ -3,7 +3,7 @@
   (:require [rum.core :as rum]
             [dommy.core :as dommy :refer-macros (sel1)]
             [oc.web.lib.utils :as utils]            
-            [oc.web.components.ui.team-disclaimer-popover :refer (team-disclaimer-popover)]
+            [oc.web.components.ui.role-explainer-popover :refer (role-explainer-popover)]
             [oc.web.components.ui.popover :as popover :refer (add-popover-with-rum-component
                                                               hide-popover)]))
 
@@ -38,15 +38,15 @@
              :on-click #(click-cb :admin)}
             [:i.fa.fa-gear] " Admin"])]]))
 
-(defn show-team-disclaimer-popover [e & [hide-admin]]
+(defn show-role-explainer-popover [e & [hide-admin]]
   (.stopPropagation e)
-  (add-popover-with-rum-component team-disclaimer-popover {;:hide-popover-cb #(hide-popover nil "team-disclaimer-popover")
+  (add-popover-with-rum-component role-explainer-popover {;:hide-popover-cb #(hide-popover nil "role-explainer-popover")
                                                            :hide-admin hide-admin
                                                            :width 422
                                                            :height (if hide-admin 170 230)
                                                            :hide-on-click-out true
                                                            :z-index-popover 0
-                                                           :container-id "team-disclaimer-popover"}))
+                                                           :container-id "role-explainer-popover"}))
 
 (rum/defcs user-type-picker < (rum/local nil ::last-user-type)
   [s user-type enabled? did-select-cb show-admins?]
@@ -63,7 +63,7 @@
        :on-click #(do (reset! (::last-user-type s) :viewer) (did-select-cb :viewer))}
       (when (= user-type :viewer)
         [:span.user-type-disc.viewer
-          {:on-click #(show-team-disclaimer-popover %)}
+          {:on-click #(show-role-explainer-popover %)}
           "VIEW " [:i.fa.fa-question-circle]])
       [:i.fa.fa-user]]
     [:button.user-type-picker-btn.btn-reset.author
@@ -72,7 +72,7 @@
        :on-click #(do (reset! (::last-user-type s) :author) (did-select-cb :author))}
       (when (= user-type :author)
         [:span.user-type-disc.author
-          {:on-click #(show-team-disclaimer-popover %)}
+          {:on-click #(show-role-explainer-popover %)}
           "EDIT " [:i.fa.fa-question-circle]])
       [:i.fa.fa-pencil]]
     (when show-admins?
@@ -82,6 +82,6 @@
          :on-click #(do (reset! (::last-user-type s) :admin) (did-select-cb :admin))}
         (when (= user-type :admin)
           [:span.user-type-disc.admin
-            {:on-click #(show-team-disclaimer-popover %)}
+            {:on-click #(show-role-explainer-popover %)}
             "ADMIN " [:i.fa.fa-question-circle]])
       [:i.fa.fa-gear]])])

--- a/src/oc/web/components/users_list.cljs
+++ b/src/oc/web/components/users_list.cljs
@@ -6,7 +6,7 @@
             [oc.web.lib.jwt :as j]
             [oc.web.lib.utils :as utils]
             [oc.web.components.ui.small-loading :refer (small-loading)]
-            [oc.web.components.ui.user-type-picker :refer (user-type-dropdown show-team-disclaimer-popover)]))
+            [oc.web.components.ui.user-type-picker :refer (user-type-dropdown show-role-explainer-popover)]))
 
 (defn user-action [team-id user action method other-link-params & [payload]]
   (.tooltip (js/$ "[data-toggle=\"tooltip\"]") "hide")
@@ -79,7 +79,7 @@
       [:thead
         [:tr
           [:th.pointer
-            {:on-click #(show-team-disclaimer-popover %)}
+            {:on-click #(show-role-explainer-popover %)}
             "ACCESS "
             [:i.fa.fa-question-circle]]
           [:th "NAME"]

--- a/src/oc/web/components/users_list.cljs
+++ b/src/oc/web/components/users_list.cljs
@@ -55,7 +55,7 @@
                               (dis/dispatch! [:input [:um-invite] {:email (:email user)
                                                                    :user-type user-type
                                                                    :error nil}])
-                              (utils/after 100 #(dis/dispatch! [:invite-by-email])))}
+                              (utils/after 100 #(dis/dispatch! [:invite-user])))}
                 [:i.fa.fa-share]])
             ; if it has a delete link
             (when remove-user

--- a/src/oc/web/components/users_list.cljs
+++ b/src/oc/web/components/users_list.cljs
@@ -86,6 +86,6 @@
           [:th "STATUS"]
           [:th {:style {:text-align "center"}} "ACTIONS"]]]
       [:tbody
-        (for [user (filter :user-id users) ; filter Slack only users
+        (for [user users
               :let [author (some #(when (= (:user-id %) (:user-id user)) %) org-authors)]]
           (rum/with-key (user-row team-id user author) (str "user-tr-" team-id "-" (:user-id user))))]]])

--- a/src/oc/web/components/users_list.cljs
+++ b/src/oc/web/components/users_list.cljs
@@ -53,6 +53,7 @@
                  :title "RESEND INVITE"
                  :on-click (fn []
                               (dis/dispatch! [:input [:um-invite] {:email (:email user)
+                                                                   :invite-from "email"
                                                                    :user-type user-type
                                                                    :error nil}])
                               (utils/after 100 #(dis/dispatch! [:invite-user])))}

--- a/src/oc/web/components/users_list.cljs
+++ b/src/oc/web/components/users_list.cljs
@@ -87,6 +87,6 @@
           [:th "STATUS"]
           [:th {:style {:text-align "center"}} "ACTIONS"]]]
       [:tbody
-        (for [user users
+        (for [user (sort #(compare (utils/name-or-email %1) (utils/name-or-email %2)) users)
               :let [author (some #(when (= (:user-id %) (:user-id user)) %) org-authors)]]
           (rum/with-key (user-row team-id user author) (str "user-tr-" team-id "-" (:user-id user))))]]])

--- a/src/oc/web/components/users_list.cljs
+++ b/src/oc/web/components/users_list.cljs
@@ -86,6 +86,6 @@
           [:th "STATUS"]
           [:th {:style {:text-align "center"}} "ACTIONS"]]]
       [:tbody
-        (for [user users
+        (for [user (filter :user-id users) ; filter Slack only users
               :let [author (some #(when (= (:user-id %) (:user-id user)) %) org-authors)]]
           (rum/with-key (user-row team-id user author) (str "user-tr-" team-id "-" (:user-id user))))]]])

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -58,6 +58,9 @@
 (defn team-data-key [team-id]
   [:teams-data team-id :data])
 
+(defn team-roster-key [team-id]
+  [:teams-data team-id :roster])
+
 (defn team-channels-key [team-id]
   [:teams-data team-id :channels])
 
@@ -96,6 +99,10 @@
                           (fn [base org-data]
                             (when org-data
                               (get-in base (team-data-key (:team-id org-data)))))]
+   :team-roster         [[:base :org-data]
+                          (fn [base org-data]
+                            (when org-data
+                              (get-in base (team-roster-key (:team-id org-data)))))]
    :team-channels       [[:base :org-data]
                           (fn [base org-data]
                             (when org-data
@@ -226,6 +233,11 @@
   ([team-id] (team-data team-id @app-state))
   ([team-id data] (get-in data (team-data-key team-id))))
 
+(defn team-roster
+  ([] (team-roster (:team-id (org-data))))
+  ([team-id] (team-roster team-id @app-state))
+  ([team-id data] (get-in data (team-roster-key team-id))))
+
 (defn team-channels
   ([] (team-channels (:team-id (org-data))))
   ([team-id] (team-channels team-id @app-state))
@@ -251,6 +263,9 @@
 (defn print-team-data []
   (js/console.log (get-in @app-state (team-data-key (:team-id (org-data))))))
 
+(defn print-team-roster []
+  (js/console.log (get-in @app-state (team-roster-key (:team-id (org-data))))))
+
 (defn print-updates-list-data []
   (js/console.log (get-in @app-state (updates-list-key (router/current-org-slug)))))
 
@@ -266,6 +281,7 @@
 (set! (.-OCWebPrintAppState js/window) print-app-state)
 (set! (.-OCWebPrintOrgData js/window) print-org-data)
 (set! (.-OCWebPrintTeamData js/window) print-team-data)
+(set! (.-OCWebPrintTeamRoster js/window) print-team-roster)
 (set! (.-OCWebPrintUpdatesListData js/window) print-updates-list-data)
 (set! (.-OCWebPrintUpdateData js/window) print-update-data)
 (set! (.-OCWebPrintBoardData js/window) print-board-data)

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -856,8 +856,6 @@
         first-name (:first-name user)
         last-name (:last-name user)]
     (cond
-      (not (empty? user-name))
-      user-name
       (and (not (empty? first-name))
            (not (empty? last-name)))
       (str first-name " " last-name)
@@ -865,6 +863,8 @@
       first-name
       (not (empty? last-name))
       last-name
+      (not (empty? user-name))
+      user-name
       :else
       (:email user))))
 


### PR DESCRIPTION
card: https://trello.com/c/LNR4dpA3

What does this branch do:
- add Slack invite grouped by Slack organization
- add team logo to the newly created org

To test:
- signup with Slack
- create a new organization
- check that the new org has the name and the logo of you Slack org
- go to Team Management
- add the bot to your Slack team
- select Slack under Invite and send the invite for one of you Slack coworker
- to check the message signin to that slack account and check the messages from opencompany bot
- add another Slack org to the team
- add the bot to this second Slack team
- open the Slack invite and check that the users are grouped by Slack org
- invite another user
- click resend invite for one of the 2 users you just invited
- the user should receive the invitation by email the second time
- check that the email has the company name and logo (that was the logo of the first Slack org you used to signup)
- merge