### PR TITLE
Add slack options  when creating a new board.

### DIFF
--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -1373,7 +1373,7 @@
   (let [board-data (:board-editing db)]
     (if (and (string/blank? (:slug board-data))
              (not (string/blank? (:name board-data))))
-      (api/create-board (:name board-data) (:access board-data))
+      (api/create-board board-data)
       (api/patch-board board-data)))
   db)
 

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -500,12 +500,17 @@
                 ; if not refirect the user to the slug
                 (router/redirect! org-url)))))))))
 
-(defn create-board [board-name board-access]
-  (let [create-link (utils/link-for (:links (dispatcher/org-data)) "create")]
+(defn create-board [board-data]
+  (let [create-link (utils/link-for (:links (dispatcher/org-data)) "create")
+        board-name (:name board-data)
+        board-access (:access board-data)
+        slack-mirror (:slack-mirror board-data)]
     (when (and board-name create-link)
       (storage-http (method-for-link create-link) (relative-href create-link)
         {:headers (headers-for-link create-link)
-         :json-params (cljs->json {:name board-name :access board-access})}
+         :json-params (cljs->json {:name board-name
+                                   :access board-access
+                                   :slack-mirror slack-mirror})}
         (fn [{:keys [success status body]}]
           (let [board-data (when success (json->cljs body))]
             (if (= status 409)

--- a/src/oc/web/components/board_edit.cljs
+++ b/src/oc/web/components/board_edit.cljs
@@ -38,7 +38,7 @@
                         ;; Locals
                         (rum/local false ::dismiss)
                         (rum/local false ::team-channels-requested)
-                        (rum/local false ::slack-enabled)
+                        (rum/local true ::slack-enabled)
                         (rum/local nil ::input-event)
                         (rum/local nil ::dom-add-event)
                         (rum/local nil ::dom-remove-event)
@@ -51,7 +51,8 @@
                         {:will-mount (fn [s]
                           (dis/dispatch! [:teams-get])
                           (let [board-data @(drv/get-ref s :board-editing)]
-                            (reset! (::slack-enabled s) (:slack-mirror board-data))
+                            (when (some? (:slack-mirror board-data))
+                              (reset! (::slack-enabled s) (:slack-mirror board-data)))
                             (reset! (::initial-board-name s) (:name board-data)))
                           (when (and (not @(drv/get-ref s :team-channels))
                                      (not @(::team-channels-requested s)))
@@ -107,8 +108,7 @@
         board-editing (drv/react s :board-editing)
         new-board? (not (contains? board-editing :links))
         slack-teams (drv/react s :team-channels)
-        show-slack-channels? (and (seq (:slug board-editing))
-                                  (pos? (apply + (map #(-> % :channels count) slack-teams))))]
+        show-slack-channels? (pos? (apply + (map #(-> % :channels count) slack-teams)))]
     [:div.board-edit-container
       {:class (utils/class-set {:will-appear (or @(::dismiss s) (not @(:first-render-done s)))
                                 :appear (and (not @(::dismiss s)) @(:first-render-done s))})}

--- a/src/oc/web/components/board_edit.cljs
+++ b/src/oc/web/components/board_edit.cljs
@@ -166,7 +166,7 @@
             [:div.board-edit-slack-channels-container
               [:div.board-edit-slack-channels-label.group
                 [:div.title
-                  "Connect comments to Slack"
+                  "Connect this board to Slack"
                   [:span.more-info]]
                 (carrot-checkbox {:selected @(::slack-enabled s)
                                   :did-change-cb #(do


### PR DESCRIPTION
Trello: 

First part of slack integration work.

This change adds the ability to setup a slack notification channel when creating a new board.

To test: 

- Click the + next to Boards with an account that has slack enabled.
- [x] Do you see the slack options
- Create the new board by clicking Save
- Edit the new board by clicking the down error next to the board name.
- [x] Are the slack options saved?

merge

