### PR TITLE
What's New api

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ provided in the table below:
 |  :user-profile-reset | UI | Reset the user profile data edited by the user but not yet saved. |
 |  :user-profile-save | UI | Save the edited user data. |
 |  :user-profile-update/failed | API | User profile update request failed. |
+|  :whats-new-modal-hide | UI | Hide the What's New modal. |
+|  :whats-new-modal-show | UI | Show the What's New modal. |
 |  :ws-interaction/comment-add | WS | Websocket message for an added comment. |
 |  :ws-interaction/reaction-add | WS | Websocket message for an added reaction. |
 |  :ws-interaction/reaction-delete | WS | Websocket message for a removed reaction. |

--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -91,6 +91,7 @@ var OCWebPrintAsciiArt = function(){};
 var OCWebConfigLogLevel = function(){};
 var OCWebPrintRouterPath = function(){};
 var OCWebForceRefreshToken = function(){};
+var OCWebPrintWhatsNewData = function(){};
 // Moment
 var moment = {};
 moment.tz = {};

--- a/scss/partials/_whats_new_modal.scss
+++ b/scss/partials/_whats_new_modal.scss
@@ -1,4 +1,4 @@
-div.about-carrot-modal-container {
+div.whats-new-modal-container {
   width: 100%;
   height: 100vh;
   position: fixed;
@@ -29,7 +29,7 @@ div.about-carrot-modal-container {
       margin-left: -378px;
     }
 
-    div.about-carrot-modal {
+    div.whats-new-modal {
       width: 700px;
       margin: 0px 0px 0px 28px;
       position: relative;

--- a/scss/partials/_whats_new_modal.scss
+++ b/scss/partials/_whats_new_modal.scss
@@ -56,6 +56,16 @@ div.whats-new-modal-container {
         margin: 0px auto;
       }
 
+      a {
+        @include avenir_H();
+        font-size: 28px;
+        color: $carrot_dark_blue;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+
       div.about-title {
         @include avenir_H();
         font-size: 28px;

--- a/scss/public/css/app.main.scss
+++ b/scss/public/css/app.main.scss
@@ -86,7 +86,7 @@
 @import "partials/_org_settings_invite_panel";
 @import "partials/_onboard_wrapper";
 @import "partials/_carrot_tip";
-@import "partials/_about_carrot_modal";
+@import "partials/_whats_new_modal";
 @import "partials/_activity_move";
 @import "partials/_onboard_overlay";
 @import "partials/_made_with_carrot_modal";

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -58,6 +58,8 @@
   (let [next-db (assoc db :latest-entry-point (.getTime (js/Date.)))]
     (if success
       (let [orgs (:items collection)]
+        (when-let [whats-new-link (utils/link-for (:links collection) "whats-new")]
+          (api/get-whats-new whats-new-link))
         (cond
           (and (:slack-lander-check-team-redirect db)
                (zero? (count orgs)))
@@ -1314,13 +1316,13 @@
     (api/patch-org (:org-editing db)))
   db)
 
-(defmethod dispatcher/action :about-carrot-modal-show
+(defmethod dispatcher/action :whats-new-modal-show
   [db [_]]
-  (assoc db :about-carrot-modal true))
+  (assoc db :whats-new-modal true))
 
-(defmethod dispatcher/action :about-carrot-modal-hide
+(defmethod dispatcher/action :whats-new-modal-hide
   [db [_]]
-  (dissoc db :about-carrot-modal))
+  (dissoc db :whats-new-modal))
 
 (defmethod dispatcher/action :org-settings-show
   [db [_ panel]]
@@ -1422,3 +1424,10 @@
     (-> db
       (dissoc :activity-loading)
       (assoc-in activity-key fixed-activity-data))))
+
+(defmethod dispatcher/action :whats-new/finish
+  [db [_ whats-new-data]]
+  (if whats-new-data
+    (let [fixed-whats-new-data (zipmap (map :uuid (:entries whats-new-data)) (:entries whats-new-data))]
+      (assoc-in db dispatcher/whats-new-key fixed-whats-new-data))
+    db))

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -203,6 +203,13 @@
       (fn [{:keys [status body success]}]
         (dispatcher/dispatch! [:board (json->cljs body)])))))
 
+(defn get-whats-new [whats-new-link]
+  (when whats-new-link
+    (storage-http (method-for-link whats-new-link) (relative-href whats-new-link)
+      {:headers (headers-for-link whats-new-link)}
+      (fn [{:keys [status body success]}]
+        (dispatcher/dispatch! [:whats-new/finish (if success (json->cljs body) {:entries []})])))))
+
 (defn patch-board [data]
   (when data
     (let [board-data (select-keys data [:name :slug :access :slack-mirror])

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -184,6 +184,6 @@
             [:div.invite-people-icon]
             [:span "Invite People"]])
         [:button.mlb-reset.about-carrot-btn
-          {:on-click #(dis/dispatch! [:about-carrot-modal-show])}
+          {:on-click #(dis/dispatch! [:whats-new-modal-show])}
           [:div.about-carrot-icon]
           [:span "About Carrot"]]]]))

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -17,7 +17,7 @@
             [oc.web.components.ui.onboard-overlay :refer (onboard-overlay)]
             [oc.web.components.ui.media-video-modal :refer (media-video-modal)]
             [oc.web.components.ui.media-chart-modal :refer (media-chart-modal)]
-            [oc.web.components.ui.about-carrot-modal :refer (about-carrot-modal)]
+            [oc.web.components.ui.whats-new-modal :refer (whats-new-modal)]
             [oc.web.components.ui.activity-share-link :refer (activity-share-link)]
             [oc.web.components.ui.activity-share-email :refer (activity-share-email)]
             [oc.web.components.ui.activity-share-slack :refer (activity-share-slack)]
@@ -67,8 +67,8 @@
             (:org-settings data)
             (org-settings)
             ;; About carrot
-            (:about-carrot-modal data)
-            (about-carrot-modal)
+            (:whats-new-modal data)
+            (whats-new-modal)
             ;; Made with carrot modal
             (:made-with-carrot-modal data)
             (made-with-carrot-modal)

--- a/src/oc/web/components/secure_activity.cljs
+++ b/src/oc/web/components/secure_activity.cljs
@@ -15,7 +15,6 @@
 
 (rum/defcs secure-activity < rum/reactive
                           (drv/drv :secure-activity-data)
-                          (drv/drv :about-carrot-modal)
                           (drv/drv :made-with-carrot-modal)
                           {:will-mount (fn [s]
                                          (utils/after 100 #(dis/dispatch! [:activity-get]))

--- a/src/oc/web/components/ui/whats_new_modal.cljs
+++ b/src/oc/web/components/ui/whats_new_modal.cljs
@@ -57,13 +57,17 @@
             (let [whats-new-data (drv/react s :whats-new-data)]
               (when (map? whats-new-data)
                 (let [sorted-whats-new (reverse (sort-by :published-at (vals whats-new-data)))]
-                  (for [n sorted-whats-new]
+                  (for [n sorted-whats-new
+                        :let [secure-url (oc-urls/secure-activity "carrot" (:secure-uuid n))]]
                     [:div.news
                       {:key (str "about-news-" (:uuid n))}
                       [:div.news-date
                         (utils/time-since (utils/js-date (:published-at n)))]
-                      [:div.news-title
-                        {:dangerouslySetInnerHTML (utils/emojify (:headline n))}]
+                      [:a
+                        {:href secure-url
+                         :on-click #(do (utils/event-stop %) (router/nav! secure-url))}
+                        [:div.news-title
+                          {:dangerouslySetInnerHTML (utils/emojify (:headline n))}]]
                       [:div.news-body
                         {:dangerouslySetInnerHTML (utils/emojify (:body n))}]]))))]
           (all-caught-up)]]]])

--- a/src/oc/web/components/ui/whats_new_modal.cljs
+++ b/src/oc/web/components/ui/whats_new_modal.cljs
@@ -25,49 +25,50 @@
                              mixins/no-scroll-mixin
                              mixins/first-render-mixin
   [s]
-  [:div.whats-new-modal-container
-    {:class (utils/class-set {:will-appear (or @(::dismiss s) (not @(:first-render-done s)))
-                              :appear (and (not @(::dismiss s)) @(:first-render-done s))})}
-    [:div.modal-wrapper
-      [:button.carrot-modal-close.mlb-reset
-        {:on-click #(close-clicked s)}]
-      [:div.whats-new-modal
-        [:div.carrot-logo]
-        [:div.about-title
-          "What’s New with Carrot"]
-        [:div.about-links
-          [:a.about-link
-            {:href oc-urls/about
-             :on-click #(do (utils/event-stop %) (router/nav! oc-urls/about))}
-            "Company"]
-          [:a.about-link
-            {:href oc-urls/help}
-            "Help"]
-          [:a.about-link
-            {:href oc-urls/contact-mail-to}
-            "Contact"]
-          [:a.about-link.twitter
-            {:href oc-urls/oc-twitter}
-            ""]
-          [:a.about-link.medium
-            {:href oc-urls/blog}
-            ""]]
-        [:div.news-list-container
-          [:div.news-list
-            (let [whats-new-data (drv/react s :whats-new-data)]
-              (when (map? whats-new-data)
-                (let [sorted-whats-new (reverse (sort-by :published-at (vals whats-new-data)))]
-                  (for [n sorted-whats-new
-                        :let [secure-url (oc-urls/secure-activity "carrot" (:secure-uuid n))]]
-                    [:div.news
-                      {:key (str "about-news-" (:uuid n))}
-                      [:div.news-date
-                        (utils/time-since (utils/js-date (:published-at n)))]
-                      [:a
-                        {:href secure-url
-                         :on-click #(do (utils/event-stop %) (router/nav! secure-url))}
-                        [:div.news-title
-                          {:dangerouslySetInnerHTML (utils/emojify (:headline n))}]]
-                      [:div.news-body
-                        {:dangerouslySetInnerHTML (utils/emojify (:body n))}]]))))]
-          (all-caught-up)]]]])
+
+  (let [whats-new-data (drv/react s :whats-new-data)]
+
+    [:div.whats-new-modal-container
+      {:class (utils/class-set {:will-appear (or @(::dismiss s) (not @(:first-render-done s)))
+                                :appear (and (not @(::dismiss s)) @(:first-render-done s))})}
+      [:div.modal-wrapper
+        [:button.carrot-modal-close.mlb-reset
+          {:on-click #(close-clicked s)}]
+        [:div.whats-new-modal
+          [:div.carrot-logo]
+          [:div.about-title
+            (if (empty? whats-new-data)
+              "About Carrot"
+              "What’s New with Carrot")]
+          [:div.about-links
+            [:a.about-link
+              {:href oc-urls/about
+               :on-click #(do (utils/event-stop %) (router/nav! oc-urls/about))}
+              "Company"]
+            [:a.about-link
+              {:href oc-urls/help}
+              "Help"]
+            [:a.about-link
+              {:href oc-urls/contact-mail-to}
+              "Contact"]
+            [:a.about-link.twitter
+              {:href oc-urls/oc-twitter}
+              ""]
+            [:a.about-link.medium
+              {:href oc-urls/blog}
+              ""]]
+          (when (not (empty? whats-new-data))
+            [:div.news-list-container
+              [:div.news-list
+                  (let [sorted-whats-new (reverse (sort-by :published-at (vals whats-new-data)))]
+                    (for [n sorted-whats-new
+                          :let [secure-url (oc-urls/secure-activity "carrot" (:secure-uuid n))]]
+                      [:div.news
+                        {:key (str "about-news-" (:uuid n))}
+                        [:div.news-date
+                          (utils/time-since (utils/js-date (:published-at n)))]
+                          [:div.news-title
+                            {:dangerouslySetInnerHTML (utils/emojify (:headline n))}]
+                        [:div.news-body
+                          {:dangerouslySetInnerHTML (utils/emojify (:body n))}]]))]
+              (all-caught-up)])]]]))

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -60,6 +60,8 @@
 (defn team-channels-key [team-id]
   [:teams-data team-id :channels])
 
+(def whats-new-key [:whats-new-data])
+
 ;; Derived Data ================================================================
 
 (defn drv-spec [db route-db]
@@ -103,7 +105,8 @@
    :subscription        [[:base] (fn [base] (:subscription base))]
    :show-login-overlay  [[:base] (fn [base] (:show-login-overlay base))]
    :rum-popover-data    [[:base] (fn [base] (:rum-popover-data base))]
-   :about-carrot-modal  [[:base] (fn [base] (:about-carrot-modal base))]
+   :whats-new-modal     [[:base] (fn [base] (:whats-new-modal base))]
+   :whats-new-data      [[:base] (fn [base] (get-in base whats-new-key))]
    :made-with-carrot-modal [[:base] (fn [base] (:made-with-carrot-modal base))]
    :org-data            [[:base :org-slug]
                           (fn [base org-slug]
@@ -404,6 +407,9 @@
 (defn print-story-editing-data []
   (js/console.log (get @app-state :story-editing)))
 
+(defn print-whats-new-data []
+  (js/console.log (get-in @app-state whats-new-key)))
+
 (set! (.-OCWebPrintAppState js/window) print-app-state)
 (set! (.-OCWebPrintOrgData js/window) print-org-data)
 (set! (.-OCWebPrintAllPostsData js/window) print-all-posts-data)
@@ -419,3 +425,4 @@
 (set! (.-OCWebPrintActivityCommentsData js/window) print-comments-data)
 (set! (.-OCWebPrintEntryEditingData js/window) print-entry-editing-data)
 (set! (.-OCWebPrintStoryEditingData js/window) print-story-editing-data)
+(set! (.-OCWebPrintWhatsNewData js/window) print-whats-new-data)


### PR DESCRIPTION
Card: https://trello.com/c/Q1pKWJIs

Look in the storage entry point request, if there in the links collection there is one with the rel `whats-new` it will be loaded and the entries will be shown in the What's New modal listed from the newest.

Additional feature: link each item to the readonly post page (ie: shared post page).