### PR TITLE
Remove board icons form All Posts pillboxes.

### DIFF
--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -60,16 +60,28 @@ $h2_top_margin: 20;
 
     &.on-gray {
       &:hover, &:active, &:focus, &.active {
-        background-color: $carrot_purple !important;
+        background-color: $carrot_purple;
         color: white;
         cursor: pointer;
+
+        &.board-tag {
+          background-color: $carrot_text_blue_3;
+          color: white;
+          cursor: pointer;
+        }
       }
     }
 
     &:hover, &:active, &:focus, &.active {
-      background-color: $carrot_light_purple !important;
+      background-color: $carrot_light_purple;
       color: $carrot_purple;
       cursor: pointer;
+
+      &.board-tag {
+        color: $carrot_text_blue_3;
+        background-color: $carrot_light_blue_2;
+        cursor: pointer;
+      }
     }
   }
 }

--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -71,24 +71,6 @@ $h2_top_margin: 20;
       color: $carrot_purple;
       cursor: pointer;
     }
-
-    &.board-tag {
-
-      &:hover:before {
-        background-image: cdnUrl("/img/ML/boards_icon_blue.png");
-      }
-
-      &:before {
-        display: inline-block;
-        margin-right: 4px;
-        content: "";
-        background-image: cdnUrl("/img/ML/boards_icon_gray.png");
-        background-size: 12px 10px;
-        background-repeat: no-repeat;
-        width: 12px;
-        height: 10px;
-      }
-    }
   }
 }
 

--- a/src/oc/web/components/activity_card.cljs
+++ b/src/oc/web/components/activity_card.cljs
@@ -259,9 +259,8 @@
                               (:topic-slug activity-data)))}
                 topic-name]))
           (when is-all-posts
-            [:div.activity-tag
-              {:class (utils/class-set {:board-tag true
-                                        :double-tag (:topic-slug activity-data)})
+            [:div.activity-tag.on-gray
+              {:class (utils/class-set {:double-tag (:topic-slug activity-data)})
                :on-click #(router/nav! (utils/get-board-url (router/current-org-slug) (:board-slug activity-data)))}
               (:board-name activity-data)])
                 ;; TODO This will be replaced w/ new Ryan new design, be sure to clean up CSS too when this changes

--- a/src/oc/web/components/activity_card.cljs
+++ b/src/oc/web/components/activity_card.cljs
@@ -259,7 +259,7 @@
                               (:topic-slug activity-data)))}
                 topic-name]))
           (when is-all-posts
-            [:div.activity-tag.on-gray
+            [:div.activity-tag.board-tag.on-gray
               {:class (utils/class-set {:double-tag (:topic-slug activity-data)})
                :on-click #(router/nav! (utils/get-board-url (router/current-org-slug) (:board-slug activity-data)))}
               (:board-name activity-data)])


### PR DESCRIPTION
From Stuart in Slack:
> so the only real change is putting the AP icon back, and taking the boards icon off

...from the AP pillboxes

To test:
- [x] Check that the icon is gone from AP posts pillboxes