### PR TITLE
Preload EmojiMart picker

### DIFF
--- a/scss/partials/_emoji_picker.scss
+++ b/scss/partials/_emoji_picker.scss
@@ -37,6 +37,12 @@ div.emoji-picker {
     position: absolute;
     display: none;
 
+    &:not(.visible).preloading {
+      display: block;
+      top: -10000px;
+      left: -10000px;
+    }
+
     &.visible {
       display: block;
     }

--- a/src/oc/web/components/ui/emoji_picker.cljs
+++ b/src/oc/web/components/ui/emoji_picker.cljs
@@ -101,7 +101,12 @@
                            (events/unlistenByKey (::ff-window-click s)))
                          (when (::ff-keypress s)
                            (events/unlistenByKey (::ff-keypress s)))
-                         (dissoc s ::click-listener ::focusin-listener ::focusout-listener ::ff-window-click ::ff-keypress))}
+                         (dissoc s
+                          ::click-listener
+                          ::focusin-listener
+                          ::focusout-listener
+                          ::ff-window-click
+                          ::ff-keypress))}
   [s {:keys [add-emoji-cb position width height container-selector]
       :as arg
       :or {position "top"

--- a/src/oc/web/components/ui/emoji_picker.cljs
+++ b/src/oc/web/components/ui/emoji_picker.cljs
@@ -60,11 +60,13 @@
   (rum/local false ::caret-pos)
   (rum/local false ::last-active-element)
   (rum/local false ::disabled)
+  (rum/local false ::preloaded)
   {:init (fn [s p] (js/rangy.init) s)
    :will-mount (fn [s]
                  (check-focus s nil)
                  s)
    :did-mount (fn [s] (when-not (utils/is-test-env?)
+                        (utils/after 1500 #(reset! (::preloaded s) true))
                         (let [click-listener (events/listen
                                               js/window
                                               EventType/CLICK
@@ -127,6 +129,7 @@
                                (reset! visible vis)))}]
       [:div.picker-container
         {:class (utils/class-set {position true
+                                  :preloading (not @(::preloaded s))
                                   :visible @visible})}
         (when-not (utils/is-test-env?)
           (react-utils/build (.-Picker js/EmojiMart)


### PR DESCRIPTION
Card: https://trello.com/c/tJ1K6Ywe

Preload the EmojiMart picker when the emoji-picker component is added so there is no delay when the user clicks on the picker button.

To test:
- click New post button
- [x] click the emoji button as fast as you can, do you see the picker? does it show immediately (less then 1 sec delay)? Good
- [x] repeat the test above for a post edit clicking the picker button at the bottom of the  post
- [x] repeat clicking the picker button in the comments