### PR TITLE
Org name fix

### DIFF
--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -92,27 +92,9 @@ nav.oc-navbar {
         @include avenir_H();
         font-size: 26px;
 
-        div.org-avatar {
+        button.orgs-dropdown div.org-avatar {
           height: 40px;
           @include org-avatar(40);
-        }
-
-        div.orgs-dropdown {
-          ul.dropdown-menu {
-            li div.org-avatar {
-              height: 24px;
-              @include org-avatar(24);
-
-              div.org-avatar-container {
-                span.org-name {
-                  @include avenir_M();
-                  font-size: 14px;
-                  color: $oc_gray_5;
-                  margin-top: 6px;
-                }
-              }
-            }
-          }
         }
       }
     }

--- a/scss/partials/_orgs_dropdown.scss
+++ b/scss/partials/_orgs_dropdown.scss
@@ -84,6 +84,9 @@ div.orgs-dropdown {
 
       div.org-avatar {
         width: 120px;
+        height: 24px;
+        overflow: hidden;
+        @include org-avatar(24);
 
         div.org-avatar-container {
           width: 120px;
@@ -97,19 +100,20 @@ div.orgs-dropdown {
             @include avenir_M();
             font-size: 14px;
             color: $oc_gray_5;
-            // margin-top: -26px;
             margin-left: 8px;
             overflow: hidden;
             text-overflow: ellipsis;
-            width: 90px;
+            max-width: 90px;
             display: inline;
             white-space: pre;
             float: left;
             max-width: 88px;
             width: auto !important;
+            margin-top: 6px;
 
             &.no-logo {
               margin-left: 32px !important;
+              margin-top: 6px !important;
             }
           }
         }

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -262,7 +262,7 @@
                           (dis/dispatch! [:input [:org-editing] (merge org-editing {:logo-url nil
                                                                                     :logo-width 0
                                                                                     :logo-height 0})])))}
-            (org-avatar org-editing false true)
+            (org-avatar org-editing false :never)
             [:div.add-picture-link
               (if (empty? (:logo-url org-editing))
                 "Upload logo"
@@ -435,7 +435,7 @@
                           (dis/dispatch! [:input [:org-editing] (merge org-editing {:logo-url nil
                                                                                     :logo-width 0
                                                                                     :logo-height 0})])))}
-            (org-avatar org-editing false true)
+            (org-avatar org-editing false :never)
             [:div.add-picture-link
               (if (empty? (:logo-url org-editing))
                 "Upload logo"

--- a/src/oc/web/components/ui/org_avatar.cljs
+++ b/src/oc/web/components/ui/org_avatar.cljs
@@ -6,25 +6,34 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]))
 
-(defn internal-org-avatar
-  [s org-data show-org-avatar? show-org-name? & [max-logo-height]]
-  (let [fixed-max-logo-height (or max-logo-height 42)]
-    [:div.org-avatar-container.group
-      (when show-org-avatar?
-        [:img.org-avatar-img
-          {:src (:logo-url org-data)
-           :style #js {:height (str (:logo-height org-data) "px")
-                       :marginTop (when (< (:logo-height org-data) fixed-max-logo-height)
-                                   (str (/ (- fixed-max-logo-height (:logo-height org-data)) 2) "px"))}
-           :on-error #(reset! (::img-load-failed s) true)}])
-      (when show-org-name?
-        [:span.org-name
-          {:class (when-not show-org-avatar? "no-logo")
-           :dangerouslySetInnerHTML (utils/emojify (:name org-data))}])]))
+(def default-max-logo-height 42)
 
-(rum/defcs org-avatar < rum/static
-                        (rum/local false ::img-load-failed)
-  [s org-data should-show-link & [hide-name]]
+(defn internal-org-avatar
+  [s org-data show-org-avatar? show-org-name?]
+  [:div.org-avatar-container.group
+    (when show-org-avatar?
+      [:img.org-avatar-img
+        {:src (:logo-url org-data)
+         :style #js {:height (str (:logo-height org-data) "px")
+                     :marginTop (when (< (:logo-height org-data) default-max-logo-height)
+                                 (str (/ (- default-max-logo-height (:logo-height org-data)) 2) "px"))}
+         :on-error #(reset! (::img-load-failed s) true)}])
+    (when show-org-name?
+      [:span.org-name
+        {:class (when-not show-org-avatar? "no-logo")
+         :dangerouslySetInnerHTML (utils/emojify (:name org-data))}])])
+
+(rum/defcs org-avatar
+  "Org avatar component, params:
+   - should-show-link: add anchor tag around the avatar linked to the company page
+   - show-org-name: possible values:
+       * :always
+       * :never
+       * :auto (default)
+      auto means that it's shown if the org logo is empty."
+  < rum/static
+    (rum/local false ::img-load-failed)
+  [s org-data should-show-link & [show-org-name]]
   (let [org-logo (:logo-url org-data)]
     [:div.org-avatar
       {:class (when (empty? org-logo) "missing-logo")}
@@ -39,18 +48,24 @@
                                     (not (clojure.string/blank? org-logo))
                                     (pos? (:logo-height org-data))
                                     (pos? (:logo-width org-data)))
-              avatar-link (if should-show-link
+              show-org-name? (case show-org-name
+                               :always
+                               true
+                               :never
+                               false
+                               ;; else
+                               (not show-org-avatar?))
+              avatar-link (when should-show-link
                             (if (and (= org-slug (router/current-org-slug))
                                      (router/current-board-slug))
                               (oc-urls/board org-slug (router/current-board-slug))
-                              (oc-urls/org org-slug))
-                            "")]
+                              (oc-urls/org org-slug)))]
           (if should-show-link
-            [:a
+            [:a.org-link
               {:href avatar-link
                :on-click (fn [e]
                            (.preventDefault e)
                            (when should-show-link
                              (router/redirect! avatar-link)))}
-              (internal-org-avatar s org-data show-org-avatar? (not hide-name))]
-            (internal-org-avatar s org-data show-org-avatar? (not hide-name)))))]))
+              (internal-org-avatar s org-data show-org-avatar? show-org-name?)]
+            (internal-org-avatar s org-data show-org-avatar? show-org-name?))))]))

