### PR TITLE
Fix small UI bug where you can interact w/ channel picker when disabled.

### DIFF
--- a/src/oc/web/components/board_edit.cljs
+++ b/src/oc/web/components/board_edit.cljs
@@ -167,7 +167,10 @@
               [:div.board-edit-slack-channels-label.group
                 [:div.title
                   "Connect comments to Slack"
-                  [:span.more-info]]
+                  [:span.more-info
+                   {:data-toggle "tooltip"
+                    :data-placement "top"
+                    :title "Post comments and updates to your selected Slack channel."}]]
                 (carrot-checkbox {:selected @(::slack-enabled s)
                                   :did-change-cb #(do
                                                     (reset! (::slack-enabled s) %)

--- a/src/oc/web/components/ui/slack_channels_dropdown.cljs
+++ b/src/oc/web/components/ui/slack_channels_dropdown.cljs
@@ -75,7 +75,7 @@
       [:i.fa
         {:class (utils/class-set {:fa-angle-down (not @(::show-channels-dropdown s))
                                   :fa-angle-up @(::show-channels-dropdown s)})
-         :on-click #(do
+         :on-click #(when (not disabled)
                       (reset! (::typing s) false)
                       (reset! (::show-channels-dropdown s) (not @(::show-channels-dropdown s)))
                       (utils/event-stop %))}]

--- a/src/oc/web/components/ui/slack_channels_dropdown.cljs
+++ b/src/oc/web/components/ui/slack_channels_dropdown.cljs
@@ -1,6 +1,5 @@
 (ns oc.web.components.ui.slack-channels-dropdown
   (:require [rum.core :as rum]
-            [dommy.core :refer-macros (sel1)]
             [org.martinklepsch.derivatives :as drv]
             [cuerdas.core :as string]
             [goog.events :as events]
@@ -38,11 +37,7 @@
                                                       (not
                                                        (utils/event-inside?
                                                         %
-                                                        (sel1 [:div.board-edit-slack-channels-dropdown])))
-                                                      (not
-                                                       (utils/event-inside?
-                                                        %
-                                                        (sel1 [:input.board-edit-slack-channel]))))
+                                                        (rum/dom-node s))))
                                              (reset! (::show-channels-dropdown s) false))))
                                        s)
                                       :did-remount (fn [o s]


### PR DESCRIPTION
Trello: https://trello.com/c/wKY660ui/1110-fix-small-ui-bug-where-you-can-interact-w-channel-picker-even-when-its-toggled-off

Also Fix small UI bug, no tooltip on the informational i in the dialog.


To test:

- Create a new board with a team that has slack enabled.
- In the new board UI you will see a toggle for Slack and make sure it is off.
- [x] You should not be able to click the down arrow for choosing a slack channel.


- [x] Mouse over the i icon to see the tooltip