### PR TITLE
Fix react from ap

### DIFF
--- a/src/oc/web/components/reactions.cljs
+++ b/src/oc/web/components/reactions.cljs
@@ -108,6 +108,9 @@
                  :class (utils/class-set {:reacted (:reacted r)
                                           :can-react (not read-only-reaction)
                                           :has-reactions (pos? (:count r))})
+                 :on-mouse-leave #(this-as this
+                                   (utils/remove-tooltips)
+                                   (.tooltip (js/$ this)))
                  :title reaction-attribution
                  :data-placement "top"
                  :data-container "body"


### PR DESCRIPTION
From [QADoc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#) feedback:

> On beta, adding a new reaction to a new post opened up from All Posts doesn’t work. Pick one from the picker, and nothing happens.

and 

> Remove the tooltip when the user remove a reaction (right now the tooltip gets stuck)