--- a/src/oc/web/components/ui/org_settings_main_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_main_panel.cljs
@@ -114,7 +114,7 @@
              :data-toggle "tooltip"
              :data-container "body"
              :data-position "top"}
-            (org-avatar org-editing false true)]
+            (org-avatar org-editing false :never)]
           [:div.org-logo-label
             [:div.cta
               (if (empty? (:logo-url org-editing))

--- a/src/oc/web/components/ui/org_settings_main_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_main_panel.cljs
@@ -95,7 +95,7 @@
                       (dis/dispatch!
                        [:input
                         [:org-editing]
-                        (merge org-editing {:logo-url nil :logo-width 0 :logo-height 0})])
+                        (merge org-editing {:logo-url nil :logo-width 0 :logo-height 0 :has-changes true})])
                       (iu/upload! {:accept "image/*"}
                         (fn [res]
                           (let [url (gobj/get res "url")

--- a/src/oc/web/components/ui/orgs_dropdown.cljs
+++ b/src/oc/web/components/ui/orgs_dropdown.cljs
@@ -8,12 +8,10 @@
 
 (rum/defc org-dropdown-item < rum/static
   [current-slug org]
-  (let [missing-logo? (empty? (:logo-url org))]
-    [:li
-      {:class (when (= (:slug org) current-slug) "active")
-       :on-click #(do (utils/event-stop %) (router/nav! (oc-urls/org (:slug org))))}
-      (when-not missing-logo?
-        (org-avatar org false false))]))
+  [:li
+    {:class (when (= (:slug org) current-slug) "active")
+     :on-click #(do (utils/event-stop %) (router/nav! (oc-urls/org (:slug org))))}
+    (org-avatar org false :always)])
 
 (rum/defcs orgs-dropdown < rum/static
                            rum/reactive
@@ -34,7 +32,7 @@
          :aria-haspopup true
          :aria-expanded false
          :on-click (fn [e] (utils/event-stop e))}
-        (org-avatar org-data (not should-show-dropdown?) true)]
+        (org-avatar org-data (not should-show-dropdown?))]
       (when should-show-dropdown?
         [:ul.dropdown-menu
           {:aria-labelledby "orgs-dropdown"}

--- a/test/test/oc/web/components/ui/org_avatar.cljs
+++ b/test/test/oc/web/components/ui/org_avatar.cljs
@@ -15,18 +15,92 @@
 ; dynamic mount point for components
 (def ^:dynamic c)
 
-(def test-atom {
+(def empty-logo
+  {:logo-url nil
+   :logo-width 0
+   :logo-height 0})
+
+(def with-logo
+  {:logo-url "http://example.com/image.png"
+   :logo-width 100
+   :logo-height 100})
+
+(def org-data {
   :org-data {
     :name "test"
-    :slug "test"
-    :logo-url nil}})
+    :slug "test"}})
 
 (deftest test-org-avatar-component
   (testing "Org avatar component"
-    (let [c (tu/new-container!)]
-      (ru/drv-root {:state test-atom
-                    :drv-spec (dis/drv-spec test-atom (atom {}))
-                    :target c
-                    :component #(om/component (org-avatar (:org-data test-atom)))})
-      (is (not (nil? (sel1 c [:div.org-avatar]))))
-      (tu/unmount! c))))
+    (testing "with link and empty logo"
+      (let [c (tu/new-container!)
+            test-atom (update-in org-data [:org-data] merge empty-logo)]
+        (ru/drv-root {:state test-atom
+                      :drv-spec (dis/drv-spec test-atom (atom {}))
+                      :target c
+                      :component #(om/component (org-avatar (:org-data test-atom) true))})
+        (is (not (nil? (sel1 c [:div.org-avatar]))))
+        (is (not (nil? (sel1 c [:div.org-avatar :a.org-link]))))
+        (is (nil? (sel1 c [:div.org-avatar :img.org-avatar-img])))
+        (is (not (nil? (sel1 c [:div.org-avatar :span.org-name]))))
+        (tu/unmount! c)))
+    (testing "without link and not empty logo"
+      (let [c (tu/new-container!)
+            test-atom (update-in org-data [:org-data] merge with-logo)]
+        (ru/drv-root {:state test-atom
+                      :drv-spec (dis/drv-spec test-atom (atom {}))
+                      :target c
+                      :component #(om/component (org-avatar (:org-data test-atom) false))})
+        (is (not (nil? (sel1 c [:div.org-avatar]))))
+        (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
+        (is (not (nil? (sel1 c [:div.org-avatar :img.org-avatar-img]))))
+        (is (nil? (sel1 c [:div.org-avatar :span.org-name])))
+        (tu/unmount! c)))
+    (testing "with logo with name always"
+      (let [c (tu/new-container!)
+            test-atom (update-in org-data [:org-data] merge with-logo)]
+        (ru/drv-root {:state test-atom
+                      :drv-spec (dis/drv-spec test-atom (atom {}))
+                      :target c
+                      :component #(om/component (org-avatar (:org-data test-atom) false :always))})
+        (is (not (nil? (sel1 c [:div.org-avatar]))))
+        (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
+        (is (not (nil? (sel1 c [:div.org-avatar :img.org-avatar-img]))))
+        (is (not (nil? (sel1 c [:div.org-avatar :span.org-name]))))
+        (tu/unmount! c)))
+    (testing "without logo with name always"
+      (let [c (tu/new-container!)
+            test-atom (update-in org-data [:org-data] merge empty-logo)]
+        (ru/drv-root {:state test-atom
+                      :drv-spec (dis/drv-spec test-atom (atom {}))
+                      :target c
+                      :component #(om/component (org-avatar (:org-data test-atom) false :always))})
+        (is (not (nil? (sel1 c [:div.org-avatar]))))
+        (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
+        (is (nil? (sel1 c [:div.org-avatar :img.org-avatar-img])))
+        (is (not (nil? (sel1 c [:div.org-avatar :span.org-name]))))
+        (tu/unmount! c)))
+    (testing "with logo with name never"
+      (let [c (tu/new-container!)
+            test-atom (update-in org-data [:org-data] merge with-logo)]
+        (ru/drv-root {:state test-atom
+                      :drv-spec (dis/drv-spec test-atom (atom {}))
+                      :target c
+                      :component #(om/component (org-avatar (:org-data test-atom) false :never))})
+        (is (not (nil? (sel1 c [:div.org-avatar]))))
+        (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
+        (is (not (nil? (sel1 c [:div.org-avatar :img.org-avatar-img]))))
+        (is (nil? (sel1 c [:div.org-avatar :span.org-name])))
+        (tu/unmount! c)))
+    (testing "without logo with name never"
+      (let [c (tu/new-container!)
+            test-atom (update-in org-data [:org-data] merge empty-logo)]
+        (ru/drv-root {:state test-atom
+                      :drv-spec (dis/drv-spec test-atom (atom {}))
+                      :target c
+                      :component #(om/component (org-avatar (:org-data test-atom) false :never))})
+        (is (not (nil? (sel1 c [:div.org-avatar]))))
+        (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
+        (is (nil? (sel1 c [:div.org-avatar :img.org-avatar-img])))
+        (is (nil? (sel1 c [:div.org-avatar :span.org-name])))
+        (tu/unmount! c)))))


### PR DESCRIPTION
Problem: if you have an org w/o logo the name doesn't show up in the dashboard navbar, it's empty.
Solution: fixed the issue and improved the org-avatar component, its avatar/name handling and related tests.
The component in used in 4 places: `onboard-wrapper` (email and slack lander), `secure-activity`, `org-settings-main-panel`, `orgs-dropdown`.

To test:
- signup with email and try to add and remove a logo in the team step
- signup with slack and try to add and remove a logo in the team step
- visit a board with a company w/o logo and check if you see the company name in the header
- visit a board with a company w/ a logo and check if you see the company logo in the header
- with an account with multiple company (at least one with a logo and one w/o) click on the navbar dropdown caret and check the orgs list
- with a company w/ a logo get the share link of a post a visit it as anonymous 
- with a company w/o logo get the share link of a post a visit it as anonymous 
- check the org-avatar tests, do you think they cover enough cases?