### PR TITLE
Comments

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -68,6 +68,7 @@ var OCWebConfigLogLevel = function(){};
 var OCWebPrintUpdatesListData = function(){};
 var OCWebPrintUpdateData = function(){};
 var OCWebPrintRouterPath = function(){};
+var OCWebPrintTopicEntriesData = function(){};
 // Filestack
 var filestack = {};
 filestack.init = function(){};

--- a/resources/public/lib/print_ascii.js
+++ b/resources/public/lib/print_ascii.js
@@ -7,6 +7,7 @@ OCWebPrintTeamData(): to print the current team data,
 OCWebPrintTeamRoster(): to print the current team roster of users,
 OCWebPrintBoardData(): to print the current board data,
 OCWebPrintEntriesData(): to print all the entries loaded,
+OCWebPrintTopicEntriesData(): to print all the entries of the currently selected topic,
 OCWebPrintJWTContents(): to print the content of the JWT.
 OCWebHelp(): print this help,
 OCWebPrintAsciiArt(): print beautiful ASCII art,

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -30,6 +30,7 @@ div.comments {
     overflow-y: auto;
     max-height: 300px;
     padding: 10px;
+    transition: 230ms;
 
     div.comment {
       margin: 10px 0;

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -6,6 +6,8 @@ div.comments {
   margin-left: 20px;
   margin-top: 20px;
   float: right;
+  max-height: 300px;
+  overflow: scroll;
 
   div.comment {
     margin: 10px 0;
@@ -53,6 +55,14 @@ div.comments {
     padding: 0.5rem;
     transition: 230ms;
 
+    &.expanded{
+      div.add-comment-internal {
+        textarea.add-comment {
+          height: 80px;
+        }
+      }
+    }
+
     div.add-comment-internal{
       textarea.add-comment {
         resize: none;
@@ -64,10 +74,6 @@ div.comments {
         height: 30px;
         font-size: 14px;
         transition: 230ms;
-
-        &.open{
-          height: 80px;
-        }
 
         @include placeholder {
           color: rgba(78,90,107,0.6);

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -1,7 +1,87 @@
+$comment_avatar_size: 23;
+
 div.comments {
   width: 300px;
   padding: 10px;
   margin-left: 20px;
   margin-top: 20px;
   float: right;
+
+  div.comment {
+    margin: 10px 0;
+
+    div.comment-header {
+      div.comment-avatar {
+        width: #{$comment_avatar_size}px;
+        height: #{$comment_avatar_size}px;
+        background-position: center;
+        background-size: #{$comment_avatar_size}px #{$comment_avatar_size}px;
+        border-radius: #{$comment_avatar_size / 2}px;
+      }
+      div.comment-author {
+        margin-left: 20px;
+        font-size: 14px;
+        color: $oc_gray_5;
+        font-weight: 700;
+      }
+
+      div.comment-timestamp {
+        margin-left: 5px;
+        margin-top: 4px;
+        font-size: 11px;
+        color: rgba(78,90,107,0.6);
+      }
+    }
+
+    div.comment-body {
+      font-size: 13px;
+      color: rgba(78,90,107,0.8);
+      font-weight: 300;
+      margin-left: #{$comment-avatar-size + 20}px;
+    }
+
+    div.comment-footer {
+      color: rgba(78,90,107,0.4);
+      font-size: 11px;
+    }
+  }
+
+  div.add-comment-box {
+    background-color: white;
+    border-radius: 4px;
+    border: 1px solid rgba(78,90,107,0.3);
+    padding: 0.5rem;
+    transition: 230ms;
+
+    div.add-comment-internal{
+      textarea.add-comment {
+        resize: none;
+        width: 100%;
+        border: none;
+        outline: none;
+        background-color: transparent;
+        color: $oc_gray_5;
+        height: 30px;
+        font-size: 14px;
+        transition: 230ms;
+
+        &.open{
+          height: 80px;
+        }
+
+        @include placeholder {
+          color: rgba(78,90,107,0.6);
+        }
+      }
+
+      div.add-comment-footer {
+        transition: 230ms;
+        div.add-comment-counter {
+          float: right;
+          margin-right: 5px;
+          margin-top: 5px;
+        }
+      }
+    }
+  }
 }

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -80,6 +80,7 @@ div.comments {
           float: right;
           margin-right: 5px;
           margin-top: 5px;
+          color: rgba(78,90,107,0.6);
         }
       }
     }

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -1,0 +1,7 @@
+div.comments {
+  width: 300px;
+  padding: 10px;
+  margin-left: 20px;
+  margin-top: 20px;
+  float: right;
+}

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -26,7 +26,8 @@ div.comments {
   }
 
   div.comments-internal {
-    overflow: scroll;
+    overflow-x: hidden;
+    overflow-y: auto;
     max-height: 300px;
     padding: 10px;
 

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -2,91 +2,113 @@ $comment_avatar_size: 23;
 
 div.comments {
   width: 300px;
-  padding: 10px;
   margin-left: 20px;
   margin-top: 20px;
   float: right;
   max-height: 300px;
-  overflow: scroll;
+  overflow: hidden;
+  position: relative;
 
-  div.comment {
-    margin: 10px 0;
-
-    div.comment-header {
-      div.comment-avatar {
-        width: #{$comment_avatar_size}px;
-        height: #{$comment_avatar_size}px;
-        background-position: center;
-        background-size: #{$comment_avatar_size}px #{$comment_avatar_size}px;
-        border-radius: #{$comment_avatar_size / 2}px;
-      }
-      div.comment-author {
-        margin-left: 20px;
-        font-size: 14px;
-        color: $oc_gray_5;
-        font-weight: 700;
-      }
-
-      div.comment-timestamp {
-        margin-left: 5px;
-        margin-top: 4px;
-        font-size: 11px;
-        color: rgba(78,90,107,0.6);
-      }
-    }
-
-    p.comment-body {
-      font-size: 13px;
-      color: rgba(78,90,107,0.8);
-      font-weight: 300;
-      margin: 0 0 0 #{$comment-avatar-size + 20}px;
-    }
-
-    div.comment-footer {
-      color: rgba(78,90,107,0.4);
-      font-size: 11px;
-    }
+  div.top-gradient {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 90%;
+    height: 40px;
+    pointer-events: none;
+    background: -moz-linear-gradient(top,  rgba(248, 248, 248, 1) 0%, rgba(255, 255, 255,0) 100%); /* FF3.6+ */
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255, 255, 255,0)), color-stop(100%,rgba(0,0,0,1))); /* Chrome,Safari4+ */
+    background: -webkit-linear-gradient(top,  rgba(248, 248, 248, 1) 0%,rgba(255, 255, 255,0) 100%); /* Chrome10+,Safari5.1+ */
+    background: -o-linear-gradient(top,  rgba(248, 248, 248, 1) 0%,rgba(255, 255, 255,0) 100%); /* Opera 11.10+ */
+    background: -ms-linear-gradient(top,  rgba(248, 248, 248, 1) 0%,rgba(255, 255, 255,0) 100%); /* IE10+ */
+    background: linear-gradient(to bottom,  rgba(248, 248, 248, 1) 0%,rgba(255, 255, 255,0) 100%); /* W3C */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f8f8f8f1', endColorstr='#FFFFFF',GradientType=0 ); /* IE6-9 */
   }
 
-  div.add-comment-box {
-    background-color: white;
-    border-radius: 4px;
-    border: 1px solid rgba(78,90,107,0.3);
-    padding: 0.5rem;
-    transition: 230ms;
+  div.comments-internal {
+    overflow: scroll;
+    max-height: 300px;
+    padding: 10px;
 
-    &.expanded{
-      div.add-comment-internal {
-        textarea.add-comment {
-          height: 80px;
+    div.comment {
+      margin: 10px 0;
+
+      div.comment-header {
+        div.comment-avatar {
+          width: #{$comment_avatar_size}px;
+          height: #{$comment_avatar_size}px;
+          background-position: center;
+          background-size: #{$comment_avatar_size}px #{$comment_avatar_size}px;
+          border-radius: #{$comment_avatar_size / 2}px;
         }
+        div.comment-author {
+          margin-left: 20px;
+          font-size: 14px;
+          color: $oc_gray_5;
+          font-weight: 700;
+        }
+
+        div.comment-timestamp {
+          margin-left: 5px;
+          margin-top: 4px;
+          font-size: 11px;
+          color: rgba(78,90,107,0.6);
+        }
+      }
+
+      p.comment-body {
+        font-size: 13px;
+        color: rgba(78,90,107,0.8);
+        font-weight: 300;
+        margin: 0 0 0 #{$comment-avatar-size + 20}px;
+      }
+
+      div.comment-footer {
+        color: rgba(78,90,107,0.4);
+        font-size: 11px;
       }
     }
 
-    div.add-comment-internal{
-      textarea.add-comment {
-        resize: none;
-        width: 100%;
-        border: none;
-        outline: none;
-        background-color: transparent;
-        color: $oc_gray_5;
-        height: 30px;
-        font-size: 14px;
-        transition: 230ms;
+    div.add-comment-box {
+      background-color: white;
+      border-radius: 4px;
+      border: 1px solid rgba(78,90,107,0.3);
+      padding: 0.5rem;
+      transition: 230ms;
 
-        @include placeholder {
-          color: rgba(78,90,107,0.6);
+      &.expanded{
+        div.add-comment-internal {
+          textarea.add-comment {
+            height: 80px;
+          }
         }
       }
 
-      div.add-comment-footer {
-        transition: 230ms;
-        div.add-comment-counter {
-          float: right;
-          margin-right: 5px;
-          margin-top: 5px;
-          color: rgba(78,90,107,0.6);
+      div.add-comment-internal{
+        textarea.add-comment {
+          resize: none;
+          width: 100%;
+          border: none;
+          outline: none;
+          background-color: transparent;
+          color: $oc_gray_5;
+          height: 30px;
+          font-size: 14px;
+          transition: 230ms;
+
+          @include placeholder {
+            color: rgba(78,90,107,0.6);
+          }
+        }
+
+        div.add-comment-footer {
+          transition: 230ms;
+          div.add-comment-counter {
+            float: right;
+            margin-right: 5px;
+            margin-top: 5px;
+            color: rgba(78,90,107,0.6);
+          }
         }
       }
     }

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -35,11 +35,11 @@ div.comments {
       }
     }
 
-    div.comment-body {
+    p.comment-body {
       font-size: 13px;
       color: rgba(78,90,107,0.8);
       font-weight: 300;
-      margin-left: #{$comment-avatar-size + 20}px;
+      margin: 0 0 0 #{$comment-avatar-size + 20}px;
     }
 
     div.comment-footer {

--- a/scss/partials/_topic.scss
+++ b/scss/partials/_topic.scss
@@ -189,7 +189,8 @@ div.topic {
 
       &.topic-comments-button {
         width: 67px;
-        margin-right: 5px;
+        margin-left: 5px;
+        opacity: 0.8;
         i.fa {
           margin-right: 5px;
         }

--- a/scss/partials/_topic.scss
+++ b/scss/partials/_topic.scss
@@ -191,8 +191,8 @@ div.topic {
         width: 67px;
         margin-left: 5px;
         opacity: 0.8;
-        i.fa {
-          margin-right: 5px;
+        span.counter {
+          margin-left: 5px;
         }
       }
     }

--- a/scss/partials/_topic.scss
+++ b/scss/partials/_topic.scss
@@ -174,7 +174,7 @@ div.topic {
 
     button.top-right-button {
       width: 30px;
-      height: 20px;
+      height: 25px;
       float: right;
       opacity: 0;
       transition: 230ms;
@@ -185,6 +185,14 @@ div.topic {
 
       &:hover {
         color: rgba(78,90,107,1);
+      }
+
+      &.topic-comments-button {
+        width: 67px;
+        margin-right: 5px;
+        i.fa {
+          margin-right: 5px;
+        }
       }
     }
 
@@ -321,6 +329,10 @@ div.topic {
         float: left;
         @include big_web(){
           width: 85%;
+
+          &.has-comments {
+            width: 75%;
+          }
         }
 
         @include mobile(){

--- a/scss/partials/_topic_view.scss
+++ b/scss/partials/_topic_view.scss
@@ -1,6 +1,5 @@
 div.topic-view-container{
-  overflow-x: hidden;
-  overflow-y: scroll;
+  overflow: hidden;
   float: right;
   margin: 0 0 0 50px;
 

--- a/scss/public/css/app.main.scss
+++ b/scss/public/css/app.main.scss
@@ -92,3 +92,4 @@
 @import "partials/_topic_attachments";
 @import "partials/_orgs_dropdown";
 @import "partials/_collect_chart_popover";
+@import "partials/_comments";

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -920,3 +920,9 @@
 (defmethod dispatcher/action :user-profile-update/failed
   [db [_]]
   (assoc db :edit-user-profile-failed true))
+
+(defmethod dispatcher/action :comments-show
+  [db [_ topic-slug entry-uuid]]
+  (if (nil? topic-slug)
+    (dissoc db :comments-open)
+    (assoc db :comments-open {:topic-slug topic-slug :entry-uuid entry-uuid})))

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -927,3 +927,17 @@
            (= (:entry-uuid (:comments-open db)) entry-uuid))
     (dissoc db :comments-open)
     (assoc db :comments-open {:topic-slug topic-slug :entry-uuid entry-uuid})))
+
+(defmethod dispatcher/action :comments-get
+  [db [_ entry-uuid]]
+  (js/console.log "comments-get" entry-uuid)
+  (api/get-comments entry-uuid)
+  (let [org-slug (router/current-org-slug)
+        board-slug (router/current-board-slug)
+        topic-slug (router/current-topic-slug)]
+    (assoc-in db (conj (dispatcher/comments-key org-slug board-slug topic-slug entry-uuid) :loading) true)))
+
+(defmethod dispatcher/action :comments-get/finish
+  [db [_ {:keys [success error body entry-uuid]}]]
+  (let [comments-key (dispatcher/comments-key (router/current-org-slug) (router/current-board-slug) (router/current-topic-slug) entry-uuid)]
+    (assoc-in db comments-key body)))

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -923,6 +923,7 @@
 
 (defmethod dispatcher/action :comments-show
   [db [_ topic-slug entry-uuid]]
-  (if (nil? topic-slug)
+  (if (and (= (:topic-slug (:comments-open db)) topic-slug)
+           (= (:entry-uuid (:comments-open db)) entry-uuid))
     (dissoc db :comments-open)
     (assoc db :comments-open {:topic-slug topic-slug :entry-uuid entry-uuid})))

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -815,10 +815,11 @@
 (defn add-comment [entry-uuid comment-body]
   (when (and entry-uuid comment-body)
     (let [entry-data (dispatcher/entry entry-uuid)
-          add-comment-link (utils/link-for (:links entry-data) "comment" "POST")]
+          add-comment-link (utils/link-for (:links entry-data) "comment" "POST")
+          json-data (cljs->json {:body comment-body})]
       (interaction-post (relative-href (:href add-comment-link))
         {:headers (headers-for-link add-comment-link)
-         :body comment-body}
+         :json-params json-data}
         (fn [{:keys [status success body]}]
           (dispatcher/dispatch! [:comment-add/finish {:success success
                                                       :error (when-not success body)

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -24,6 +24,11 @@
 
 (def ^:private interaction-endpoint ls/interaction-server-domain)
 
+(defn- relative-href [href]
+  (if (s/starts-with? href "http")
+    (str "/" (s/join "/" (subvec (s/split href #"/") 3)))
+    href))
+
 (defn- content-type [type]
   (str "application/vnd.open-company." type ".v1+json;charset=UTF-8"))
 
@@ -61,7 +66,7 @@
 
 (defn refresh-jwt [refresh-link]
   (let [refresh-url (if (map? refresh-link)
-                      (str ls/auth-server-domain (:href refresh-link))
+                      (str ls/auth-server-domain (relative-href (:href refresh-link)))
                       refresh-link)
         headers (if (map? refresh-link) {:headers (headers-for-link refresh-link)} {})]
   (http/get refresh-url (complete-params headers))))
@@ -183,14 +188,14 @@
 
 (defn get-org [org-data]
   (when-let [org-link (or (utils/link-for (:links org-data) "item" "GET") (utils/link-for (:links org-data) "self" "GET"))]
-    (api-get (:href org-link)
+    (api-get (relative-href (:href org-link))
       {:headers (headers-for-link org-link)}
       (fn [{:keys [status body success]}]
         (dispatcher/dispatch! [:org (json->cljs body)])))))
 
 (defn get-board [board-data]
   (when-let [board-link (or (utils/link-for (:links board-data) "item" "GET") (utils/link-for (:links board-data) "self" "GET"))]
-    (api-get (:href board-link)
+    (api-get (relative-href (:href board-link))
       {:headers (headers-for-link board-link)}
       (fn [{:keys [status body success]}]
         (dispatcher/dispatch! [:board (json->cljs body)])))))
@@ -201,7 +206,7 @@
           json-data (cljs->json board-data)
           links (:links (dispatcher/board-data))
           board-patch-link (utils/link-for links "partial-update")]
-      (api-patch (:href board-patch-link)
+      (api-patch (relative-href (:href board-patch-link))
         {:json-params json-data
          :headers (headers-for-link board-patch-link)}
         (fn [{:keys [success body status]}]
@@ -215,7 +220,7 @@
           json-data (cljs->json org-data)
           links (:links (dispatcher/org-data))
           org-patch-link (utils/link-for links "partial-update")]
-      (api-patch (:href org-patch-link)
+      (api-patch (relative-href (:href org-patch-link))
         {:json-params json-data
          :headers (headers-for-link org-patch-link)}
         (fn [{:keys [success body status]}]
@@ -256,7 +261,7 @@
           cleaned-topic-data (apply dissoc topic-data topic-private-keys)
           json-data (cljs->json cleaned-topic-data)
           topic-link (utils/link-for links "create" "POST")]
-      (api-post (:href topic-link)
+      (api-post (relative-href (:href topic-link))
         { :json-params json-data
           :headers (headers-for-link topic-link)}
         (fn [{:keys [body success headers]}]
@@ -265,7 +270,7 @@
 
 (defn load-entries [topic entries-link]
   (when (and topic entries-link)
-    (api-get (:href entries-link)
+    (api-get (relative-href (:href entries-link))
       {:headers (headers-for-link entries-link)}
       (fn [{:keys [status body success]}]
         (dispatcher/dispatch! [:entries-loaded {:topic topic :entries (if success (json->cljs body) {})}])))))
@@ -277,7 +282,7 @@
     (let [partial-update-link (utils/link-for (:links topic-data) "partial-update" "PATCH")
           cleaned-topic-data (apply dissoc topic-data topic-private-keys)
           json-data (cljs->json cleaned-topic-data)]
-      (api-patch (:href partial-update-link)
+      (api-patch (relative-href (:href partial-update-link))
         { :json-params json-data
           :headers (headers-for-link partial-update-link)}
         (fn [{:keys [success body]}]
@@ -294,7 +299,7 @@
                      (keyword topic-name) new-topic}
                     {:topics topics})
           json-data (cljs->json payload)]
-      (api-patch (:href board-patch-link)
+      (api-patch (relative-href (:href board-patch-link))
         {:json-params json-data
          :headers (headers-for-link board-patch-link)}
         (fn [{:keys [success body status]}]
@@ -317,7 +322,7 @@
         links (:links board-data)
         add-topic-link (utils/link-for links "new" "GET")]
     (when add-topic-link
-      (api-get (:href add-topic-link)
+      (api-get (relative-href (:href add-topic-link))
         { :headers (headers-for-link add-topic-link)}
         (fn [{:keys [success body]}]
           (let [fixed-body (if body (json->cljs body) {})]
@@ -328,7 +333,7 @@
         share-link (utils/link-for (:links org-data) "create" "POST" {:accept "application/vnd.open-company.update.v1+json"})
         json-data  (merge update-data {:title (:su-title @dispatcher/app-state)
                                        :entries (vec (map #(dissoc % :board-slug) (:dashboard-selected-topics @dispatcher/app-state)))})]
-    (api-post (:href share-link)
+    (api-post (relative-href (:href share-link))
               {:json-params (cljs->json json-data)
                :headers (headers-for-link share-link)}
       (fn [{:keys [success body]}]
@@ -342,7 +347,7 @@
         links (:links org-data)
         su-link (utils/link-for links "collection" "GET")]
     (when su-link
-      (api-get (:href su-link)
+      (api-get (relative-href (:href su-link))
         {:headers (headers-for-link su-link)}
         (fn [{:keys [success body]}]
           (let [fixed-body (if success (json->cljs body) {})]
@@ -352,7 +357,7 @@
   ([update-data load-org-data]
     (when update-data
       (let [update-link (utils/link-for (:links update-data) "self")]
-        (api-get (:href update-link)
+        (api-get (relative-href (:href update-link))
           {:headers (headers-for-link update-link)}
           (fn [{:keys [success body] :as response}]
             (let [fixed-body (if success (json->cljs body) {})
@@ -384,7 +389,7 @@
   (when (and email pswd)
     (let [email-links (:links (:auth-settings @dispatcher/app-state))
           auth-url (utils/link-for email-links "authenticate" "GET" {:auth-source "email"})]
-      (auth-get (:href auth-url)
+      (auth-get (relative-href (:href auth-url))
         {:basic-auth {
           :username email
           :password pswd}
@@ -402,7 +407,7 @@
   (when token
     (let [token-links (:links (:auth-settings @dispatcher/app-state))
           auth-url (utils/link-for token-links "authenticate" "GET" {:auth-source "email"})]
-      (auth-get (:href auth-url)
+      (auth-get (relative-href (:href auth-url))
         {:headers (merge (headers-for-link auth-url)
                    {; required by Chrome
                     "Access-Control-Allow-Headers" "Content-Type, Authorization"
@@ -423,7 +428,7 @@
   (when (and first-name last-name email pswd)
     (let [email-links (:links (:auth-settings @dispatcher/app-state))
           auth-url (utils/link-for email-links "create" "POST" {:auth-source "email"})]
-      (auth-post (:href auth-url)
+      (auth-post (relative-href (:href auth-url))
         {:json-params {:first-name first-name
                        :last-name last-name
                        :email email
@@ -436,7 +441,7 @@
 
 (defn get-teams []
   (let [enumerate-link (utils/link-for (:links (:auth-settings @dispatcher/app-state)) "collection" "GET")]
-    (auth-get (:href enumerate-link)
+    (auth-get (relative-href (:href enumerate-link))
       {:headers (headers-for-link enumerate-link)}
       (fn [{:keys [success body status]}]
         (let [fixed-body (if success (json->cljs body) {})]
@@ -449,7 +454,7 @@
 
 (defn get-team [team-link]
   (when team-link
-    (auth-get (:href team-link)
+    (auth-get (relative-href (:href team-link))
       {:headers (headers-for-link team-link)}
       (fn [{:keys [success body status]}]
         (let [fixed-body (if success (json->cljs body) {})]
@@ -463,7 +468,7 @@
     (let [team-data (dispatcher/team-data team-id)
           enumerate-link (utils/link-for (:links team-data) "channels" "GET")]
       (when enumerate-link
-        (auth-get (:href enumerate-link)
+        (auth-get (relative-href (:href enumerate-link))
           {:headers (headers-for-link enumerate-link)}
           (fn [{:keys [success body status]}]
             (let [fixed-body (if success (json->cljs body) {})]
@@ -482,7 +487,7 @@
           with-payload (if payload
                           (assoc headers :json-params payload)
                           headers)]
-      (auth-req (:href action-link)
+      (auth-req (relative-href (:href action-link))
         with-payload
         (fn [{:keys [status success body]}]
           (dispatcher/dispatch! [:user-action/complete]))))))
@@ -490,7 +495,7 @@
 (defn confirm-invitation [token]
   (let [auth-link (utils/link-for (:links (:auth-settings @dispatcher/app-state)) "authenticate" "GET" {:auth-source "email"})]
     (when (and token auth-link)
-      (auth-get (:href auth-link)
+      (auth-get (relative-href (:href auth-link))
         {:headers (merge (headers-for-link auth-link)
                          {; required by Chrome
                           "Access-Control-Allow-Headers" "Content-Type, Authorization"
@@ -504,7 +509,7 @@
 (defn collect-name-password [firstname lastname pswd]
   (let [update-link (utils/link-for (:links (:current-user-data @dispatcher/app-state)) "partial-update" "PATCH")]
     (when (and (or firstname lastname) pswd update-link)
-      (auth-patch (:href update-link)
+      (auth-patch (relative-href (:href update-link))
         {:json-params {
           :first-name firstname
           :last-name lastname
@@ -519,7 +524,7 @@
 (defn collect-password [pswd]
   (let [update-link (utils/link-for (:links (:current-user-data @dispatcher/app-state)) "partial-update" "PATCH")]
     (when (and pswd update-link)
-      (auth-patch (:href update-link)
+      (auth-patch (relative-href (:href update-link))
         {:json-params {
           :password pswd}
          :headers (headers-for-link update-link)}
@@ -533,14 +538,14 @@
     (let [links (:links entry-data)
           delete-link (utils/link-for links "delete")]
       (when delete-link
-        (api-delete (:href delete-link)
+        (api-delete (relative-href (:href delete-link))
           {:headers (headers-for-link delete-link)}
           (fn [_]
             (dispatcher/dispatch! [:entry-delete/success should-redirect-to-board])))))))
 
 (defn get-current-user [auth-links]
   (when-let [user-link (utils/link-for (:links auth-links) "user" "GET")]
-    (auth-get (:href user-link)
+    (auth-get (relative-href (:href user-link))
       {:headers (headers-for-link user-link)}
       (fn [{:keys [status body success]}]
         (dispatcher/dispatch! [:user-data (json->cljs body)])))))
@@ -549,7 +554,7 @@
   (when (and (:links old-user-data)
              (map? new-user-data))
     (let [user-update-link (utils/link-for (:links old-user-data) "partial-update" "PATCH")]
-      (auth-patch (:href user-update-link)
+      (auth-patch (relative-href (:href user-update-link))
         {:headers (headers-for-link user-update-link)
          :json-params (cljs->json (dissoc new-user-data :links :updated-at :created-at))}
          (fn [{:keys [status body success]}]
@@ -570,7 +575,7 @@
   (when domain
     (let [team-data (dispatcher/team-data)
           add-domain-team-link (utils/link-for (:links team-data) "add" "POST" {:content-type "application/vnd.open-company.team.email-domain.v1"})]
-      (auth-post (:href add-domain-team-link)
+      (auth-post (relative-href (:href add-domain-team-link))
         {:headers (headers-for-link add-domain-team-link)
          :body domain}
         (fn [{:keys [status body success]}]
@@ -578,7 +583,7 @@
 
 (defn refresh-slack-user []
   (let [refresh-url (utils/link-for (:links (:auth-settings @dispatcher/app-state)) "refresh")]
-    (auth-get (:href refresh-url)
+    (auth-get (relative-href (:href refresh-url))
       {:headers (headers-for-link refresh-url)}
       (fn [{:keys [status body success]}]
         (if success
@@ -590,7 +595,7 @@
 (defn patch-team [team-id new-team-data redirect-url]
   (when-let* [team-data (dispatcher/team-data team-id)
               team-patch (utils/link-for (:links team-data) "partial-update")]
-    (auth-patch (:href team-patch)
+    (auth-patch (relative-href (:href team-patch))
       {:headers (headers-for-link team-patch)
        :json-params (cljs->json new-team-data)}
       (fn [{:keys [success body status]}]
@@ -606,7 +611,7 @@
                     (assoc org-data :logo-url logo-url)
                     org-data)]
     (when (and org-name create-org-link)
-      (api-post (:href create-org-link)
+      (api-post (relative-href (:href create-org-link))
         {:headers (headers-for-link create-org-link)
          :json-params (cljs->json with-logo)}
         (fn [{:keys [success status body]}]
@@ -627,7 +632,7 @@
 (defn create-board [board-name]
   (let [create-link (utils/link-for (:links (dispatcher/org-data)) "create")]
     (when (and board-name create-link)
-      (api-post (:href create-link)
+      (api-post (relative-href (:href create-link))
         {:headers (headers-for-link create-link)
          :json-params (cljs->json {:name board-name})}
         (fn [{:keys [success status body]}]
@@ -640,7 +645,7 @@
   Refresh the user list and the org-data when finished."
   [user-id]
   (when-let [add-author-link (utils/link-for (:links (dispatcher/org-data)) "add")]
-    (api-post (:href add-author-link)
+    (api-post (relative-href (:href add-author-link))
       {:headers (headers-for-link add-author-link)
        :body user-id}
       (fn [{:keys [status success body]}]
@@ -653,7 +658,7 @@
   [user-author]
   (let [remove-author-link (utils/link-for (:links user-author) "remove")]
     (when remove-author-link
-      (api-delete (:href remove-author-link)
+      (api-delete (relative-href (:href remove-author-link))
         {:headers (headers-for-link remove-author-link)}
         (fn [{:keys [status success body]}]
           (utils/after 1 #(get-org (dispatcher/org-data))))))))
@@ -677,7 +682,7 @@
                               (assoc json-params :email invited-user))
           with-company-name (merge with-invited-user {:org-name (:name org-data)
                                                       :logo-url (:logo-url org-data)})]
-      (auth-post (:href invitation-link)
+      (auth-post (relative-href (:href invitation-link))
         {:json-params (cljs->json with-company-name)
          :headers (headers-for-link invitation-link)}
         (fn [{:keys [success body status]}]
@@ -709,7 +714,7 @@
           remove-author?     (= new-user-type :viewer)]
       ;; Add an admin call
       (when (and add-admin? add-admin-link)
-        (auth-put (:href add-admin-link)
+        (auth-put (relative-href (:href add-admin-link))
           {:headers (headers-for-link add-admin-link)}
           (fn [{:keys [status success body]}]
             (if success
@@ -717,7 +722,7 @@
               (dispatcher/dispatch! [:invite-user/failed])))))
       ;; Remove admin call
       (when (and remove-admin? remove-admin-link)
-        (auth-delete (:href remove-admin-link)
+        (auth-delete (relative-href (:href remove-admin-link))
           {:headers (headers-for-link remove-admin-link)}
           (fn [{:keys [status success body]}]
             (if success
@@ -735,7 +740,7 @@
   [topic topic-data]
   (when (and topic topic-data)
     (when-let [archive-link (utils/link-for (:links topic-data) "archive")]
-      (api-delete (:href archive-link)
+      (api-delete (relative-href (:href archive-link))
         {:headers (headers-for-link archive-link)}
         (fn [{:keys [status success body] :as response}]
           (dispatcher/dispatch! [:topic-archive/success]))))))
@@ -748,7 +753,7 @@
                                         "application/vnd.open-company.board.viewer.v1"
                                         "application/vnd.open-company.board.author.v1")}
           add-link (utils/link-for (:links board-data) "add" "POST" content-type)]
-      (api-post (:href add-link)
+      (api-post (relative-href (:href add-link))
         {:headers (headers-for-link add-link)
          :body user-id}
         (fn [{:keys [status success body]}]
@@ -767,7 +772,7 @@
           with-params (if params
                         (assoc headers :json-params (cljs->json params))
                         headers)]
-      (api-req (:href action-link)
+      (api-req (relative-href (:href action-link))
         with-params
         (fn [{:keys [status success body]}]
           (get-board (dispatcher/board-data)))))))
@@ -776,7 +781,7 @@
   [email]
   (when email
     (when-let [reset-link (utils/link-for (:links (:auth-settings @dispatcher/app-state)) "reset")]
-      (auth-post (:href reset-link)
+      (auth-post (relative-href (:href reset-link))
         {:headers (headers-for-link reset-link)
          :body email}
         (fn [{:keys [status success body]}]
@@ -787,7 +792,7 @@
     (let [board-data (dispatcher/board-data @dispatcher/app-state (router/current-org-slug) board-slug)
           delete-board-link (utils/link-for (:links board-data) "delete")]
       (when delete-board-link
-        (api-delete (:href delete-board-link)
+        (api-delete (relative-href (:href delete-board-link))
           {:headers (headers-for-link delete-board-link)}
           (fn [{:keys [status success body]}]
             (if success
@@ -797,9 +802,8 @@
 (defn get-comments [entry-uuid]
   (when entry-uuid
     (let [entry-data (dispatcher/entry entry-uuid)
-          comments-link (utils/link-for (:links entry-data) "comments")
-          comments-href (str "/" (s/join "/" (subvec (s/split (:href comments-link) #"/") 3)))]
-      (interaction-get comments-href
+          comments-link (utils/link-for (:links entry-data) "comments")]
+      (interaction-get (relative-href (:href comments-link))
         {:headers (headers-for-link comments-link)}
         (fn [{:keys [status success body]}]
           (dispatcher/dispatch! [:comments-get/finish {:success success

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -16,7 +16,7 @@
 })
 
 (def comments-data {
-  :entry-slug "1234-1234-1234-1234"
+  :entry-uuid "1234-1234-1234-1234"
   :id "1234"
   :topic-slug "product"
   :body "Body"
@@ -90,9 +90,10 @@
                       rum/static
   [s]
   (let [entry-data (drv/react s :entry-data)
-        entry-comments (:comments comments-data)];(:comments entry-data)]
-    [:div.comments
-      (when (pos? (count entry-comments))
-        (for [c entry-comments]
-         (rum/with-key (comment-row c) (str "entry-" (:created-at entry-data) "comment-" (:comment-id c)))))
-      (add-comment)]))
+        entry-comments (:comments comments-data)] ; (:comments entry-data)]
+    (when (:show-comments entry-data)
+      [:div.comments
+        (when (pos? (count entry-comments))
+          (for [c entry-comments]
+           (rum/with-key (comment-row c) (str "entry-" (:created-at entry-data) "comment-" (:comment-id c)))))
+        (add-comment)])))

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -1,12 +1,98 @@
 (ns oc.web.components.comments
   (:require [rum.core :as rum]
-            [org.martinklepsch.derivatives :as drv]))
+            [org.martinklepsch.derivatives :as drv]
+            [oc.web.lib.utils :as utils]))
+
+(def comment-author-me {
+  :name "Iacopo Carraro"
+  :user-id "3af0-4014-a3c6"
+  :avatar-url "https://avatars.slack-edge.com/2017-02-02/136114833346_3758034af26a3b4998f4_512.jpg"
+})
+
+(def comment-author-2 {
+  :name "Sean Johnson"
+  :user-id "4fb0-1536-a8c0"
+  :avatar-url "https://ca.slack-edge.com/T06SBMH60-U06SBTXJR-gf5b8fc1affa-1024"
+})
+
+(def comments-data {
+  :entry-slug "1234-1234-1234-1234"
+  :id "1234"
+  :topic-slug "product"
+  :body "Body"
+  :headline "Headline"
+  :created-at "2017-03-23T11:21:39.000Z"
+  :updated-at "2017-03-23T12:21:39.000Z"
+  :author comment-author-me
+  :links []
+  :comments [{
+    :comment-id "fedc-ba98-7654-3210"
+    :body "Comment #1 body"
+    :created-at "2017-04-21T12:12:12.000Z"
+    :updated-at "2017-04-21T12:12:12.000Z"
+    :author comment-author-me
+  } {
+    :comment-id "fedc-ba98-7654-1230"
+    :body "Comment #2 body"
+    :created-at "2017-04-30T12:12:12.000Z"
+    :updated-at "2017-04-30T12:12:12.000Z"
+    :author comment-author-2
+  } {
+    :comment-id "fedc-ba98-7654-ab21"
+    :body "Comment #3 body"
+    :created-at "2017-05-01T12:12:12.000Z"
+    :updated-at "2017-05-01T12:12:12.000Z"
+    :author comment-author-me
+  }]
+})
+
+(rum/defc comment-row
+  [c]
+  (let [author (:author c)]
+    [:div.comment
+      [:div.comment-header.group
+        [:div.comment-avatar.left
+          {:style {:background-image (str "url(" (:avatar-url author) ")")}}]
+        [:div.comment-author.left
+          (:name author)]
+        [:div.comment-timestamp.left
+          (utils/date-string (utils/js-date (:created-at c)))]]
+      [:div.comment-body.group
+        (:body c)]
+      [:div.comment-footer.group]]))
+
+(rum/defcs add-comment < (rum/local "" ::v)
+                         (rum/local false ::show-footer)
+                         rum/static
+  [s]
+  (let [v (::v s)
+        show-footer (::show-footer s)
+        fixed-show-footer (or @show-footer (not (empty? @v)))]
+    [:div.add-comment-box
+      [:div.add-comment-internal
+        [:textarea.add-comment
+          {:value @v
+           :class (if fixed-show-footer "open" "")
+           :on-focus #(reset! show-footer true)
+           :on-blur #(reset! show-footer false)
+           :on-change #(reset! v (.. % -target -value))
+           :placeholder "Add a comment..."}]
+        [:div.add-comment-footer.group
+          ; {:style {:opacity (if fixed-show-footer 1 0)}}
+          {:style {:display (if fixed-show-footer "block" "none")}}
+          [:div.right
+            [:button.btn-reset.btn-solid "Post"]]
+          [:div.add-comment-counter
+            (str (- 300 (count @v)))]]]]))
 
 (rum/defcs comments < (drv/drv :entry-data)
                       rum/reactive
+                      rum/static
   [s]
   (let [entry-data (drv/react s :entry-data)
-        comments (:comments entry-data)]
+        entry-comments (:comments comments-data)];(:comments entry-data)]
     [:div.comments
-      (when (pos? (count comments))
-        [:div.comment])]))
+      (when (pos? (count entry-comments))
+        (for [c entry-comments]
+         (rum/with-key (comment-row c) (str "entry-" (:created-at entry-data) "comment-" (:comment-id c)))))
+      (add-comment)]))

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -1,7 +1,8 @@
 (ns oc.web.components.comments
   (:require [rum.core :as rum]
             [org.martinklepsch.derivatives :as drv]
-            [oc.web.lib.utils :as utils]))
+            [oc.web.lib.utils :as utils]
+            [oc.web.components.ui.small-loading :refer (small-loading)]))
 
 (def comment-author-me {
   :name "Iacopo Carraro"
@@ -85,15 +86,19 @@
           [:div.add-comment-counter
             (str (- 300 (count @v)))]]]]))
 
-(rum/defcs comments < (drv/drv :entry-data)
+(rum/defcs comments < (drv/drv :comments-data)
                       rum/reactive
                       rum/static
   [s]
-  (let [entry-data (drv/react s :entry-data)
-        entry-comments (:comments comments-data)] ; (:comments entry-data)]
-    (when (:show-comments entry-data)
+  (let [comments-data (drv/react s :comments-data)
+        entry-comments (:comments comments-data)]
+    (js/console.log "comments/render" comments-data)
+    (if (:loading comments-data)
       [:div.comments
-        (when (pos? (count entry-comments))
-          (for [c entry-comments]
-           (rum/with-key (comment-row c) (str "entry-" (:created-at entry-data) "comment-" (:comment-id c)))))
-        (add-comment)])))
+        (small-loading)]
+      (when (:show-comments comments-data)
+        [:div.comments
+          (when (pos? (count entry-comments))
+            (for [c entry-comments]
+              (rum/with-key (comment-row c) (str "entry-" (:entry-uuid (:show-comments comments-data)) "comment-" (:comment-id c)))))
+          (add-comment)]))))

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -2,6 +2,7 @@
   (:require [rum.core :as rum]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.lib.utils :as utils]
+            [oc.web.dispatcher :as dis]
             [oc.web.components.ui.small-loading :refer (small-loading)]))
 
 (def comment-author-me {
@@ -82,7 +83,11 @@
           ; {:style {:opacity (if fixed-show-footer 1 0)}}
           {:style {:display (if fixed-show-footer "block" "none")}}
           [:div.right
-            [:button.btn-reset.btn-solid "Post"]]
+            [:button.btn-reset.btn-solid
+              {:on-click #(do
+                            (dis/dispatch! [:comment-add @v])
+                            (reset! v ""))}
+              "Post"]]
           [:div.add-comment-counter
             (str (- 300 (count @v)))]]]]))
 

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -69,10 +69,10 @@
         show-footer (::show-footer s)
         fixed-show-footer (or @show-footer (not (empty? @v)))]
     [:div.add-comment-box
+      {:class (if fixed-show-footer "expanded" "")}
       [:div.add-comment-internal
         [:textarea.add-comment
           {:value @v
-           :class (if fixed-show-footer "open" "")
            :on-focus #(reset! show-footer true)
            :on-blur #(reset! show-footer false)
            :on-change #(reset! v (.. % -target -value))

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -16,7 +16,7 @@
           (:name author)]
         [:div.comment-timestamp.left
           (utils/time-since (:created-at c))]]
-      [:div.comment-body.group
+      [:p.comment-body.group
         (:body c)]
       [:div.comment-footer.group]]))
 
@@ -48,9 +48,21 @@
           [:div.add-comment-counter
             (str (- 300 (count @v)))]]]]))
 
+(defn scroll-to-bottom [s]
+  (when-not (.-_calledComponentWillUnmount (:rum/react-component s))
+    (let [component (:rum/react-component s)
+          dom-node  (js/ReactDOM.findDOMNode component)]
+      (set! (.-scrollTop dom-node) (.-scrollHeight dom-node)))))
+
 (rum/defcs comments < (drv/drv :comments-data)
                       rum/reactive
                       rum/static
+                      {:did-mount (fn [s]
+                                    (utils/after 100 #(scroll-to-bottom s))
+                                  s)
+                       :did-remount (fn [_ s]
+                                      (utils/after 100 #(scroll-to-bottom s))
+                                    s)}
   [s]
   (let [comments-data (drv/react s :comments-data)
         entry-comments (:comments comments-data)]

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -68,12 +68,12 @@
                       (rum/local false ::needs-gradient)
                       {:after-render (fn [s]
                                        (when-let* [dom-node (get-dom-node s)
-                                                   comments-internal (sel1 dom-node :div.comments-internal)
-                                                   next-needs-gradient (>= (.-scrollHeight comments-internal) 300)]
-                                         ;; Show the gradient at the top only if there are at least 5 comments
-                                         ;; or the container has some scroll
-                                         (when (not= @(::needs-gradient s) next-needs-gradient)
-                                           (reset! (::needs-gradient s) next-needs-gradient)))
+                                                   comments-internal (sel1 dom-node :div.comments-internal)]
+                                         (let [next-needs-gradient (> (.-scrollHeight comments-internal) 300)]
+                                           ;; Show the gradient at the top only if there are at least 5 comments
+                                           ;; or the container has some scroll
+                                           (when (not= @(::needs-gradient s) next-needs-gradient)
+                                             (reset! (::needs-gradient s) next-needs-gradient))))
                                        ;; recall scroll to bottom if needed
                                        (scroll-to-bottom s)
                                        s)}

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -1,0 +1,12 @@
+(ns oc.web.components.comments
+  (:require [rum.core :as rum]
+            [org.martinklepsch.derivatives :as drv]))
+
+(rum/defcs comments < (drv/drv :entry-data)
+                      rum/reactive
+  [s]
+  (let [entry-data (drv/react s :entry-data)
+        comments (:comments entry-data)]
+    [:div.comments
+      (when (pos? (count comments))
+        [:div.comment])]))

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -52,7 +52,9 @@
   (when-not (.-_calledComponentWillUnmount (:rum/react-component s))
     (let [component (:rum/react-component s)
           dom-node  (js/ReactDOM.findDOMNode component)]
-      (set! (.-scrollTop dom-node) (.-scrollHeight dom-node)))))
+      ;; Make sure the dom-node exists and that it's part of the dom, ie has a parent element.
+      (when (and dom-node (.-parentElement dom-node))
+        (set! (.-scrollTop dom-node) (.-scrollHeight dom-node))))))
 
 (rum/defcs comments < (drv/drv :comments-data)
                       rum/reactive

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -5,49 +5,6 @@
             [oc.web.dispatcher :as dis]
             [oc.web.components.ui.small-loading :refer (small-loading)]))
 
-(def comment-author-me {
-  :name "Iacopo Carraro"
-  :user-id "3af0-4014-a3c6"
-  :avatar-url "https://avatars.slack-edge.com/2017-02-02/136114833346_3758034af26a3b4998f4_512.jpg"
-})
-
-(def comment-author-2 {
-  :name "Sean Johnson"
-  :user-id "4fb0-1536-a8c0"
-  :avatar-url "https://ca.slack-edge.com/T06SBMH60-U06SBTXJR-gf5b8fc1affa-1024"
-})
-
-(def comments-data {
-  :entry-uuid "1234-1234-1234-1234"
-  :id "1234"
-  :topic-slug "product"
-  :body "Body"
-  :headline "Headline"
-  :created-at "2017-03-23T11:21:39.000Z"
-  :updated-at "2017-03-23T12:21:39.000Z"
-  :author comment-author-me
-  :links []
-  :comments [{
-    :comment-id "fedc-ba98-7654-3210"
-    :body "Comment #1 body"
-    :created-at "2017-04-21T12:12:12.000Z"
-    :updated-at "2017-04-21T12:12:12.000Z"
-    :author comment-author-me
-  } {
-    :comment-id "fedc-ba98-7654-1230"
-    :body "Comment #2 body"
-    :created-at "2017-04-30T12:12:12.000Z"
-    :updated-at "2017-04-30T12:12:12.000Z"
-    :author comment-author-2
-  } {
-    :comment-id "fedc-ba98-7654-ab21"
-    :body "Comment #3 body"
-    :created-at "2017-05-01T12:12:12.000Z"
-    :updated-at "2017-05-01T12:12:12.000Z"
-    :author comment-author-me
-  }]
-})
-
 (rum/defc comment-row
   [c]
   (let [author (:author c)]
@@ -58,7 +15,7 @@
         [:div.comment-author.left
           (:name author)]
         [:div.comment-timestamp.left
-          (utils/date-string (utils/js-date (:created-at c)))]]
+          (utils/time-since (:created-at c))]]
       [:div.comment-body.group
         (:body c)]
       [:div.comment-footer.group]]))
@@ -104,5 +61,5 @@
         [:div.comments
           (when (pos? (count entry-comments))
             (for [c entry-comments]
-              (rum/with-key (comment-row c) (str "entry-" (:entry-uuid (:show-comments comments-data)) "comment-" (:comment-id c)))))
+              (rum/with-key (comment-row c) (str "entry-" (:entry-uuid (:show-comments comments-data)) "-comment-" (:created-at c)))))
           (add-comment)]))))

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -92,7 +92,6 @@
   [s]
   (let [comments-data (drv/react s :comments-data)
         entry-comments (:comments comments-data)]
-    (js/console.log "comments/render" comments-data)
     (if (:loading comments-data)
       [:div.comments
         (small-loading)]

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -233,7 +233,8 @@
                                          :dashboard-sharing (:dashboard-sharing data)
                                          :prevent-topic-not-found-navigation (:prevent-topic-not-found-navigation data)
                                          :is-dashboard true
-                                         :show-top-menu (:show-top-menu data)}))))
+                                         :show-top-menu (:show-top-menu data)
+                                         :comments-open (:comments-open data)}))))
                       (om/build topics-list
                                   {:loading (:loading data)
                                    :content-loaded (or (:loading board-data) (:loading data))
@@ -255,7 +256,8 @@
                                    :dashboard-sharing (:dashboard-sharing data)
                                    :prevent-topic-not-found-navigation (:prevent-topic-not-found-navigation data)
                                    :is-dashboard true
-                                   :show-top-menu (:show-top-menu data)})))
+                                   :show-top-menu (:show-top-menu data)
+                                   :comments-open (:comments-open data)})))
                   (when (and (not (:read-only org-data))
                              (not (:show-add-topic data))
                              (not (router/current-topic-slug))

--- a/src/oc/web/components/topic.cljs
+++ b/src/oc/web/components/topic.cljs
@@ -194,7 +194,7 @@
                          :data-placement "top"}
               (dom/i {:class "fa fa-comments-o"})
               (when (pos? (:count comments-link))
-                (dom/span {:class "counter"} "(" (:count comments-link) ")"))))
+                (dom/span {:class "counter"} (str "(" (:count comments-link) ")")))))
           (when (and show-editing
                      (not is-stakeholder-update)
                      (not is-dashboard)

--- a/src/oc/web/components/topic.cljs
+++ b/src/oc/web/components/topic.cljs
@@ -185,6 +185,15 @@
                            :data-toggle "tooltip"
                            :title "This topic has prior history"}
                 (dom/i {:class "fa fa-history"}))))
+          (when should-show-comments-button
+            (dom/button {:class "top-right-button topic-comments-button btn-reset"
+                         :on-click #(dis/dispatch! [:comments-show topic-kw (:uuid topic-data)])
+                         :title "Comments"
+                         :data-toggle "tooltip"
+                         :data-container "body"
+                         :data-placement "top"}
+              (dom/i {:class "fa fa-comments-o"})
+              (str "(" (:count comments-link) ")")))
           (when (and show-editing
                      (not is-stakeholder-update)
                      (not is-dashboard)
@@ -203,15 +212,6 @@
                       :data-toggle "tooltip"
                       :data-container "body"
                       :data-placement "top"})))
-          (when should-show-comments-button
-            (dom/button {:class "top-right-button topic-comments-button btn-reset"
-                         :on-click #(dis/dispatch! [:comments-show topic-kw (:uuid topic-data)])
-                         :title "Comments"
-                         :data-toggle "tooltip"
-                         :data-container "body"
-                         :data-placement "top"}
-              (dom/i {:class "fa fa-comments-o"})
-              (str "(" (:count comments-link) ")")))
           (when (and show-editing
                      (not is-stakeholder-update)
                      is-dashboard

--- a/src/oc/web/components/topic.cljs
+++ b/src/oc/web/components/topic.cljs
@@ -193,7 +193,8 @@
                          :data-container "body"
                          :data-placement "top"}
               (dom/i {:class "fa fa-comments-o"})
-              (str "(" (:count comments-link) ")")))
+              (when (pos? (:count comments-link))
+                (dom/span {:class "counter"} "(" (:count comments-link) ")"))))
           (when (and show-editing
                      (not is-stakeholder-update)
                      (not is-dashboard)

--- a/src/oc/web/components/topic.cljs
+++ b/src/oc/web/components/topic.cljs
@@ -191,6 +191,21 @@
                       :data-placement "top"})))
           (when (and show-editing
                      (not is-stakeholder-update)
+                     (not is-dashboard)
+                     (not is-mobile?)
+                     is-topic-view
+                     (not foce-active))
+            (dom/button {:class "top-right-button topic-comments-button btn-reset"
+                         :on-click #(if (nil? (:comments-open data))
+                                      (dis/dispatch! [:comments-show topic-kw (:created-at topic-data)])
+                                      (dis/dispatch! [:comments-show nil nil]))}
+              (dom/i {:class "fa fa-comments-o"
+                      :title "Comments"
+                      :data-toggle "tooltip"
+                      :data-container "body"
+                      :data-placement "top"})))
+          (when (and show-editing
+                     (not is-stakeholder-update)
                      is-dashboard
                      (not dashboard-sharing)
                      (not is-mobile?)
@@ -395,6 +410,7 @@
                                     :is-topic-view is-topic-view
                                     :show-editing show-editing
                                     :column column
-                                    :show-top-menu (:show-top-menu data)}
+                                    :show-top-menu (:show-top-menu data)
+                                    :comments-open (:comments-open data)}
                                    {:opts options
                                     :key (str "topic-" topic)}))))))

--- a/src/oc/web/components/topic.cljs
+++ b/src/oc/web/components/topic.cljs
@@ -196,9 +196,7 @@
                      is-topic-view
                      (not foce-active))
             (dom/button {:class "top-right-button topic-comments-button btn-reset"
-                         :on-click #(if (nil? (:comments-open data))
-                                      (dis/dispatch! [:comments-show topic-kw (:created-at topic-data)])
-                                      (dis/dispatch! [:comments-show nil nil]))}
+                         :on-click #(dis/dispatch! [:comments-show topic-kw (:created-at topic-data)])}
               (dom/i {:class "fa fa-comments-o"
                       :title "Comments"
                       :data-toggle "tooltip"

--- a/src/oc/web/components/topic.cljs
+++ b/src/oc/web/components/topic.cljs
@@ -84,6 +84,11 @@
                                       column
                                       show-top-menu] :as data} owner options]
 
+  (did-mount [_]
+    (when (and is-topic-view
+               (not is-mobile?))
+      (dis/dispatch! [:comments-get (:uuid topic-data)])))
+
   (render [_]
     (let [topic-kw          (keyword topic)
           chart-opts          {:chart-size {:width 230}
@@ -102,7 +107,15 @@
                                  (.truncate js/$ topic-body (clj->js {:length utils/topic-body-limit :words true}))
                                  topic-body)
           showing-menu        (= show-top-menu topic)
-          attachments         (:attachments topic-data)]
+          attachments         (:attachments topic-data)
+          comments-link       (utils/link-for (:links topic-data) "comments")
+          should-show-comments-button (and comments-link
+                                           show-editing
+                                           (not is-stakeholder-update)
+                                           (not is-dashboard)
+                                           (not is-mobile?)
+                                           is-topic-view
+                                           (not foce-active))]
       (dom/div #js {:className "topic-internal group"
                     :key (str "topic-internal-" (name topic))
                     :ref "topic-internal"}
@@ -138,7 +151,8 @@
                            :on-click #(assign-topic-click)}
                 (dom/i {:class "fa fa-user"}) " Assign")))
           (chart topic-data (- card-width (* 16 2)))
-          (dom/div {:class "topic-title"}
+          (dom/div {:class (utils/class-set {:topic-title true
+                                             :has-comments should-show-comments-button})}
 
             (when-not (and is-topic-view
                        is-mobile?)
@@ -189,19 +203,15 @@
                       :data-toggle "tooltip"
                       :data-container "body"
                       :data-placement "top"})))
-          (when (and show-editing
-                     (not is-stakeholder-update)
-                     (not is-dashboard)
-                     (not is-mobile?)
-                     is-topic-view
-                     (not foce-active))
+          (when should-show-comments-button
             (dom/button {:class "top-right-button topic-comments-button btn-reset"
-                         :on-click #(dis/dispatch! [:comments-show topic-kw (:created-at topic-data)])}
-              (dom/i {:class "fa fa-comments-o"
-                      :title "Comments"
-                      :data-toggle "tooltip"
-                      :data-container "body"
-                      :data-placement "top"})))
+                         :on-click #(dis/dispatch! [:comments-show topic-kw (:created-at topic-data)])
+                         :title "Comments"
+                         :data-toggle "tooltip"
+                         :data-container "body"
+                         :data-placement "top"}
+              (dom/i {:class "fa fa-comments-o"})
+              (str "(" (:count comments-link) ")")))
           (when (and show-editing
                      (not is-stakeholder-update)
                      is-dashboard

--- a/src/oc/web/components/topic.cljs
+++ b/src/oc/web/components/topic.cljs
@@ -205,7 +205,7 @@
                       :data-placement "top"})))
           (when should-show-comments-button
             (dom/button {:class "top-right-button topic-comments-button btn-reset"
-                         :on-click #(dis/dispatch! [:comments-show topic-kw (:created-at topic-data)])
+                         :on-click #(dis/dispatch! [:comments-show topic-kw (:uuid topic-data)])
                          :title "Comments"
                          :data-toggle "tooltip"
                          :data-container "body"

--- a/src/oc/web/components/topic_view.cljs
+++ b/src/oc/web/components/topic_view.cljs
@@ -11,6 +11,7 @@
             [oc.web.lib.responsive :as responsive]
             [oc.web.components.topic :refer (topic)]
             [oc.web.components.topic-edit :refer (topic-edit)]
+            [oc.web.components.comments :refer (comments)]
             [oc.web.components.ui.popover :refer (add-popover hide-popover)]
             [oc.web.components.ui.loading :refer (loading)]
             [cuerdas.core :as s]))
@@ -102,7 +103,8 @@
 
   (render [_]
     (let [topic-kw (keyword (router/current-topic-slug))
-          topic-view-width (responsive/topic-view-width card-width columns-num)
+          comment-view-width 320
+          topic-view-width (- (responsive/topic-view-width card-width columns-num) comment-view-width)
           topic-card-width (responsive/calc-update-width columns-num)
           topic-data (get board-data topic-kw)
           is-custom-topic (s/starts-with? (:topic topic-data) "custom-")
@@ -112,11 +114,13 @@
           loading-topic-data (and (contains? board-data topic-kw)
                                   (:loading topic-data))]
       (dom/div {:class "topic-view-container group"
-                :style {:width (if (responsive/is-tablet-or-mobile?) "100%" (str topic-card-width "px"))
+                :style {:width (if (responsive/is-tablet-or-mobile?) "100%" (str (+ topic-card-width comment-view-width) "px"))
                         :margin-right (if (responsive/is-tablet-or-mobile?) "0px" (str (max 0 (- topic-view-width topic-card-width 50)) "px"))}
                 :key (str "topic-view-inner-" (router/current-topic-slug))}
+        (comments)
         (dom/div {:class (utils/class-set {:topic-view true
                                            :group true
+                                           :left true
                                            :tablet-view (responsive/is-tablet-or-mobile?)
                                            :topic-404 (nil? topic-data)})}
           (when (responsive/is-tablet-or-mobile?)
@@ -202,9 +206,9 @@
                                       :key (str "topic-"
                                             (when foce-key
                                               "foce-")
-                                            (router/current-topic-slug) "-" (:updated-at rev))})))))))
-        (when (and (not loading-topic-data)
-                   (not (responsive/is-tablet-or-mobile?))
-                   (not (:read-only board-data)))
-          (dom/button {:class "btn-reset btn-link archive-topic"
-                       :on-click (partial remove-topic-click owner)} "Archive this topic"))))))
+                                            (router/current-topic-slug) "-" (:updated-at rev))}))))
+              (when (and (not loading-topic-data)
+                         (not (responsive/is-tablet-or-mobile?))
+                         (not (:read-only board-data)))
+                (dom/button {:class "btn-reset btn-link archive-topic"
+                             :on-click (partial remove-topic-click owner)} "Archive this topic")))))))))

--- a/src/oc/web/components/topic_view.cljs
+++ b/src/oc/web/components/topic_view.cljs
@@ -133,7 +133,7 @@
             (dom/div {:class "topic-view-internal loading group"}
               (om/build loading {:loading true}))
             (dom/div {:class "topic-view-internal"
-                      :style {:width (if (responsive/is-tablet-or-mobile?) "auto" (str topic-card-width "px"))}}
+                      :style {:width (if (responsive/is-tablet-or-mobile?) "auto" (str (- topic-card-width responsive/topic-total-x-padding) "px"))}}
               (when (and (not (:read-only board-data))
                          (not (responsive/is-tablet-or-mobile?)))
                 (dom/div {:class (str "fake-textarea group " (when is-another-foce "disabled"))}

--- a/src/oc/web/components/topic_view.cljs
+++ b/src/oc/web/components/topic_view.cljs
@@ -99,7 +99,8 @@
 
   (will-unmount [_]
     (when (om/get-state owner :entries-reload-interval)
-      (js/clearInterval (om/get-state owner :entries-reload-interval))))
+      (js/clearInterval (om/get-state owner :entries-reload-interval)))
+    (dis/dispatch! [:comments-show nil nil]))
 
   (render-state [_ {:keys [comments-open?]}]
     (let [topic-kw (keyword (router/current-topic-slug))
@@ -117,7 +118,8 @@
                 :style {:width (if (responsive/is-tablet-or-mobile?) "100%" (str (+ topic-card-width comment-view-width) "px"))
                         :margin-right (if (responsive/is-tablet-or-mobile?) "0px" (str (max 0 (- topic-view-width topic-card-width 50)) "px"))}
                 :key (str "topic-view-inner-" (router/current-topic-slug))}
-        (comments)
+        (when (= (:topic-slug (:comments-open data)) topic-kw)
+          (comments))
         (dom/div {:class (utils/class-set {:topic-view true
                                            :group true
                                            :left true

--- a/src/oc/web/components/topic_view.cljs
+++ b/src/oc/web/components/topic_view.cljs
@@ -101,9 +101,9 @@
     (when (om/get-state owner :entries-reload-interval)
       (js/clearInterval (om/get-state owner :entries-reload-interval))))
 
-  (render [_]
+  (render-state [_ {:keys [comments-open?]}]
     (let [topic-kw (keyword (router/current-topic-slug))
-          comment-view-width 320
+          comment-view-width (if (= (:topic-slug (:comments-open data)) topic-kw) 320 0)
           topic-view-width (- (responsive/topic-view-width card-width columns-num) comment-view-width)
           topic-card-width (responsive/calc-update-width columns-num)
           topic-data (get board-data topic-kw)
@@ -180,7 +180,8 @@
                                    :foce-data-editing? foce-data-editing?
                                    :foce-key foce-key
                                    :foce-data foce-data
-                                   :show-editing false}
+                                   :show-editing false
+                                   :comments-open (:comments-open data)}
                                    {:opts {:topic-name (router/current-topic-slug)}})))
               (for [idx (range (count entries))
                     :let [rev (get entries idx)]]
@@ -201,7 +202,8 @@
                                      :foce-key foce-key
                                      :foce-data foce-data
                                      :show-delete-entry-button true
-                                     :show-editing true}
+                                     :show-editing true
+                                     :comments-open (:comments-open data)}
                                      {:opts {:topic-name (router/current-topic-slug)}
                                       :key (str "topic-"
                                             (when foce-key

--- a/src/oc/web/components/topic_view.cljs
+++ b/src/oc/web/components/topic_view.cljs
@@ -108,7 +108,7 @@
           topic-card-width (responsive/calc-update-width columns-num)
           topic-data (get board-data topic-kw)
           is-custom-topic (s/starts-with? (:topic topic-data) "custom-")
-          entries (get entries-data topic-kw [])
+          entries (or (get-in entries-data [topic-kw :entries]) [])
           is-new-foce (and (= foce-key topic-kw) (nil? (:created-at foce-data)))
           is-another-foce (and (not (nil? foce-key)) (not (nil? (:created-at foce-data))))
           loading-topic-data (and (contains? board-data topic-kw)

--- a/src/oc/web/components/topics_columns.cljs
+++ b/src/oc/web/components/topics_columns.cljs
@@ -221,7 +221,8 @@
                                     :foce-data (:foce-data data)
                                     :foce-data-editing? (:foce-data-editing? data)
                                     :new-topics (:new-topics data)
-                                    :prevent-topic-not-found-navigation (:prevent-topic-not-found-navigation data)})
+                                    :prevent-topic-not-found-navigation (:prevent-topic-not-found-navigation data)
+                                    :comments-open (:comments-open data)})
               ; for each column key contained in best layout
               :else
               (dom/div {:class (str "right" (when (:dashboard-sharing data) " mt2"))

--- a/src/oc/web/components/topics_list.cljs
+++ b/src/oc/web/components/topics_list.cljs
@@ -92,6 +92,7 @@
                          :dashboard-sharing (:dashboard-sharing data)
                          :prevent-topic-not-found-navigation (:prevent-topic-not-found-navigation data)
                          :is-dashboard (:is-dashboard data)
-                         :show-top-menu (:show-top-menu data)}
+                         :show-top-menu (:show-top-menu data)
+                         :comments-open (:comments-open data)}
               sub-component (if (responsive/is-mobile-size?) mobile-topics-list topics-columns)]
           (om/build sub-component comp-data))))))

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -254,9 +254,6 @@
     (entry org-slug board-slug topic-slug entry-uuid @app-state))
   ([org-slug board-slug topic-slug entry-uuid data]
     (let [entries-data (get-in data (topic-entries-key org-slug board-slug topic-slug))]
-      (js/console.log "dispatcher/entry" org-slug board-slug topic-slug entry-uuid "->" (topic-entries-key org-slug board-slug topic-slug))
-      (js/console.log "entries-data" entries-data)
-      (js/console.log "filter" (first (filter #(= (:uuid %) entry-uuid) entries-data)))
       (first (filter #(= (:uuid %) entry-uuid) entries-data)))))
 
 (defn comments-data

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -139,7 +139,8 @@
                                     comments-data (get-in base (comments-key org-slug board-slug topic-slug (:entry-uuid comments-open)))
                                     should-show-comments (and (= (:topic-slug comments-open) (keyword topic-slug))
                                                               (= (:entry-uuid comments-open) entry-uuid))]
-                                (assoc comments-data :show-comments comments-open))))]
+                                {:comments comments-data
+                                 :show-comments comments-open})))]
    :error-banner        [[:base]
                           (fn [base]
                             {:error-banner-message (:error-banner-message base)

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -48,13 +48,10 @@
   [(keyword org-slug) :boards (keyword board-slug) :entries-data])
 
 (defn topic-entries-key [org-slug board-slug topic-slug]
-  (vec (conj (entries-key org-slug board-slug) (keyword topic-slug))))
-
-(defn entry-key [org-slug board-slug topic-slug entry-uuid]
-  (vec (conj (topic-entries-key org-slug board-slug topic-slug) entry-uuid :entry-data)))
+  (vec (conj (entries-key org-slug board-slug) (keyword topic-slug) :entries)))
 
 (defn comments-key [org-slug board-slug topic-slug entry-uuid]
-  (vec (conj (topic-entries-key org-slug board-slug topic-slug) entry-uuid :comments-data)))
+ (vec (conj (entries-key org-slug board-slug) (keyword topic-slug) entry-uuid :comments-data)))
 
 (def teams-data-key [:teams-data :teams])
 
@@ -137,9 +134,9 @@
                                 (assoc entry-data :show-comments (= (:topic-slug comments-open) (keyword topic-slug))))))]
    :comments-data       [[:base :org-slug :board-slug :topic-slug :entry-uuid]
                           (fn [base org-slug board-slug topic-slug entry-uuid]
-                            (when (and org-slug board-slug topic-slug entry-uuid)
-                              (let [comments-data (get-in base (comments-key org-slug board-slug topic-slug entry-uuid))
-                                    comments-open (:comments-open base)
+                            (when (and org-slug board-slug topic-slug)
+                              (let [comments-open (:comments-open base)
+                                    comments-data (get-in base (comments-key org-slug board-slug topic-slug (:entry-uuid comments-open)))
                                     should-show-comments (and (= (:topic-slug comments-open) (keyword topic-slug))
                                                               (= (:entry-uuid comments-open) entry-uuid))]
                                 (assoc comments-data :show-comments comments-open))))]

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -50,8 +50,8 @@
 (defn topic-entries-key [org-slug board-slug topic-slug]
   (vec (conj (entries-key org-slug board-slug) (keyword topic-slug))))
 
-(defn entry-key [org-slug board-slug topic-slug as-of]
-  (vec (conj (topic-entries-key org-slug board-slug topic-slug) (str as-of))))
+(defn entry-key [org-slug board-slug topic-slug entry-slug]
+  (vec (conj (topic-entries-key org-slug board-slug topic-slug) (keyword entry-slug))))
 
 (def teams-data-key [:teams-data :teams])
 
@@ -72,6 +72,8 @@
    :orgs                [[:base] (fn [base] (:orgs base))]
    :org-slug            [[:route] (fn [route] (:org route))]
    :board-slug          [[:route] (fn [route] (:board route))]
+   :topic-slug          [[:route] (fn [route] (:topic route))]
+   :entry-slug          [[:route] (fn [route] (:entry route))]
    :su-share            [[:base] (fn [base] (:su-share base))]
    :updates-list        [[:base :org-slug]
                           (fn [base org-slug]
@@ -120,6 +122,14 @@
                           (fn [base org-slug board-slug]
                             (when (and org-slug board-slug)
                               (get-in base (board-data-key org-slug board-slug))))]
+   :topic-data          [[:base :org-slug :board-slug :topic-slug]
+                          (fn [base org-slug board-slug topic-slug]
+                            (when (and org-slug board-slug topic-slug)
+                              (get-in base (board-topic-key org-slug board-slug topic-slug))))]
+   :entry-data          [[:topic-data]
+                          (fn [base org-slug board-slug topic-slug entry-slug]
+                            (when (and org-slug board-slug topic-slug entry-slug)
+                              (get-in base (entry-key org-slug board-slug topic-slug entry-slug))))]
    :error-banner        [[:base]
                           (fn [base]
                             {:error-banner-message (:error-banner-message base)
@@ -212,8 +222,8 @@
   (:force-edit-topic @app-state))
 
 (defn entry
-  ([org-slug board-slug topic-slug as-of] (entry org-slug board-slug topic-slug as-of @app-state))
-  ([org-slug board-slug topic-slug as-of data] (get-in data (entry-key org-slug board-slug topic-slug as-of))))
+  ([org-slug board-slug topic-slug entry-slug] (entry org-slug board-slug topic-slug entry-slug @app-state))
+  ([org-slug board-slug topic-slug entry-slug data] (get-in data (entry-key org-slug board-slug topic-slug entry-slug))))
 
 (defn entries-data
   ([] (entries-data @app-state (router/current-org-slug) (router/current-board-slug)))

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -328,6 +328,9 @@
 (defn print-entries-data []
   (js/console.log (get-in @app-state (entries-key (router/current-org-slug) (router/current-board-slug)))))
 
+(defn print-topic-entries-data []
+  (js/console.log (get-in @app-state (topic-entries-key (router/current-org-slug) (router/current-board-slug) (router/current-topic-slug)))))
+
 (set! (.-OCWebPrintAppState js/window) print-app-state)
 (set! (.-OCWebPrintOrgData js/window) print-org-data)
 (set! (.-OCWebPrintTeamData js/window) print-team-data)
@@ -336,3 +339,4 @@
 (set! (.-OCWebPrintUpdateData js/window) print-update-data)
 (set! (.-OCWebPrintBoardData js/window) print-board-data)
 (set! (.-OCWebPrintEntriesData js/window) print-entries-data)
+(set! (.-OCWebPrintTopicEntriesData js/window) print-topic-entries-data)

--- a/src/oc/web/lib/responsive.cljs
+++ b/src/oc/web/lib/responsive.cljs
@@ -142,11 +142,9 @@
 (defn calc-update-width [columns-num]
   (let [card-width   (calc-card-width)
         total-width-int (total-layout-width-int card-width columns-num)
-        total-width  (str total-width-int "px")
         fixed-total-width-int (if (<= total-width-int (+ updates-content-cards-min-width updates-content-cards-right-margin updates-content-list-width))
                                 (+ updates-content-cards-min-width updates-content-cards-right-margin updates-content-list-width)
                                 total-width-int)
-        total-width  (str fixed-total-width-int "px")
         fixed-card-width (if (>= (- fixed-total-width-int updates-content-list-width updates-content-cards-right-margin) updates-content-cards-max-width)
                             updates-content-cards-max-width
                             (- fixed-total-width-int updates-content-list-width updates-content-cards-right-margin))]

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -847,7 +847,7 @@
     :viewer))
 
 (defn index-of
-  "Given a collection and a function return the index that match make the function truely."
+  "Given a collection and a function return the index that make the function truely."
   [s f]
   (loop [idx 0 items s]
     (cond

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -185,7 +185,8 @@
         years-interval (.floor js/Math (/ seconds 31536000))
         months-interval (.floor js/Math (/ seconds 2592000))
         days-interval (.floor js/Math (/ seconds 86400))
-        hours-interval (.floor js/Math (/ seconds 3600))]
+        hours-interval (.floor js/Math (/ seconds 3600))
+        minutes-interval (.floor js/Math (/ seconds 60))]
     (cond
       (pos? years-interval)
       (date-string past-js-date (concat flags [:year]))
@@ -198,6 +199,9 @@
 
       (pos? hours-interval)
       (str hours-interval " " (pluralize "hour" hours-interval) " ago")
+
+      (pos? minutes-interval)
+      (str minutes-interval " " (pluralize "min" minutes-interval) " ago")
 
       :else
       "just now")))

--- a/src/oc/web/local_settings.cljs
+++ b/src/oc/web/local_settings.cljs
@@ -13,6 +13,9 @@
 ;; Pay location
 (def pay-server-domain "http://localhost:3004")
 
+;; Interaction location
+(def interaction-server-domain "http://localhost:3002")
+
 ;; Web location
 (def web-server "localhost:3559")
 


### PR DESCRIPTION
Part 1 of this card: https://trello.com/c/aBhDvqzr

Static comments. This is missing the delete and edit comments. For now it retrieves the comments for each rendered entry in the topic view. When the user clicks on the comments icon it toggles the comments UI.
The comments button is shown only if there is the `comments` rel in the entry data. The new comment component at the bottom of the comments container is shown only if the is the `comment` rel in the entry area.
So the comments icon won't be shown on a new entry (not yet saved).

To test:
- open a board and click on a topic (with more entries if possible)
- check the number of comments besides the comments icon (shown only if >0)
- click it
- check that the comments are shown
- add a comment
- check that the number of comments is increased in the comments button
- refresh the topic view and check that the number of comments is still good
- toggle the comments for more entries to make sure the right data are always shown