### PR TITLE
Post comments resize

### DIFF
--- a/scss/partials/_activity_modal.scss
+++ b/scss/partials/_activity_modal.scss
@@ -232,6 +232,7 @@ div.activity-modal-container {
       div.activity-modal-columns {
         display: flex;
         flex-direction: row;
+        align-items: stretch;
 
         div.activity-left-column {
           flex-grow: 0;
@@ -244,15 +245,15 @@ div.activity-modal-container {
           border-bottom-left-radius: 8px;
 
           div.activity-left-column-content {
-
+              height: 100%;
             div.activity-modal-content {
               padding: 0 50px;
               float: none;
               width: 100%;
+              height: calc(100% - 72px);
               position: relative;
               overflow-y: auto;
-              max-height: calc(100vh - 72px - 96px); // Total window height less the header and the footer
-              min-height: 304px;
+
 
               div.activity-modal-content-title {
                 margin-top: 32px;
@@ -456,13 +457,14 @@ div.activity-modal-container {
           flex-shrink: 0;
           flex-basis: 301px;
           width: 301px;
+          max-height: calc(100vh - 72px);
+          min-height: 378px;
           background-color: rgba($carrot_light_gray_2, 0.15);
           position: relative;
           border-left: 1px solid rgba(#E4E3DE, 0.5);
 
           div.activity-right-column-content {
             padding: 24px;
-            position: absolute;
             bottom: 0px;
             width: 100%;
             height: 100%;

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -24,9 +24,8 @@ div.comments {
   }
 
   div.comments-internal {
-    padding-bottom: 123px;
     min-height: 127px;
-    height: 100%;
+    height: calc(100% - 123px);
     width: 100%;
     position: relative;
     bottom: 8px;
@@ -132,11 +131,6 @@ div.comments {
         .emojione {
           @include emoji-size(13);
         }
-      }
-
-      div.comment-footer {
-        color: rgba(78,90,107,0.4);
-        font-size: 11px;
       }
     }
 

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -43,7 +43,13 @@ div.comments {
 
     &.empty {
       min-height: 100%;
-    
+      padding-bottom: 0px;
+
+      div.add-comment-box {
+          top: 45px;
+          bottom: 0px;
+      }
+
       div.comments-internal-empty {
         text-align: center;
         @include avenir_M();

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -24,7 +24,7 @@ div.comments {
   }
 
   div.comments-internal {
-    padding-bottom: 103px;
+    padding-bottom: 123px;
     min-height: 127px;
     height: 100%;
     width: 100%;
@@ -32,6 +32,7 @@ div.comments {
     bottom: 8px;
     left: 0;
     right: 0;
+    top: 0;
 
     div.comments-internal-scroll {
       overflow-x: hidden;
@@ -142,8 +143,9 @@ div.comments {
       position: relative;
       left: 0;
       right: 0;
-      bottom: 8px;
+      bottom: 12px;
       width: 100%;
+      margin-top: 16px;
 
       div.successfully-posted {
         width: 168px;

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -29,7 +29,7 @@ div.comments {
     height: 100%;
     width: 100%;
     position: relative;
-    bottom: 0px;
+    bottom: 8px;
     left: 0;
     right: 0;
 
@@ -142,7 +142,7 @@ div.comments {
       position: relative;
       left: 0;
       right: 0;
-      bottom: 16px;
+      bottom: 8px;
       width: 100%;
 
       div.successfully-posted {

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -24,14 +24,14 @@ div.comments {
   }
 
   div.comments-internal {
-    padding-bottom: 143px;
+    padding-bottom: 103px;
     min-height: 127px;
     height: 100%;
     width: 100%;
+    position: relative;
     bottom: 0px;
     left: 0;
     right: 0;
-    position: absolute;
 
     div.comments-internal-scroll {
       overflow-x: hidden;
@@ -139,10 +139,10 @@ div.comments {
       border: 1px solid rgba($carrot_light_gray_1, 0.5);
       box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.07);
       padding: 16px;
+      position: relative;
       left: 0;
       right: 0;
-      position: absolute;
-      bottom: 0px;
+      bottom: 16px;
       width: 100%;
 
       div.successfully-posted {

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -250,9 +250,10 @@
                               s)
                              :after-render (fn [s]
                               (when @(:first-render-done s)
-                                (let [wh (.-innerHeight js/window)
-                                      activity-modal (rum/ref-node s "activity-modal")
-                                      next-show-bottom-border (>= (.-clientHeight activity-modal) wh)]
+                                (let [activity-modal-content (sel1 [:div.activity-modal-content])
+                                      scroll-height (.-scrollHeight activity-modal-content)
+                                      client-height (.-clientHeight activity-modal-content)
+                                      next-show-bottom-border (> scroll-height client-height)]
                                   (when (not= @(::show-bottom-border s) next-show-bottom-border)
                                     (reset! (::show-bottom-border s) next-show-bottom-border))))
                               s)

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -179,6 +179,14 @@
         (dis/dispatch! [:alert-modal-show alert-data]))
       (dismiss-fn)))))
 
+(defn modal-height-did-change
+  "Save the height of the activity modal in the local component state
+   so the top margin is moved accordigly on the next render."
+  [s]
+  (when-let [activity-modal (rum/ref-node s "activity-modal")]
+    (when (not= @(::activity-modal-height s) (.-clientHeight activity-modal))
+      (reset! (::activity-modal-height s) (.-clientHeight activity-modal)))))
+
 (def default-min-modal-height 450)
 
 (rum/defcs activity-modal < rum/reactive
@@ -193,6 +201,7 @@
                             (rum/local default-min-modal-height ::activity-modal-height)
                             (rum/local nil ::window-click)
                             (rum/local false ::show-bottom-border)
+                            (rum/local nil ::window-resize-listener)
                             ;; Editing locals
                             (rum/local false ::editing)
                             (rum/local "" ::initial-headline)
@@ -208,10 +217,8 @@
                               (let [modal-data @(drv/get-ref s :modal-data)]
                                 (when (and (not @(::animate s))
                                          (= (:activity-modal-fade-in modal-data) (:uuid (first (:rum/args s)))))
-                                  (reset! (::animate s) true))
-                                (when-let [activity-modal (sel1 [:div.activity-modal])]
-                                  (when (not= @(::activity-modal-height s) (.-clientHeight activity-modal))
-                                    (reset! (::activity-modal-height s) (.-clientHeight activity-modal)))))
+                                  (reset! (::animate s) true)))
+                              (modal-height-did-change s)
                               s)
                              :will-mount (fn [s]
                               (reset! (::esc-key-listener s)
@@ -243,6 +250,11 @@
                                              (not
                                               (utils/event-inside? e (sel1 [:div.activity-modal :div.activity-move]))))
                                     (reset! (::showing-dropdown s) false)))))
+                              (reset! (::window-resize-listener s)
+                               (events/listen
+                                js/window
+                                EventType/RESIZE
+                                #(modal-height-did-change s)))
                               (let [modal-data @(drv/get-ref s :modal-data)]
                                 (when (:modal-editing modal-data)
                                   (utils/after 1000
@@ -264,6 +276,9 @@
                               (when @(::esc-key-listener s)
                                 (events/unlistenByKey @(::esc-key-listener s))
                                 (reset! (::esc-key-listener s) nil))
+                              (when @(::window-resize-listener s)
+                                (events/unlistenByKey @(::window-resize-listener s))
+                                (reset! (::window-resize-listener s) nil))
                               s)
                              :did-remount (fn [_ s]
                               (let [activity-data (first (:rum/args s))
@@ -386,7 +401,9 @@
                                        (utils/event-stop e)
                                        (utils/to-end-of-content-editable (sel1 [:div.rich-body-editor]))))
                        :dangerouslySetInnerHTML @(::initial-headline s)}]
-                    (rich-body-editor {:on-change (partial body-on-change s)
+                    (rich-body-editor {:on-change #(do
+                                                    (body-on-change s)
+                                                    (modal-height-did-change s))
                                        :initial-body @(::initial-body s)
                                        :show-placeholder false
                                        :show-h2 true

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -28,8 +28,8 @@
             (utils/time-since (:created-at c))]]]
       [:p.comment-body.group
         {:dangerouslySetInnerHTML (utils/emojify (:body c))}]
-      [:div.comment-reactions (comment-reactions/comment-reactions c)]
-      [:div.comment-footer.group]]))
+      [:div.comment-reactions-container.group
+        (comment-reactions/comment-reactions c)]]))
 
 (defn add-comment-content [add-comment-div]
   (let [inner-html (.-innerHTML add-comment-div)


### PR DESCRIPTION
Trello: https://trello.com/c/nXNhN0le/1097-entry-modal-changes-when-comments-are-larger-than-entry-content

When the number of comments are large resize modal to show comments or to the entire window size.

---
To test: 

Open a post with little content and no comments.
- [x] Does it show the minimum sized modal with the appropriately sized left and right columns?

Open a post with a lot of content and little or no comments.
- [x] Does it the modal resize to fit the content or the screen size with a border to indicate more content?

Open a post with a lot of comments and little content.
- [x] Does it resize to fit the comments or window size? 
