### PR TITLE
Native emojis

### DIFF
--- a/resources/public/js/emojione/autocomplete.js
+++ b/resources/public/js/emojione/autocomplete.js
@@ -46,10 +46,10 @@ function emojiAutocomplete() {
               return emojiStrategy[shortname].unicode;
             },
             imageTemplate: function(shortname, unicode){
-              return '<img class="emojione emojione-'+unicode+'"  alt="'+unicodeChar(unicode)+'" title=":'+shortname+':"/>';
+              return unicodeChar(unicode);
             },
             SVGImageFromShortname: function(shortname){
-              return '<svg class="emojione"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="'+this.spritePath+'.svg#emoji-' +emojiStrategy[shortname].unicode+ '"></use></svg>';
+              return emojiStrategy[shortname].unicode;
             },
             PNGImageFromShortname: function(shortname){
               var unicode = this.unicodeFromShortname(shortname);

--- a/src/oc/web/components/ui/emoji_picker.cljs
+++ b/src/oc/web/components/ui/emoji_picker.cljs
@@ -39,11 +39,8 @@
     (.restoreSelection js/rangy @caret-pos)
     (let [unicode-str (googobj/get emoji "unicode")
           unicodes  (clojure.string/split unicode-str #"-")
-          unicode-c (apply str (map utils/unicode-char unicodes))
-          shortname (subs (googobj/get emoji "shortname") 1 (dec (count (googobj/get emoji "shortname"))))
-          ; new-html  (str "<img class=\"emojione\" alt=\"" unicode-c "\" src=\"//cdn.jsdelivr.net/emojione/assets/png/" unicode-str ".png?" (googobj/get js/emojione "cacheBustParam") "\"/>")
-          new-html  (str "<img class=\"emojione emojione-" unicode-str "\" data-unicode=\"" unicode-c "\" title=\":" shortname ":\" alt=\"" unicode-c "\" />")]
-        (js/pasteHtmlAtCaret new-html (.getSelection js/rangy js/window) false))))
+          unicode-c (apply str (map utils/unicode-char unicodes))]
+        (js/pasteHtmlAtCaret unicode-c (.getSelection js/rangy js/window) false))))
 
 (defn check-focus [s _]
   (let [active-element (googobj/get js/document "activeElement")]

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -665,21 +665,24 @@
   or ASCII emoji (old skool) and convert it to HTML string ready to be added to the DOM (dangerously)
   with emoji image tags via the Emoji One lib and resources."
   [text & [plain-text]]
-  ;; use an SVG sprite map
-  (set! (.-imageType js/emojione) "png")
-  (set! (.-sprites js/emojione) true)
-  (set! (.-spritePath js/emojione) "https://d1wc0stj82keig.cloudfront.net/emojione.sprites.png")
-  ;; convert ascii emoji's (like  :) and :D) into emojis
-  (set! (.-ascii js/emojione) true)
-  (let [text-string (or text "") ; handle nil
-        unicode-string (.toImage js/emojione text-string)
-        r (js/RegExp "<span " "ig")
-        with-img (.replace unicode-string r "<img ")
-        without-span (.replace with-img (js/RegExp ">(.{1,2})</span>" "ig") (str "alt=\"$1\" />"))]
+  ; ;; use an SVG sprite map
+  ; (set! (.-imageType js/emojione) "png")
+  ; (set! (.-sprites js/emojione) true)
+  ; (set! (.-spritePath js/emojione) "https://d1wc0stj82keig.cloudfront.net/emojione.sprites.png")
+  ; ;; convert ascii emoji's (like  :) and :D) into emojis
+  ; (set! (.-ascii js/emojione) true)
+  ; (let [text-string (or text "") ; handle nil
+  ;       unicode-string (.toImage js/emojione text-string)
+  ;       r (js/RegExp "<span " "ig")
+  ;       with-img (.replace unicode-string r "<img ")
+  ;       without-span (.replace with-img (js/RegExp ">(.{1,2})</span>" "ig") (str "alt=\"$1\" />"))]
 
-    (if plain-text
-      without-span
-      #js {"__html" without-span})))
+  ;   (if plain-text
+  ;     without-span
+  ;     #js {"__html" without-span}))
+  (if plain-text
+    text
+    #js {"__html" text}))
 
 (defn strip-HTML-tags [text]
   (when text


### PR DESCRIPTION
## NB: review after #271 

This is needed to resolve the problems emoji in headline are causing in Safari and FireFox.

Discussion happened in Slack and Talky but we finally decided that it was better to go with the native emojis for a number of benefits and one major problem: the picker still uses the image emojis.
We will fix this in a second moment most probably using this https://github.com/missive/emoji-mart or something close to it.

Card: https://trello.com/c/uVaZbfmZ