### PR TITLE
Fix NUX issue upon email verification

### DIFF
--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -444,7 +444,7 @@
     (= status 204) ;; Email wall since it's a valid signup w/ non verified email address
     (do
       (cook/set-cookie!
-       (router/show-nux-cookie (jwt/user-id))
+       (router/show-nux-cookie (:user-id jwt))
        (:new-user router/nux-cookie-values)
        (* 60 60 24 7))
       (utils/after 10 #(router/nav! (str oc-urls/email-wall "?e=" (:email (:signup-with-email db)))))

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -443,10 +443,6 @@
   (cond
     (= status 204) ;; Email wall since it's a valid signup w/ non verified email address
     (do
-      (cook/set-cookie!
-       (router/show-nux-cookie (:user-id jwt))
-       (:new-user router/nux-cookie-values)
-       (* 60 60 24 7))
       (utils/after 10 #(router/nav! (str oc-urls/email-wall "?e=" (:email (:signup-with-email db)))))
       db)
     (= status 200) ;; Valid login, not signup, redirect to home

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -535,12 +535,7 @@
           {:on-click #(router/nav!
                         (let [org (utils/get-default-org orgs)]
                           (if org
-                            (do
-                             (cook/set-cookie!
-                              (router/show-nux-cookie (jwt/user-id))
-                              (:new-user router/nux-cookie-values)
-                              (* 60 60 24 7))
-                             (oc-urls/org (:slug org)))
+                            (oc-urls/org (:slug org))
                             oc-urls/login)))}
           "Get Started"]]
       :else

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -532,14 +532,18 @@
       [:div.onboard-email-container
         "Thanks for verifying"
         [:button.mlb-reset.continue
-          {:on-click #(router/nav!
-                        (let [org (utils/get-default-org orgs)]
-                          (if org
-                            (if (and (empty? (jwt/get-key :first-name))
-                                     (empty? (jwt/get-key :last-name)))
-                              oc-urls/confirm-invitation-profile
-                              (oc-urls/org (:slug org)))
-                            oc-urls/login)))}
+          {:on-click #(let [org (utils/get-default-org orgs)]
+                        (if org
+                          (if (and (empty? (jwt/get-key :first-name))
+                                   (empty? (jwt/get-key :last-name)))
+                            (do
+                              (cook/set-cookie!
+                               (router/show-nux-cookie (jwt/user-id))
+                               (:new-user router/nux-cookie-values)
+                               (* 60 60 24 7))
+                              (router/nav! oc-urls/confirm-invitation-profile))
+                            (router/nav! (oc-urls/org (:slug org))))
+                          (router/nav! oc-urls/login)))}
           "Get Started"]]
       :else
       [:div.onboard-email-container.small.dot-animation

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -535,7 +535,10 @@
           {:on-click #(router/nav!
                         (let [org (utils/get-default-org orgs)]
                           (if org
-                            (oc-urls/org (:slug org))
+                            (if (and (empty? (jwt/get-key :first-name))
+                                     (empty? (jwt/get-key :last-name)))
+                              oc-urls/confirm-invitation-profile
+                              (oc-urls/org (:slug org)))
                             oc-urls/login)))}
           "Get Started"]]
       :else


### PR DESCRIPTION
Card: https://trello.com/c/XOJyhZIh

When a user land to the email verification and then continue to the org dashboard the NUX was repeated. This simply remove the NUX cookie set from email verification lander.
There are 2 flows that land at /verify:
1) users that have signed up with a new email (and created a new org), they do not need to see the NUX again since they have already, if they didn't yet they still have the cookie set from the signup process
2) users that hit the email verification wall upon signup using an email domain. They don't need the NUX cookie to be set since they still should have it from the initial signup.

First case test:
- create a brand new user (no email domain, no existing slack org)
- create a new org (during the signup flow)
- go through all the NUX
- check your email and click the verify link
- proceed from the verification email lander and go to your dashboard
- [x] did you NOT see the NUX for the second time? Good

Second case test:
- setup an email domain (if you are local use carrot.io so you can test it easly)
- open a new browser session
- signup using an email under the domain used above
- proceed from the email signup to the profile setup
- [x] once you land to the org dashboard, do you see the NUX? Good
