### PR TITLE
Comment box resize.

### DIFF
--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -34,7 +34,7 @@ div.comments {
     top: 0;
 
     &.add-comment-focus {
-      padding-bottom: 148px;
+      height: calc(100% - 123px);
     }
 
     div.comments-internal-scroll {
@@ -152,7 +152,7 @@ div.comments {
 
       left: 0;
       right: 0;
-      bottom: 12px;
+      bottom: 0px;
       width: 100%;
       margin-top: 16px;
 

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -25,13 +25,17 @@ div.comments {
 
   div.comments-internal {
     min-height: 127px;
-    height: calc(100% - 123px);
+    height: calc(100% - 58px);
     width: 100%;
     position: relative;
     bottom: 8px;
     left: 0;
     right: 0;
     top: 0;
+
+    &.add-comment-focus {
+      padding-bottom: 148px;
+    }
 
     div.comments-internal-scroll {
       overflow-x: hidden;
@@ -139,8 +143,13 @@ div.comments {
       border-radius: 4px;
       border: 1px solid rgba($carrot_light_gray_1, 0.5);
       box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.07);
-      padding: 16px;
       position: relative;
+      padding: 12px;
+
+      &.show-buttons {
+        padding: 16px;
+      }
+
       left: 0;
       right: 0;
       bottom: 12px;
@@ -193,7 +202,11 @@ div.comments {
           color: $carrot_light_gray_3;
           font-size: 13px;
           cursor: text;
-          height: 58px;
+
+          &.show-buttons {
+            height: 58px;
+          }
+
           margin-bottom: 4px;
           overflow: auto;
 

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -100,12 +100,12 @@
                             (dis/dispatch! [:comment-add activity-data (add-comment-content add-comment-div)])
                             (set! (.-innerHTML add-comment-div) ""))
                :disabled @(::add-button-disabled s)}
-              "Add"]]]]
-      (when (and (not (js/isIE)) @(::show-buttons s))
-        (emoji-picker {:width 32
-                       :height 32
-                       :add-emoji-cb #(enable-add-comment? s)
-                       :container-selector "div.add-comment-box"}))])))
+              "Add"]]])]
+     (when (and (not (js/isIE)) @(::show-buttons s))
+       (emoji-picker {:width 32
+                      :height 32
+                      :add-emoji-cb #(enable-add-comment? s)
+                      :container-selector "div.add-comment-box"}))]))
 
 (defn scroll-to-bottom [s]
   (when-let* [dom-node (utils/rum-dom-node s)

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -52,10 +52,12 @@
                          (drv/drv :current-user-data)
                          (drv/drv :comment-add-finish)
                          (rum/local true ::add-button-disabled)
+                         (rum/local false ::show-buttons)
                          rum/static
                          first-render-mixin
                          {:did-mount (fn [s]
                                        (utils/after 2500 #(js/emojiAutocomplete))
+                                       (dis/dispatch! [:input [:add-comment-focus] false])
                                        s)
                           :after-render (fn [s]
                                           (when (and (not @(::show-successful s))
@@ -69,33 +71,41 @@
   [s activity-data]
   (let [current-user-data (drv/react s :current-user-data)]
     [:div.add-comment-box
-      (when @(::show-successful s)
-        [:div.successfully-posted
-          "Comment was posted successfully!"])
-      [:div.add-comment-internal
-        [:div.add-comment.emoji-autocomplete.emojiable
-          {:ref "add-comment"
-           :content-editable true
-           :on-key-up #(enable-add-comment? s)
-           :on-focus #(enable-add-comment? s)
-           :on-blur #(enable-add-comment? s)
-           :on-paste #(do
-                        (js/OnPaste_StripFormatting (rum/ref-node s "add-comment") %)
-                        (enable-add-comment? s))
-           :placeholder "Share your thoughts..."}]
+      {:class (utils/class-set {:show-buttons @(::show-buttons s)})}
+     (when @(::show-successful s)
+       [:div.successfully-posted
+         "Comment was posted successfully!"])
+     [:div.add-comment-internal
+       [:div.add-comment.emoji-autocomplete.emojiable
+         {:ref "add-comment"
+          :content-editable true
+          :on-key-up #(enable-add-comment? s)
+          :on-focus #(do
+                       (enable-add-comment? s)
+                       (dis/dispatch! [:input [:add-comment-focus] true])
+                       (reset! (::show-buttons s) true))
+          :on-blur #(enable-add-comment? s)
+          :on-paste #(do
+                       (js/OnPaste_StripFormatting (rum/ref-node s "add-comment") %)
+                       (enable-add-comment? s))
+          :placeholder "Share your thoughts..."
+          :class (utils/class-set {:show-buttons @(::show-buttons s)})}]
+      (when @(::show-buttons s)
         [:div.add-comment-footer.group
           [:div.reply-button-container
             [:button.mlb-reset.mlb-default.reply-btn
               {:on-click #(let [add-comment-div (rum/ref-node s "add-comment")]
+                            (reset! (::show-buttons s) false)
+                            (dis/dispatch! [:input [:add-comment-focus] false])
                             (dis/dispatch! [:comment-add activity-data (add-comment-content add-comment-div)])
                             (set! (.-innerHTML add-comment-div) ""))
                :disabled @(::add-button-disabled s)}
               "Add"]]]]
-      (when-not (js/isIE)
+      (when (and (not (js/isIE)) @(::show-buttons s))
         (emoji-picker {:width 32
                        :height 32
                        :add-emoji-cb #(enable-add-comment? s)
-                       :container-selector "div.add-comment-box"}))]))
+                       :container-selector "div.add-comment-box"}))])))
 
 (defn scroll-to-bottom [s]
   (when-let* [dom-node (utils/rum-dom-node s)
@@ -113,9 +123,9 @@
 
 (rum/defcs comments < (drv/drv :activity-comments-data)
                       (drv/drv :comment-add-finish)
+                      (drv/drv :add-comment-focus)
                       rum/reactive
                       rum/static
-                      (rum/local false ::add-comment-focus)
                       (rum/local false ::needs-gradient)
                       (rum/local false ::comments-requested)
                       (rum/local true  ::scroll-bottom-after-render)
@@ -141,6 +151,7 @@
                                        s)}
   [s activity-data]
   (let [comments-data (drv/react s :activity-comments-data)
+        add-comment-focus (drv/react s :add-comment-focus)
         sorted-comments (:sorted-comments comments-data)
         needs-gradient @(::needs-gradient s)]
     (if (and (zero? (count sorted-comments))
@@ -152,8 +163,8 @@
         (when needs-gradient
           [:div.top-gradient])
         [:div.comments-internal
-          {:class (utils/class-set {:add-comment-focus (and (pos? (count sorted-comments)) @(::add-comment-focus s))
-                                    :empty (zero? (count sorted-comments))})}
+         {:class (utils/class-set {:add-comment-focus add-comment-focus
+                                   :empty (zero? (count sorted-comments))})}
           (if (pos? (count sorted-comments))
             [:div.comments-internal-scroll
              {:on-scroll (fn [e]
@@ -167,8 +178,7 @@
                              (.data comments-internal-scroll "lastScrollTop" (.scrollTop comments-internal-scroll))))}
               (for [c sorted-comments]
                 (rum/with-key (comment-row c) (str "activity-" (:uuid activity-data) "-comment-" (:created-at c))))]
-            (when-not @(::add-comment-focus s)
-              [:div.comments-internal-empty
-                [:div.no-comments-placeholder]
-                [:div.no-comments-message "No comments yet. Jump in and let everyone know what you think!"]]))
+            [:div.comments-internal-empty
+              [:div.no-comments-placeholder]
+              [:div.no-comments-message "No comments yet. Jump in and let everyone know what you think!"]])
           (add-comment activity-data)]])))

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -259,6 +259,7 @@
    :media-input           [[:base]
                             (fn [base]
                               (:media-input base))]
+   :add-comment-focus     [[:base] (fn [base] (:add-comment-focus base))]
    :comment-add-finish    [[:base] (fn [base] (:comment-add-finish base))]})
 
 ;; Action Loop =================================================================


### PR DESCRIPTION
Until you click in the comment box, have it just be 1 line high with “Share your thoughts…”. Once it has focus, it should be the same size as now with the Emoji and Add button

To test:

- open a post with comments
- click the "Share your thoughts..."
- [x] Does the input resize and show the emoji and add buttons?
- [x] Does adding a comment resize it back to the smaller version?
- [x] Does closing the post also resize it after reopening the closed post?

merge