### PR TITLE
Comments autolink

### DIFF
--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -287,6 +287,7 @@ div.comments {
             background-color: $carrot_light_gray_9;
             border-radius: 6px;
             margin: 0px;
+            min-height: initial;
 
             &.is-owner {
               background-color: $carrot_light_yellow;
@@ -483,6 +484,7 @@ div.comments {
             margin: 2px 0px;
             overflow-y: auto;
             overflow-x: hidden;
+            min-height: initial;
 
             &.show-buttons {
               height: 58px;
@@ -492,12 +494,13 @@ div.comments {
               @include emoji-size(13);
             }
 
-            &:empty:before {
+            &:after {
               @include avenir_M();
               font-size: 14px;
               content: attr(placeholder);
               color: rgba($carrot_light_gray_3, 0.4);
               cursor: text;
+              font-style: none;
             }
           }
 

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -484,6 +484,7 @@ div.comments {
             margin: 2px 0px;
             overflow-y: auto;
             overflow-x: hidden;
+            height: 20px;
             min-height: initial;
 
             &.show-buttons {

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -272,12 +272,17 @@
                                (events/listen
                                 js/window
                                 EventType/KEYDOWN
-                                #(when (= (.-key %) "Escape")
-                                   (let [modal-data @(drv/get-ref s :modal-data)]
-                                     (if (and (:modal-editing modal-data)
-                                              (not @(::uploading-media s)))
-                                       (dismiss-editing? s true)
-                                       (close-clicked s))))))
+                                #(let [modal-data @(drv/get-ref s :modal-data)
+                                       add-comment-focus (:add-comment-focus modal-data)
+                                       comment-edit (:comment-edit modal-data)]
+                                   (when (and (= (.-key %) "Escape")
+                                              (not add-comment-focus)
+                                              (not comment-edit))
+                                     (let [modal-data @(drv/get-ref s :modal-data)]
+                                       (if (and (:modal-editing modal-data)
+                                                (not @(::uploading-media s)))
+                                         (dismiss-editing? s true)
+                                         (close-clicked s)))))))
                               (setup-editing-data s)
                               s)
                              :did-mount (fn [s]

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -65,8 +65,9 @@
 (defn cancel-edit
   [e s c]
   (.stopPropagation e)
-  (let [comment-field (rum/ref-node s "comment-body")]
-    (set! (.-innerHTML comment-field) (utils/emojify @(::initial-body s) true))
+  (let [comment-field (rum/ref-node s "comment-body")
+        comment-data (first (:rum/args s))]
+    (set! (.-innerHTML comment-field) (utils/emojify (:body comment-data) true))
     (stop-editing s)))
 
 (defn add-comment-content [add-comment-div]
@@ -144,7 +145,6 @@
                          (rum/local false ::medium-editor)
                          (rum/local nil ::window-click)
                          (rum/local false ::show-more-dropdown)
-                         (rum/local false ::initial-body)
                          (rum/local nil ::esc-key-listener)
                          {:did-mount (fn [s]
                             (reset! (::window-click s)
@@ -159,8 +159,6 @@
                                 (when (and @(::show-more-dropdown s)
                                            (not (utils/event-inside? e (rum/ref-node s "comment-edit-delete"))))
                                   (reset! (::show-more-dropdown s) false)))))
-                            (let [comment-data (first (:rum/args s))]
-                              (reset! (::initial-body s) (:body comment-data)))
                             s)
                           :will-unmount (fn [s]
                             (events/unlistenByKey

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -257,6 +257,9 @@
                            (let [add-comment-node (rum/ref-node s "add-comment")
                                  medium-editor (setup-medium-editor add-comment-node)]
                              (reset! (::medium-editor s) medium-editor)
+                             (.subscribe medium-editor
+                              "editableInput"
+                              #(enable-add-comment? s))
                              (reset! (::focus-listener s)
                               (events/listen add-comment-node EventType/FOCUS
                                (fn [e]
@@ -280,6 +283,10 @@
                            s)
                           :will-unmount (fn [s]
                            (when @(::medium-editor s)
+                             (.unsubscribe
+                              @(::medium-editor s)
+                              "editableInput"
+                              #(enable-add-comment? s))
                              (.destroy @(::medium-editor s))
                              (reset! (::medium-editor s) nil))
                            (when @(::esc-key-listener s)

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -86,8 +86,9 @@
   (let [new-comment (rum/ref-node s "comment-body")
         comment-text (add-comment-content new-comment)]
     (stop-editing s)
-    (set! (.-innerHTML new-comment) comment-text)
-    (dis/dispatch! [:comment-save c comment-text])))
+    (when (pos? (count comment-text))
+      (set! (.-innerHTML new-comment) comment-text)
+      (dis/dispatch! [:comment-save c comment-text]))))
 
 (defn start-editing [s]
   (dis/dispatch! [:input [:comment-edit] (:uuid (first (:rum/args s)))])

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -85,10 +85,12 @@
   [e s c]
   (let [new-comment (rum/ref-node s "comment-body")
         comment-text (add-comment-content new-comment)]
-    (stop-editing s)
-    (when (pos? (count comment-text))
-      (set! (.-innerHTML new-comment) comment-text)
-      (dis/dispatch! [:comment-save c comment-text]))))
+    (if (pos? (count comment-text))
+      (do
+        (stop-editing s)
+        (set! (.-innerHTML new-comment) comment-text)
+        (dis/dispatch! [:comment-save c comment-text]))
+      (cancel-edit e s c))))
 
 (defn start-editing [s]
   (dis/dispatch! [:input [:comment-edit] (:uuid (first (:rum/args s)))])

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -76,8 +76,10 @@
         replace-br (.replace with-emojis-html (js/RegExp. "<br[ ]{0,}/?>" "ig") "\n")
         cleaned-text (.replace replace-br (js/RegExp. "<div?[^>]+(>|$)" "ig") "\n")
         cleaned-text-1 (.replace cleaned-text (js/RegExp. "</div?[^>]+(>|$)" "ig") "")
-        final-text (.html (.html (js/$ "<div/>") cleaned-text-1))]
-    (.trim final-text)))
+        final-node (.html (js/$ "<div/>") cleaned-text-1)
+        final-text (.trim (.text final-node))]
+    (when (pos? (count final-text))
+      (.trim (.html final-node)))))
 
 (defn edit-finished
   [e s c]

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -101,6 +101,9 @@
    :entry-save-on-exit  [[:base] (fn [base] (:entry-save-on-exit base))]
    :mobile-navigation-sidebar [[:base] (fn [base] (:mobile-navigation-sidebar base))]
    :orgs-dropdown-visible [[:base] (fn [base] (:orgs-dropdown-visible base))]
+   :add-comment-focus   [[:base] (fn [base] (:add-comment-focus base))]
+   :comment-add-finish  [[:base] (fn [base] (:comment-add-finish base))]
+   :comment-edit        [[:base] (fn [base] (:comment-edit base))]
    :email-verification  [[:base :auth-settings]
                           (fn [base auth-settings]
                             {:auth-settings auth-settings
@@ -234,8 +237,8 @@
                                 (get-in base (vec (conj (board-data-key org-slug edit-board-slug) :topics))))))]
    :activity-share        [[:base] (fn [base] (:activity-share base))]
    :activity-shared-data  [[:base] (fn [base] (:activity-shared-data base))]
-   :modal-data          [[:base :org-data :entry-edit-topics :activity-share]
-                          (fn [base org-data entry-edit-topics activity-share]
+   :modal-data          [[:base :org-data :entry-edit-topics :activity-share :add-comment-focus :comment-edit]
+                          (fn [base org-data entry-edit-topics activity-share add-comment-focus comment-edit]
                             {:org-data org-data
                              :activity-modal-fade-in (:activity-modal-fade-in base)
                              :board-filters (:board-filters base)
@@ -244,7 +247,9 @@
                              :dismiss-modal-on-editing-stop (:dismiss-modal-on-editing-stop base)
                              :entry-edit-topics entry-edit-topics
                              :activity-share activity-share
-                             :entry-save-on-exit (:entry-save-on-exit base)})]
+                             :entry-save-on-exit (:entry-save-on-exit base)
+                             :add-comment-focus add-comment-focus
+                             :comment-edit comment-edit})]
    :navbar-data         [[:base :org-data :board-data]
                           (fn [base org-data board-data]
                             (let [navbar-data (select-keys base [:mobile-menu-open
@@ -268,9 +273,7 @@
                                :error (:collect-pswd-error base)})]
    :media-input           [[:base]
                             (fn [base]
-                              (:media-input base))]
-   :add-comment-focus     [[:base] (fn [base] (:add-comment-focus base))]
-   :comment-add-finish    [[:base] (fn [base] (:comment-add-finish base))]})
+                              (:media-input base))]})
 
 ;; Action Loop =================================================================
 


### PR DESCRIPTION
Card: https://trello.com/c/LyZOf6zw

From a discussion in Slack with Stuart we decided to adopt MediumEditor even for our new and edit comment fields. This means that we can use its autolink feature that automatically turn links into anchor and the paste one that clean all the rich HTML before pasting content in the field.
All the rest of the features are disabled.

To test:
- focus the add comment link
- press Escape: do you NOT see the modal dismiss and go back to the board view? Good
- focus on the add comment and blur it while the field is empty, does it collapse back? Good
- type something with a url in it and check that it's turned into a link, it works? Good
- select some text, do you NOT see the MediumEditor toolbar appearing? Good
- while typing use CMD+B or CMD+I or CMD+U, do you NOT see the bold, italic or underline formatting appear when you type more? Good
- add the comment, does the link is still clickable in the new added comment? Good
- now from the horizontal ellipsis of the newly added comment click edit
- press Escape while the comment is in edit mode, do you NOT see the modal dismiss and go back to board? Good
- edit again, now click outside the comment, is it NOT the comment still editable? Good
- repeat the above tests of the add comment for the comment edit

NB: archive this card https://trello.com/c/BZ0fA4Rm/1113-auto-link-urls-in-comments when done since it's a duplicate of this one but with less details