### PR TITLE
Comment delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ provided in the table below:
 |  :channels-enumerate/success | API | Slack channels loaded, it saves them in the proper place of the app-state. |
 |  :comment-add | UI | Add a comment to an entry. |
 |  :comment-add/finish | API | Request to add a comment finished, can be it failed. In all cases reloads the comments with :comments-get. |
+|  :comment-delete | UI | Delete a comment to an entry. |
+|  :comment-delete/finish | API | Request to delete a comment finished, can be it failed. In all cases reloads the comments with :comments-get. |
 |  :comments-get | UI | Starts the request to load the comments given an entry UUID. |
 |  :comments-get/finish | API | Request to load the comments for an entry finished, could be it failed though. |
 |  :container/change | WS | Notice from change service with change info for a board |

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -38,7 +38,7 @@ div.comments {
     }
 
     div.comments-internal-scroll {
-      overflow-x: hidden;
+      overflow-x: visible;
       overflow-y: auto;
       height: 100%;
       padding: 10px 10px 0px;
@@ -73,6 +73,10 @@ div.comments {
     div.comment {
       margin: 10px 0;
 
+      &:hover div.comment-header div.more-button button.more-ellipsis {
+        opacity: 0.8;
+      }
+
       div.comment-header {
         div.comment-avatar {
           width: #{$comment_avatar_size}px;
@@ -85,7 +89,6 @@ div.comments {
 
         div.comment-author-timestamp {
           display: block;
-          float: left;
           width: calc(100% - 23px);
 
           div.comment-author {
@@ -112,6 +115,77 @@ div.comments {
             white-space: nowrap;
             // display: block;
             float: left;
+          }
+        }
+        div.more-button {
+          float: right;
+          position: relative;
+          margin-right: -6px;
+
+          button.more-ellipsis {
+            width: 24px;
+            height: 24px;
+            padding: 2px 10px;
+            display: block;
+            background-image: cdnUrl("/img/ML/vertical_ellipsis.svg");
+            background-position: center;
+            background-size: 4px 20px;
+            background-repeat: no-repeat;
+            opacity: 0;
+
+            &:hover {
+              opacity: 1;
+            }
+          }
+
+          div.comment-more-dropdown-menu {
+            position: absolute;
+            top: 36px;
+            right: -4px;
+            left: calc(100% - 100px + 31px);
+            height: auto;
+            border: none;
+            outline: none;
+            box-shadow: none;
+            background-color: transparent;
+            overflow: visible;
+            z-index: 300;
+
+            div.triangle {
+               position: absolute;
+               top: -7px;
+               left: calc(100% - 23px);
+               background-color: white;
+               border-top: 1px solid rgba(177,184,192,0.50);
+               border-left: 1px solid rgba(177,184,192,0.50);
+               transform: rotate(45deg);
+               width: 15px;
+               height: 15px;
+            }
+
+            ul.comment-card-more-menu {
+              background-color: white;
+              border: 1px solid rgba(177,184,192,0.50);
+              box-shadow: 0 4px 10px 1px rgba(0,0,0,0.10);
+              border-radius: 5px;
+              margin: 0px;
+              padding: 10px 13px 6px 8px;
+              list-style-type: none;
+              width: 100%;
+
+              li {
+                padding: 3px 8px;
+                @include avenir_M();
+                font-size: 14px;
+                color: $carrot_light_gray_3;
+                cursor: pointer;
+                background-color: transparent;
+
+                &:hover {
+                  background-color: rgba($carrot_light_gray_4, 0.2);
+                }
+              }
+            }
           }
         }
       }

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -73,7 +73,7 @@ div.comments {
     div.comment {
       margin: 10px 0;
 
-      &:hover div.comment-header div.delete-button button {
+      &:hover div.comment-header div.delete-button button.mdi.mdi-delete {
         opacity: 0.8;
       }
 
@@ -122,14 +122,9 @@ div.comments {
           position: relative;
           margin-right: -6px;
 
-          button {
-            width: 18px;
-            height: 18px;
-            display: block;
-            background-image: cdnUrl("/img/ML/trash.svg");
+          button.mdi.mdi-delete {
+            padding: 7px 2px 1px;
             background-position: center;
-            background-size: 18px 18px;
-            background-repeat: no-repeat;
             background-color: rgba($carrot_light_gray_2, 0.15);
             opacity: 0;
             border: none;

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -73,7 +73,7 @@ div.comments {
     div.comment {
       margin: 10px 0;
 
-      &:hover div.comment-header div.more-button button.more-ellipsis {
+      &:hover div.comment-header div.delete-button button {
         opacity: 0.8;
       }
 
@@ -117,74 +117,25 @@ div.comments {
             float: left;
           }
         }
-        div.more-button {
+        div.delete-button {
           float: right;
           position: relative;
           margin-right: -6px;
 
-          button.more-ellipsis {
-            width: 24px;
-            height: 24px;
-            padding: 2px 10px;
+          button {
+            width: 18px;
+            height: 18px;
             display: block;
-            background-image: cdnUrl("/img/ML/vertical_ellipsis.svg");
+            background-image: cdnUrl("/img/ML/trash.svg");
             background-position: center;
-            background-size: 4px 20px;
+            background-size: 18px 18px;
             background-repeat: no-repeat;
+            background-color: rgba($carrot_light_gray_2, 0.15);
             opacity: 0;
+            border: none;
 
             &:hover {
               opacity: 1;
-            }
-          }
-
-          div.comment-more-dropdown-menu {
-            position: absolute;
-            top: 36px;
-            right: -4px;
-            left: calc(100% - 100px + 31px);
-            height: auto;
-            border: none;
-            outline: none;
-            box-shadow: none;
-            background-color: transparent;
-            overflow: visible;
-            z-index: 300;
-
-            div.triangle {
-               position: absolute;
-               top: -7px;
-               left: calc(100% - 23px);
-               background-color: white;
-               border-top: 1px solid rgba(177,184,192,0.50);
-               border-left: 1px solid rgba(177,184,192,0.50);
-               transform: rotate(45deg);
-               width: 15px;
-               height: 15px;
-            }
-
-            ul.comment-card-more-menu {
-              background-color: white;
-              border: 1px solid rgba(177,184,192,0.50);
-              box-shadow: 0 4px 10px 1px rgba(0,0,0,0.10);
-              border-radius: 5px;
-              margin: 0px;
-              padding: 10px 13px 6px 8px;
-              list-style-type: none;
-              width: 100%;
-
-              li {
-                padding: 3px 8px;
-                @include avenir_M();
-                font-size: 14px;
-                color: $carrot_light_gray_3;
-                cursor: pointer;
-                background-color: transparent;
-
-                &:hover {
-                  background-color: rgba($carrot_light_gray_4, 0.2);
-                }
-              }
             }
           }
         }

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -695,15 +695,15 @@
                                                       :activity-data activity-data}]))))))
 
 (defn delete-comment
-  [comment-data]
-  (when (and comment-data)
+  [activity-uuid comment-data]
+  (when comment-data
     (let [comment-link (utils/link-for (:links comment-data) "delete")]
       (interaction-http (method-for-link comment-link) (relative-href comment-link)
         {:headers (headers-for-link comment-link)}
         (fn [{:keys [status success body]}]
           (dispatcher/dispatch!
            [:comment-delete/finish
-            {:sucess success}]))))))
+            {:success success :activity-uuid activity-uuid}]))))))
 
 (defn toggle-reaction
   [item-data reaction-data]

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -692,7 +692,18 @@
           (dispatcher/dispatch! [:comment-add/finish {:success success
                                                       :error (when-not success body)
                                                       :body (when (seq body) (json->cljs body))
-                                                      :activity-uuid (:uuid activity-data)}]))))))
+                                                      :activity-data activity-data}]))))))
+
+(defn delete-comment
+  [comment-data]
+  (when (and comment-data)
+    (let [comment-link (utils/link-for (:links comment-data) "delete")]
+      (interaction-http (method-for-link comment-link) (relative-href comment-link)
+        {:headers (headers-for-link comment-link)}
+        (fn [{:keys [status success body]}]
+          (dispatcher/dispatch!
+           [:comment-delete/finish
+            {:sucess success}]))))))
 
 (defn toggle-reaction
   [item-data reaction-data]

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -37,24 +37,9 @@
 
 (rum/defcs comment-row < rum/static
                          rum/reactive
-                         (rum/local false ::more-dropdown)
-                         (rum/local nil ::window-click)
-                         {:did-mount (fn [s]
-                           (let [comment-data (first (:rum/args s))
-                                 comment-node (rum/ref-node s "comment")
-                                 comment-more-button (rum/ref-node s "more-button")]
-                             (reset! (::window-click s)
-                               (events/listen comment-node EventType/CLICK
-                                 (fn [e]
-                                   (when (not (utils/event-inside? e comment-more-button))
-                                     (reset! (::more-dropdown s) false))))))
-                             s)
-                          :will-unmount (fn [s]
-                                          (events/unlistenByKey @(::window-click s))
-                                          s)}
   [s c]
   (let [author (:author c)]
-    [:div.comment {:ref "comment"}
+    [:div.comment
       [:div.comment-header.group
         [:div.comment-avatar
           {:style {:background-image (str "url(" (:avatar-url author) ")")}}]
@@ -64,31 +49,16 @@
           [:div.comment-timestamp
             (utils/time-since (:created-at c))]]
           (when (seq (:links c))
-            [:div.more-button {:ref "more-button"}
-              [:button.mlb-reset.more-ellipsis
+            [:div.delete-button
+              [:button
                 {:type "button"
                  :on-click (fn [e]
                              (utils/remove-tooltips)
-                             (reset! (::more-dropdown s) (not @(::more-dropdown s))))
-                 :title "More"
+                             (delete-clicked e c))
+                 :title "Delete"
                  :data-toggle "tooltip"
                  :data-placement "top"
-                 :data-container "body"}]
-             (when @(::more-dropdown s)
-               [:div.comment-more-dropdown-menu
-                [:div.triangle]
-                  [:ul.comment-card-more-menu
-                   (when (utils/link-for (:links c) "delete")
-                     [:li
-                      {:on-click #(do
-                                    (reset! (::more-dropdown s) false)
-                                    (delete-clicked % c))}
-                      "Delete"])
-                ]
-              ]
-             )
-          ])
-       ]
+                 :data-container "body"}]])]
       [:p.comment-body.group
         {:dangerouslySetInnerHTML (utils/emojify (:body c))}]
       [:div.comment-reactions-container.group

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -18,10 +18,6 @@
             [goog.events :as events]
             [goog.events.EventType :as EventType]))
 
