### PR TITLE
Change events

### DIFF
--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -1223,8 +1223,10 @@
         fixed-board-data (utils/fix-board board-data)]
     (api/get-org (dispatcher/org-data))
     (if (not= (:slug board-data) (router/current-board-slug))
-      ;; If creating a new board, redirect to that board page
-      (utils/after 100 #(router/nav! (oc-urls/board (router/current-org-slug) (:slug board-data))))
+      ;; If creating a new board, redirect to that board page, and watch the new board
+      (do
+        (utils/after 100 #(router/nav! (oc-urls/board (router/current-org-slug) (:slug board-data))))
+        (ws-cc/container-watch [(:uuid board-data)]))
       ;; If updating an existing board, refresh the org data
       (api/get-org (dispatcher/org-data)))
   (-> db

--- a/src/oc/web/lib/jwt.cljs
+++ b/src/oc/web/lib/jwt.cljs
@@ -32,6 +32,9 @@
 (defn team-id []
   (first (get-key :teams)))
 
+(defn user-id []
+  (get-key :user-id))
+
 (defn is-admin? [team-id]
   (let [admins (get-key :admin)]
     (some #{team-id} admins)))

--- a/src/oc/web/lib/ws_change_client.cljs
+++ b/src/oc/web/lib/ws_change_client.cljs
@@ -20,8 +20,9 @@
 
 (defn container-watch []
   (when @chsk-send!
-    (timbre/debug "Sending container/watch for:" @board-ids)
-    (@chsk-send! [:container/watch @board-ids] 1000)))
+    (let [watch-ids (conj @board-ids (:uuid (dis/org-data)))]
+      (timbre/debug "Sending container/watch for:" watch-ids)
+      (@chsk-send! [:container/watch watch-ids] 1000))))
 
 (defn container-seen [container-id]
   (when @chsk-send!

--- a/src/oc/web/lib/ws_change_client.cljs
+++ b/src/oc/web/lib/ws_change_client.cljs
@@ -18,11 +18,14 @@
 
 ;; ----- Actions -----
 
-(defn container-watch []
+(defn container-watch 
+  ([]
+  (container-watch (conj @board-ids (:uuid (dis/org-data)))))
+
+  ([watch-ids]
   (when @chsk-send!
-    (let [watch-ids (conj @board-ids (:uuid (dis/org-data)))]
-      (timbre/debug "Sending container/watch for:" watch-ids)
-      (@chsk-send! [:container/watch watch-ids] 1000))))
+    (timbre/debug "Sending container/watch for:" watch-ids)
+    (@chsk-send! [:container/watch watch-ids] 1000))))
 
 (defn container-seen [container-id]
   (when @chsk-send!


### PR DESCRIPTION
https://trello.com/c/Um6p3FXO

This is the Web UI portion of the broadening of change events to include all of:

- board add
- board update
- board delete
- entry add
- entry update
- entry delete

Rather than just entry add, which we had before.

Adds the org uuid to watched containers, so we are notified by change services of org level container change events (changes to a board). React to those changes by reloading the org so we see board adds/removes and updates in near real-time.

Adds watching of new boards created by you and created by others.

- [x] Review [https://github.com/open-company/open-company-change/pull/1](https://github.com/open-company/open-company-change/pull/1)
- [x] Review [https://github.com/open-company/open-company-storage/pull/93](https://github.com/open-company/open-company-storage/pull/93)
- [ ] Review the code
- [x] Create 2 users of the same org, A and B
- [x] Create a new board with A, does it appear for B?

For these next few, have them on the same board:

- [x] Add a post to the new board with B, does the new post appear for A?
- [x] Update the post headline with A, does the update appear for B
- [x] Delete the post with B, does it go away for A?

You can try these next 2 on the same board or while viewing different boards. The delete case on the same board will 404 for the non-deleter right now.

- [x] Rename the board for A, does the new name appear for B?
- [x] Delete the board with B, does it go away for A?

All set.

- [ ] Merge
- [ ] Learn to count cards and head to Vegas!
