### PR TITLE
All posts improvements

### DIFF
--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -29,6 +29,17 @@ $h2_top_margin: 20;
     font-size: 12px;
     white-space: nowrap;
 
+    time a.board-name {
+      text-decoration: none;
+      @include avenir_H();
+      color: $carrot_light_gray_3;
+      font-size: 12px;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
     div.tooltip {
       .tooltip-inner {
         white-space:pre-wrap;

--- a/scss/partials/_activity_card.scss
+++ b/scss/partials/_activity_card.scss
@@ -10,18 +10,18 @@ div.activity-card {
   &:hover, &.dropdown-active {
     box-shadow: 0 4px 10px 0 rgba(0,0,0,0.15);
 
-    div.activity-card-head.entry-card {
+    div.activity-card-head {
       background-color: $carrot_light_gray_5;
-    }
 
-    div.activity-card-head div.activity-card-head-right {
-      div.activity-tag {
-        background-color: $carrot_light_gray_6;
-      }
+      div.activity-card-head-right {
+        div.activity-tag {
+          background-color: $carrot_light_gray_6;
+        }
 
-      div.more-button {
-        button.more-ellipsis {
-          opacity: 0.8;
+        div.more-button {
+          button.more-ellipsis {
+            opacity: 0.8;
+          }
         }
       }
     }
@@ -157,12 +157,9 @@ div.activity-card {
     width: 100%;
     padding: 16px 24px;
     height: 72px;
-
-    &.entry-card {
-      background-color: $carrot_light_gray_2;
-      border-top-left-radius: 4px;
-      border-top-right-radius: 4px;
-    }
+    background-color: $carrot_light_gray_2;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
 
     div.activity-card-head-author {
       float: left;
@@ -202,10 +199,6 @@ div.activity-card {
         text-overflow: ellipsis;
         overflow: hidden;
         margin-right: 8px;
-
-        &.double-tag {
-          max-width: 50%;
-        }
       }
 
       @include activity-tag();

--- a/src/oc/web/components/activity_card.cljs
+++ b/src/oc/web/components/activity_card.cljs
@@ -191,11 +191,9 @@
                        [:activity-modal-fade-in
                         (:board-slug activity-data)
                         (:uuid activity-data)
-                        (:type activity-data)]))))
-     }
+                        (:type activity-data)]))))}
       ; Card header
-      [:div.activity-card-head.group
-        {:class "entry-card"}
+      [:div.activity-card-head.entry-card.group
         ; Card author
         [:div.activity-card-head-author
           (user-avatar-image (:publisher activity-data))
@@ -208,7 +206,14 @@
                  :data-placement "top"
                  :data-delay "{\"show\":\"1000\", \"hide\":\"0\"}"
                  :title (utils/activity-date-tooltip activity-data)}
-                (utils/time-since t)])]]
+                (utils/time-since t)
+                (when is-all-posts
+                  [" in "
+                   (let [board-url (utils/get-board-url (router/current-org-slug) (:board-slug activity-data))]
+                     [:a.board-name
+                       {:href board-url
+                        :on-click #(do (utils/event-stop %) (router/nav! board-url))}
+                       (:board-name activity-data)])])])]]
         ; Card labels
         [:div.activity-card-head-right
           (when (or (utils/link-for (:links activity-data) "partial-update")
@@ -252,22 +257,15 @@
           (when (:topic-slug activity-data)
             (let [topic-name (or (:topic-name activity-data) (s/upper (:topic-slug activity-data)))]
               [:div.activity-tag.on-gray
-                {:class (when is-all-posts "double-tag")
-                 :on-click #(router/nav!
+                {:on-click #(router/nav!
                              (oc-urls/board-filter-by-topic
                               (router/current-org-slug)
                               (:board-slug activity-data)
                               (:topic-slug activity-data)))}
                 topic-name]))
-          (when is-all-posts
-            [:div.activity-tag
-              {:class (utils/class-set {:board-tag true
-                                        :double-tag (:topic-slug activity-data)})
-               :on-click #(router/nav! (utils/get-board-url (router/current-org-slug) (:board-slug activity-data)))}
-              (:board-name activity-data)])
-                ;; TODO This will be replaced w/ new Ryan new design, be sure to clean up CSS too when this changes
-                ;;(when is-new [:div.new-tag "New"])
-                ]]
+          ;; TODO This will be replaced w/ new Ryan new design, be sure to clean up CSS too when this changes
+          ;;(when is-new [:div.new-tag "New"])
+          ]]
       [:div.activity-card-content.group
         ; Headline
         [:div.activity-card-headline

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -126,9 +126,8 @@
             {:class (when is-all-posts "item-selected")
              :href (oc-urls/all-posts)
              :on-click #(anchor-nav! % (oc-urls/all-posts))}
-            [:div.all-posts-icon]
             [:div.all-posts-label
-                "All Posts"]])
+              "All Posts"]])
         ;; Boards list
         (when show-boards
           [:div.left-navigation-sidebar-top.group


### PR DESCRIPTION
Slack discussion, Stuart said:
> @here if you open up All Posts you’ll see the Boards icon in the board label. That grid icon used to make more sense because we also showed it in navigation; but not any more.

> I think it can be confusing. I’m always a little surprised by it when I go into AP because I don’t see it anywhere else. 

> Why not just add the board name to the time stamp, e.g. “1 day ago in Design” or “October 29 in Product Feedback”? Then we’d only have the Topic pillbox if there is one which is more consistent.

I added the link to the board in bold.

Tests:
- [ ] Review the code
- [ ] Open All Posts, do you NOT see the icon besides the link in left nav? Good
- [ ] Do you NOT see the board name in the boards top right? Good
- [ ] Do you see the board name in bold besides the post creation/update date? Good
- [ ] Is it clickable and sends you to the last viewed sort of that board? Good
- [ ] Merge
- [ ] Do one of Sean's things when you close a PR