-(defn- comment-uuid
-  [comment-data]
-  (last (clojure.string/split (:href (first (:links comment-data))) "/")))
-
 (defn delete-clicked [e comment-data]
   (let [alert-data {:icon "/img/ML/trash.svg"
                     :action "delete-comment"

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -3,7 +3,11 @@
                    [dommy.core :refer (sel1)])
   (:require [rum.core :as rum]
             [org.martinklepsch.derivatives :as drv]
+            [taoensso.timbre :as timbre]
             [oc.web.lib.utils :as utils]
+            [oc.web.lib.jwt :as jwt]
+            [oc.web.urls :as oc-urls]
+            [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
             [oc.web.local-settings :as ls]
             [oc.web.mixins.ui :refer (first-render-mixin)]
@@ -14,10 +18,47 @@
             [goog.events :as events]
             [goog.events.EventType :as EventType]))
 
-(rum/defc comment-row < rum/static
-  [c]
+(defn- comment-uuid
+  [comment-data]
+  (last (clojure.string/split (:href (first (:links comment-data))) "/")))
+
+(defn delete-clicked [e comment-data]
+  (let [alert-data {:icon "/img/ML/trash.svg"
+                    :action "delete-comment"
+                    :message (str "Delete this comment?")
+                    :link-button-title "No"
+                    :link-button-cb #(dis/dispatch! [:alert-modal-hide])
+                    :solid-button-title "Yes"
+                    :solid-button-cb #(let [org-slug (router/current-org-slug)
+                                            board-slug (router/current-board-slug)
+                                            board-url (utils/get-board-url org-slug board-slug)
+                                            activity-uuid (router/current-activity-id)]
+                                       (router/nav! (oc-urls/entry org-slug board-slug activity-uuid))
+                                       (dis/dispatch! [:comment-delete activity-uuid comment-data])
+                                       (dis/dispatch! [:alert-modal-hide]))
+                    }]
+    (dis/dispatch! [:alert-modal-show alert-data])))
+
+(rum/defcs comment-row < rum/static
+                         rum/reactive
+                         (rum/local false ::more-dropdown)
+                         (rum/local nil ::window-click)
+                         {:did-mount (fn [s]
+                           (let [comment-data (first (:rum/args s))
+                                 comment-node (rum/ref-node s "comment")
+                                 comment-more-button (sel1 [comment-node :div.more-button])]
+                             (reset! (::window-click s)
+                               (events/listen comment-node EventType/CLICK
+                                 (fn [e]
+                                   (when (not (utils/event-inside? e comment-more-button))
+                                     (reset! (::more-dropdown s) false))))))
+                             s)
+                          :will-unmount (fn [s]
+                                          (events/unlistenByKey @(::window-click s))
+                                          s)}
+  [s c]
   (let [author (:author c)]
-    [:div.comment
+    [:div.comment {:ref "comment"}
       [:div.comment-header.group
         [:div.comment-avatar
           {:style {:background-image (str "url(" (:avatar-url author) ")")}}]
@@ -25,7 +66,33 @@
           [:div.comment-author
             (:name author)]
           [:div.comment-timestamp
-            (utils/time-since (:created-at c))]]]
+            (utils/time-since (:created-at c))]]
+          (when (seq (:links c))
+            [:div.more-button
+              [:button.mlb-reset.more-ellipsis
+                {:type "button"
+                 :on-click (fn [e]
+                             (utils/remove-tooltips)
+                             (reset! (::more-dropdown s) (not @(::more-dropdown s))))
+                 :title "More"
+                 :data-toggle "tooltip"
+                 :data-placement "top"
+                 :data-container "body"}]
+             (when @(::more-dropdown s)
+               [:div.comment-more-dropdown-menu
+                [:div.triangle]
+                  [:ul.comment-card-more-menu
+                   (when (utils/link-for (:links c) "delete")
+                     [:li
+                      {:on-click #(do
+                                    (reset! (::more-dropdown s) false)
+                                    (delete-clicked % c))}
+                      "Delete"])
+                ]
+              ]
+             )
+          ])
+       ]
       [:p.comment-body.group
         {:dangerouslySetInnerHTML (utils/emojify (:body c))}]
       [:div.comment-reactions-container.group
@@ -121,6 +188,7 @@
       (reset! (::comments-requested s) true)
       (utils/after 10 #(dis/dispatch! [:comments-get activity-data])))))
 
+;; Rum comments component
 (rum/defcs comments < (drv/drv :activity-comments-data)
                       (drv/drv :comment-add-finish)
                       (drv/drv :add-comment-focus)

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -25,11 +25,7 @@
                     :link-button-title "No"
                     :link-button-cb #(dis/dispatch! [:alert-modal-hide])
                     :solid-button-title "Yes"
-                    :solid-button-cb #(let [org-slug (router/current-org-slug)
-                                            board-slug (router/current-board-slug)
-                                            board-url (utils/get-board-url org-slug board-slug)
-                                            activity-uuid (router/current-activity-id)]
-                                       (router/nav! (oc-urls/entry org-slug board-slug activity-uuid))
+                    :solid-button-cb #(let [activity-uuid (router/current-activity-id)]
                                        (dis/dispatch! [:comment-delete activity-uuid comment-data])
                                        (dis/dispatch! [:alert-modal-hide]))
                     }]
