### PR TITLE
Preload CSS images

### DIFF
--- a/scss/mixins/_reusable.scss
+++ b/scss/mixins/_reusable.scss
@@ -243,3 +243,25 @@
     background-image: cdnUrl($image + "@2x" + $suffix);
   }
 }
+
+@mixin preload_image($image_urls, $place: "after") {
+  @if $place == "after" {
+    &:after{
+      position:absolute;
+      width:0;
+      height:0;
+      overflow:hidden;
+      z-index:-1;
+      content: $image_urls;
+    }
+  } @else if $place == "before" {
+    &:before{
+      position:absolute;
+      width:0;
+      height:0;
+      overflow:hidden;
+      z-index:-1;
+      content: $image_urls;
+    }
+  }
+}

--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -145,6 +145,8 @@ div.left-navigation-sidebar {
         background-color: $carrot_green_2;
         background-image: cdnUrl("/img/ML/plus_button_icon_white.svg");
       }
+
+      @include preload_image(cdnUrl("/img/ML/plus_button_icon_white.svg"));
     }
   }
 


### PR DESCRIPTION
Add a preload images SCSS mixin that can be used to preload whatever image via CSS.
For now it preloads only the white plus icon used in the add board button.

To test:
- open an incognito tab or clean up all your browser cached data (better the first to make sure)
- signup
- create an org
- when you land on the welcome board check in the network tab if the image called `plus_button_icon_white.svg` is already loaded, was it? good
- follow the onboard and stop at the second bat signal tooltip, do you see the white plus appearing with the tooltip? good