### PR TITLE
Tooltip data for reactions

### DIFF
--- a/src/oc/web/components/reactions.cljs
+++ b/src/oc/web/components/reactions.cljs
@@ -81,6 +81,11 @@
                   :let [reaction-data (get reactions-data idx)
                         is-loading (utils/in? reactions-loading (:reaction reaction-data))
                         reacted (:reacted reaction-data)
+                        reaction-authors (:authors reaction-data)
+                        reaction-start (if (> 1 (count reaction-authors)) "Reactions" "Reaction")
+                        reaction-attribution (if (empty? reaction-authors)
+                          ""
+                          (str reaction-start " by " (clojure.string/join "," reaction-authors)))
                         read-only-reaction (not (utils/link-for
                                                  (:links reaction-data)
                                                  "react"
@@ -91,11 +96,16 @@
                                                           (inc (:count reaction-data)))
                                                   :reacted (not reacted)})
                             reaction-data)]]
+
               [:button.reaction-btn.btn-reset
                 {:key (str "reaction-" (:uuid entry-data) "-" idx)
                  :class (utils/class-set {:reacted (:reacted r)
                                           :can-react (not read-only-reaction)
                                           :has-reactions (pos? (:count r))})
+                 :title reaction-attribution
+                 :data-placement (if (empty? reaction-authors) "none" "top")
+                 :data-container "body"
+                 :data-toggle "tooltip"
                  :on-click (fn [e]
                              (when (and (not is-loading) (not read-only-reaction))
                                (when (and (not (:reacted r))

--- a/src/oc/web/components/reactions.cljs
+++ b/src/oc/web/components/reactions.cljs
@@ -82,10 +82,16 @@
                         is-loading (utils/in? reactions-loading (:reaction reaction-data))
                         reacted (:reacted reaction-data)
                         reaction-authors (:authors reaction-data)
-                        reaction-start (if (> 1 (count reaction-authors)) "Reactions" "Reaction")
+                        multiple-reaction-authors? (> (count reaction-authors) 1)
+                        attribution-start (if multiple-reaction-authors? "Reactions" "Reaction")
+                        attribution-end (if multiple-reaction-authors?
+                                          (str (clojure.string/join ", " (butlast reaction-authors))
+                                               " and "
+                                               (last reaction-authors))
+                                          (first reaction-authors))
                         reaction-attribution (if (empty? reaction-authors)
-                          ""
-                          (str reaction-start " by " (clojure.string/join "," reaction-authors)))
+                                                ""
+                                                (str attribution-start " by " attribution-end))
                         read-only-reaction (not (utils/link-for
                                                  (:links reaction-data)
                                                  "react"
@@ -103,7 +109,7 @@
                                           :can-react (not read-only-reaction)
                                           :has-reactions (pos? (:count r))})
                  :title reaction-attribution
-                 :data-placement (if (empty? reaction-authors) "none" "top")
+                 :data-placement "top"
                  :data-container "body"
                  :data-toggle "tooltip"
                  :on-click (fn [e]


### PR DESCRIPTION
Small PR to add tooltip data for reactions.

No Trello card.

Known limitations:

- You aren't added to the attribution list when you first react
- You won't see another user added to the list if they react while you are looking at the post (don't pick up new authors from websockets)
- We don't use second person "you" for your own name

To test:

- [x] Review the code

It's on staging (`merge-branch`, which is probably the easiest place to check it:

- [x] look at some reactions w/ no reactions (favorites) so no tip
- [x] look at some reactions w/ 1 reaction
- [x] look at some reactions w/ more than 1 reaction
- [ ] merge
- [ ] deploy to data
- [ ] drop and give me 20
