### PR TITLE
Filestack update

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -47,7 +47,7 @@
     [cljsjs/emojione-picker "0.3.6-2"] ; EmojionePicker cljsjs package https://github.com/tommoor/emojione-picker
     [cljsjs/web-animations "2.1.4-0"] ; JavaScript implementation of the Web Animations API https://github.com/web-animations/web-animations-js
     [cljsjs/moment-timezone "0.5.11-0"] ; Timezone support for moment.js https://github.com/moment/moment-timezone/
-    [cljsjs/filestack "0.6.3-0"] ; Filestack image manipulatino and storing https://github.com/filestack/filestack-js
+    [cljsjs/filestack "0.9.9-0"] ; Filestack image manipulatino and storing https://github.com/filestack/filestack-js
 
     [binaryage/devtools "0.9.4"] ; Chrome DevTools enhancements https://github.com/binaryage/cljs-devtools
 

--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -91,13 +91,6 @@ var OCWebPrintAsciiArt = function(){};
 var OCWebConfigLogLevel = function(){};
 var OCWebPrintRouterPath = function(){};
 var OCWebForceRefreshToken = function(){};
-// Filestack
-var filestack = {};
-filestack.init = function(){};
-filestack.pick = function(){};
-filestack.then = function(){};
-filestack.transform = function(){};
-filestack.storeURL = function(){};
 // Moment
 var moment = {};
 moment.tz = {};

--- a/scss/vendor/_filestack.scss
+++ b/scss/vendor/_filestack.scss
@@ -65,6 +65,10 @@ div.fsp-picker {
       }
 
       div.fsp-source-list {
+        .fsp-source-list__item--active {
+          background-color: white;
+        }
+
         .fsp-source-list__item.active {
           display: inherit !important;
           .fsp-source-list__label {
@@ -88,6 +92,13 @@ div.fsp-picker {
             border-radius: 20px;
             background-color: rgba($oc_gray_7,0.4);
             position: absolute;
+          }
+        }
+
+        .fsp-source-list__item--active {
+          span.fsp-source-list__icon {
+            background-color: $carrot_light_blue;
+            border-radius: 19px;
           }
         }
 

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -168,14 +168,21 @@
          (gdom/append (.-body js/document) img)
          (set! (.-src img) url)
          (reset! (::media-photo s) {:res res :url url})
-         (iu/thumbnail! url
-          (fn [thumbnail-url]
-            (reset! (::media-photo s) (assoc @(::media-photo s) :thumbnail thumbnail-url))
-            (media-photo-add-if-finished s editable))
-          (fn [res progress])
-          (fn [res err]
-            (media-photo-add-error s))
-          )))
+         ;; if the image is a vector image
+         (if (or (= (string/lower (gobj/get res "mimetype")) "image/svg+xml")
+                 (string/ends-with? (string/lower (gobj/get res "filename")) ".svg"))
+           ;l use the same url for the thumbnail since the size doesn't matter
+           (do
+             (reset! (::media-photo s) (assoc @(::media-photo s) :thumbnail url))
+             (media-photo-add-if-finished s editable))
+           ;; else create the thumbnail
+           (iu/thumbnail! url
+            (fn [thumbnail-url]
+              (reset! (::media-photo s) (assoc @(::media-photo s) :thumbnail thumbnail-url))
+              (media-photo-add-if-finished s editable))
+            (fn [res progress])
+            (fn [res err]
+              (media-photo-add-error s))))))
      ;; progress-cb
      (fn [res progress])
      ;; error-cb

--- a/src/oc/web/components/ui/org_avatar.cljs
+++ b/src/oc/web/components/ui/org_avatar.cljs
@@ -7,20 +7,22 @@
             [oc.web.lib.utils :as utils]))
 
 (defn internal-org-avatar
-  [s org-logo org-name show-org-avatar? hide-name show-avatar-and-name]
+  [s org-data show-org-avatar? hide-name show-avatar-and-name]
   [:div.org-avatar-container.group
     (when show-org-avatar?
       [:div.org-avatar-border
         [:span.helper]
         [:img.org-avatar-img
-          {:src org-logo
+          {:src (:logo-url org-data)
+           :width (:logo-width org-data)
+           :height (:logo-height org-data)
            :on-error #(reset! (::img-load-failed s) true)}]])
     (when (and (not hide-name)
                (or (not show-org-avatar?)
                    show-avatar-and-name))
       [:span.org-name
         {:class (when-not show-org-avatar? "no-logo")}
-        org-name])])
+        (:name org-data)])])
 
 (rum/defcs org-avatar < rum/static
                         (rum/local false ::img-load-failed)
@@ -50,5 +52,5 @@
                            (.preventDefault e)
                            (when should-show-link
                              (router/redirect! avatar-link)))}
-              (internal-org-avatar s org-logo org-name show-org-avatar? hide-name show-avatar-and-name)]
-            (internal-org-avatar s org-logo org-name show-org-avatar? hide-name show-avatar-and-name))))]))
+              (internal-org-avatar s org-data show-org-avatar? hide-name show-avatar-and-name)]
+            (internal-org-avatar s org-data show-org-avatar? hide-name show-avatar-and-name))))]))


### PR DESCRIPTION
This rely on filestack update in cljsjs: https://github.com/cljsjs/packages/pull/1371

Once that is merged you can review this.
Right now we have an error if you try to upload an SVG image, that's because filestack API return an error when we try to resize the image to get a thumbnail.
Now we skip the thumbnail creation and we use the just uploaded image as thumbnail too.

To test:
- click New Post
- upload a PNG image
- check that `src` and `data-thumbnail` attributes of the uploaded image are different
- upload an SVG image
- check that you see the uploaded image in the post body
- check that now the 2 attributes are equal and there are no error in the console