@@ -48,7 +44,7 @@
             (:name author)]
           [:div.comment-timestamp
             (utils/time-since (:created-at c))]]
-          (when (seq (:links c))
+          (when (boolean (utils/link-for (:links c) "delete"))
             [:div.delete-button
               [:button
                 {:type "button"

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -46,7 +46,7 @@
             (utils/time-since (:created-at c))]]
           (when (boolean (utils/link-for (:links c) "delete"))
             [:div.delete-button
-              [:button
+              [:button.mdi.mdi-delete
                 {:type "button"
                  :on-click (fn [e]
                              (utils/remove-tooltips)

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -42,7 +42,7 @@
                          {:did-mount (fn [s]
                            (let [comment-data (first (:rum/args s))
                                  comment-node (rum/ref-node s "comment")
-                                 comment-more-button (sel1 [comment-node :div.more-button])]
+                                 comment-more-button (rum/ref-node s "more-button")]
                              (reset! (::window-click s)
                                (events/listen comment-node EventType/CLICK
                                  (fn [e]
@@ -64,7 +64,7 @@
           [:div.comment-timestamp
             (utils/time-since (:created-at c))]]
           (when (seq (:links c))
-            [:div.more-button
+            [:div.more-button {:ref "more-button"}
               [:button.mlb-reset.more-ellipsis
                 {:type "button"
                  :on-click (fn [e]

--- a/src/oc/web/lib/ws_interaction_client.cljs
+++ b/src/oc/web/lib/ws_interaction_client.cljs
@@ -49,8 +49,13 @@
 
 (defmethod event-handler :interaction-comment/add
   [_ body]
-  (timbre/debug "Comment event" body)
+  (timbre/debug "Comment add event" body)
   (dis/dispatch! [:ws-interaction/comment-add body]))
+
+(defmethod event-handler :interaction-comment/delete
+  [_ body]
+  (timbre/debug "Comment delete event" body)
+  (dis/dispatch! [:ws-interaction/comment-delete body]))
 
 (defmethod event-handler :interaction-reaction/add
   [_ body]


### PR DESCRIPTION
Trello: https://trello.com/c/ClMlhLsU/1105-comments-ui-delete

This change adds a drop down menu on comments owned by the current user. The menu has a 'Delete' option that will prompt the user if they are sure they want to delete when clicked. Once clicked the comment is removed.

To test:

- Open up an activity with comments owned by your current test user.
- [x] Hover over the comment and a trash can will appear on the top right of the comment.
- [x] Clicking the delete can will bring up a modal asking if you are sure you want to delete.
- [x] Clicking yes will remove the comment.

- Login as a different user and leave the first user logged in.
- Add a comment to the same activity the first user is viewing.
- Follow the same delete steps as above.
- [x] Is the comment removed from both user's views?
- merge