### PR TITLE
Fix bold

### DIFF
--- a/resources/public/lib/MediumEditorExtensions/MediumEditorCustomBold/CustomBold.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorCustomBold/CustomBold.js
@@ -1,29 +1,47 @@
+rangy.init();
+
 var CustomBold = MediumEditor.extensions.button.extend({
   name: 'custombold',
 
-  tagNames: ['b'],
+  tagNames: ['b', 'strong'],
   contentDefault: '<b>B</b>',
-  aria: 'Bold',
-  action: 'bold',
+  contentFA: '<i class="fa fa-bold"></i>',
+  aria: 'bold',
+  action: 'custombold',
+  style: {
+    prop: 'font-family',
+    value: 'AvenirLTStd-Heavy, Muli, Arial, sans-serif'
+  },
+  key: "B",
 
   init: function () {
-    rangy.init();
-
     MediumEditor.extensions.button.prototype.init.call(this);
 
+    this.subscribe('editableKeydown', this.handleKeydown.bind(this));
     this.classApplier = rangy.createClassApplier('bold', {
       elementTagName: 'b',
+      tagNames: ['b', 'strong'],
       normalize: true
     });
+  },
+
+  handleKeydown: function (event) {
+    var keyCode = MediumEditor.util.getKeyCode(event),
+        isMeta = MediumEditor.util.isMetaCtrlKey(event),
+        isShift = !!event.shiftKey,
+        isAlt = !!event.altKey;
+
+    if (keyCode === this.key.charCodeAt(0) &&
+        isMeta && !isShift && !isAlt){
+      event.preventDefault();
+      event.stopPropagation();
+      this.classApplier.toggleSelection();
+      this.base.checkContentChanged();
+    }
   },
 
   handleClick: function (event) {
     this.classApplier.toggleSelection();
     this.base.checkContentChanged();
-    if (this.isActive()){
-      this.setInactive();
-    } else {
-      this.setActive();
-    }
   }
 });

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -252,7 +252,8 @@
                   ["custombold" "italic" "unorderedlist" "anchor"])
         options {:toolbar #js {:buttons (clj->js buttons)}
                  :buttonLabels "fontawesome"
-                 :anchorPreview #js {:hideDelay 500, :previewValueSelector "a"}
+                 :anchorPreview #js {:hideDelay 500
+                                     :previewValueSelector "a"}
                  :extensions #js {"autolist" (js/AutoList.)
                                   "media-picker" media-picker-ext
                                   "custombold" (new js/CustomBold)}
@@ -269,7 +270,25 @@
                              :cleanTags #js ["meta" "video" "audio"]
                              :unwrapTags #js ["div" "span" "label" "font" "h1" "h3" "h4" "h5" "h6" "strong"]}
                  :placeholder #js {:text "Start writing..."
-                                   :hideOnClick true}}
+                                   :hideOnClick true}
+                 ;; Disable image dragging into medium editor, we use the FileStack picker
+                 :imageDragging false
+                 ;; Pass the dfault options less the BOLD command
+                 :keyboardCommands #js {:commands #js [
+                                    #js {
+                                      :command "italic"
+                                      :key "I"
+                                      :meta true
+                                      :shift false
+                                      :alt false
+                                    }
+                                    #js {
+                                      :command false
+                                      :key "U"
+                                      :meta true
+                                      :shift false
+                                      :alt false
+                                    }]}}
         body-editor  (new js/MediumEditor body-el (clj->js options))]
     (reset! (::media-picker-ext s) media-picker-ext)
     (.subscribe body-editor


### PR DESCRIPTION
Fix CMD+B on medium editor. There are 3 players here: chrome default CMD+B that wraps highlighted text into a B tags, medium editor default extension that use it's own bold (that we disabled for the toolbar), our own bolding that didn't have a CMD+B handling before.
Even disabling the medium editor handling the chrome (or browser) bold handling was taking place and it was applying the default bolding, not our custom.
So i had to add the CMD+B handling for our custom bolding so we apply it how we want and block the event before it bubbles up to medium editor or the browser itself.

To test check that the problems in these looms are solved:
https://www.useloom.com/share/b6a370abbbb74d13b78aaed6a1dc0b39
https://www.useloom.com/share/95311d6acca643f0a36b80165373958b

Test the bold formatting from the toolbar to make sure it works and mix the 2 bolding methods. Also test that CMD+i and CMD+U are not broken. Since we don't provide underline in the toolbar we may want to disable underline via keyboard too

This also disable the image dragging default medium editor extension since it doesn't uses FileStack upload but it simply put images inline.
