### PR TITLE
By topic stuck situation

### DIFF
--- a/src/oc/web/components/topics_columns.cljs
+++ b/src/oc/web/components/topics_columns.cljs
@@ -222,7 +222,7 @@
               (when (and (not is-mobile-size?)
                          (not empty-board?)
                          (not is-all-posts)
-                         (or (string? board-filters) (> (count entry-topics) 1)))
+                         (or (not board-filters) (not= board-filters :latest) (> (count entry-topics) 1)))
                 (filters-dropdown))
               ;; Add entry floating button
               (when (and (not is-all-posts)

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -432,56 +432,18 @@
 
     (defroute board-route (urls/board ":org" ":board") {:as params}
       (timbre/info "Routing board-route" (urls/board ":org" ":board"))
-      (board-handler
-       "dashboard"
-       target
-       org-dashboard
-       params
-       (or
-        (keyword
-         (cook/get-cookie
-          (router/last-board-filter-cookie
-           (:org (:params params))
-           (:board (:params params)))))
-        :latest)))
+      (board-handler "dashboard" target org-dashboard params :latest))
 
     (defroute board-slash-route (str (urls/board ":org" ":board") "/") {:as params}
       (timbre/info "Routing board-route-slash" (str (urls/board ":org" ":board") "/"))
-      (board-handler
-       "dashboard"
-       target
-       org-dashboard
-       params
-       (or
-        (keyword
-         (cook/get-cookie
-          (router/last-board-filter-cookie
-           (:org (:params params))
-           (:board (:params params)))))
-        :latest)))
+      (board-handler "dashboard" target org-dashboard params :latest))
 
     (defroute board-sort-by-topic-route (urls/board-sort-by-topic ":org" ":board") {:as params}
       (timbre/info "Routing board-sort-by-topic-route" (urls/board-sort-by-topic ":org" ":board"))
-      (when (=
-             (keyword
-              (cook/get-cookie
-               (router/last-board-filter-cookie
-                (:org (:params params))
-                (:board (:params params)))))
-             :latest)
-        (router/redirect! (urls/board (:org (:params params)) (:board (:params params)))))
       (board-handler "dashboard" target org-dashboard params :by-topic))
 
     (defroute board-sort-by-topic-slash-route (str (urls/board-sort-by-topic ":org" ":board") "/") {:as params}
       (timbre/info "Routing board-sort-by-topic-slash-route" (str (urls/board-sort-by-topic ":org" ":board") "/"))
-      (when (=
-             (keyword
-              (cook/get-cookie
-               (router/last-board-filter-cookie
-                (:org (:params params))
-                (:board (:params params)))))
-             :latest)
-        (router/redirect! (urls/board (:org (:params params)) (:board (:params params)))))
       (board-handler "dashboard" target org-dashboard params :by-topic))
 
     (defroute board-filter-by-topic-route (urls/board-filter-by-topic ":org" ":board" ":topic-filter") {:as params}


### PR DESCRIPTION
From Slack, Sean:
> http://take.ms/LRHIn
>  I'm in by-topic view, but since my 2 topics are a topic and no topic, I have no ability to switch out of it
> even if I try manually, removing `by-topic` from the URL, the view is the same: http://take.ms/t8O83 

To test the stuck situation:
- Create a board with at least 2 posts and 2 different topics
- Go to by topic
- Edit a post and remove a topic
- [x] Do you still see the board filters dropdown with only Recent, By topic and one single topic? Good
- Select the single topic
- [x] Can you get out of the topic filter? Good
- [x] Can you select recent? Good
- [x] Do you NOT see the filters dropdown now that you are in latest? Good
- You are not stuck! At least on Carrot..

To test you can visit latest even if your cookie says by topic:
- Create 2 boards with at least 2 topics both: A and B
- Visit board A and select by topic filter
- Visit board B and stay on recent
- [x] Now write in the url /your-org/A, do you it in latest view? Good, no cookie used
- [x] Write in the url /your-org/B/by-topic, do you see it in by topic view? Good, no cookie used
- Go to All Posts
- Click on board B on the pillbox of one of the posts
- [x] Are you redirected to /your-org/B/by-topic? Good, the cookie was used