### PR TITLE
Change service fixes

### DIFF
--- a/src/oc/web/components/ui/login_overlay.cljs
+++ b/src/oc/web/components/ui/login_overlay.cljs
@@ -244,7 +244,7 @@
 ;               {:value (:email (:signup-with-email (rum/react dis/app-state)))
 ;                :id "sign-up-email"
 ;                :on-change #(dis/dispatch! [:input [:signup-with-email :email] (.-value (sel1 [:input.email]))])
-;                :pattern "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$"
+;                :pattern "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$"
 ;                :placeholder "email@example.com"
 ;                :type "email"
 ;                :tabIndex 3

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -51,7 +51,7 @@
         [:input.field
           {:type "email"
            :class (when (= (:error signup-with-email) 409) "error")
-           :pattern "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$"
+           :pattern "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$"
            :value (:email signup-with-email)
            :on-change #(do
                          (reset! (::password-error s) false)

--- a/src/oc/web/components/ui/org_settings_invite_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_invite_panel.cljs
@@ -149,7 +149,7 @@
                     [:input.org-settings-field.email-field
                       {:type "text"
                        :class (when (:error user-data) "error")
-                       :pattern "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$"
+                       :pattern "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$"
                        :placeholder "email@example.com"
                        :on-change #(dis/dispatch! [:input [:invite-users] (assoc invite-users i (merge user-data {:error nil :user (.. % -target -value)}))])
                        :value (:user user-data)}])]


### PR DESCRIPTION
This PR is needed because `change-service` PR #259 has a couple of issues, the first is about this item in the test steps:
> Put user A and user B on the same board (what the heck, put the viewer on the board to). Create some content with A. Do B and the viewer see it immediately'ish? Is it NEW? Humdiggity.

And that's fixed by the first commit here, to test open the same board X with 3 users: 2 authors and a viewer and with the first of them add a post to X. Does the board autoupdate for user 2 and 3? Good.

The second issue, fixed with the second commit, it's that on firefox email addresses with uppercase letters will add the red error border around the email field in: signup with email, invite by email and login with email.
To test try to put this testEMAIL@ADDress.com one or all the 3 the specified places.