### PR TITLE
Fix editing

### DIFF
--- a/src/oc/web/components/activity_card.cljs
+++ b/src/oc/web/components/activity_card.cljs
@@ -110,8 +110,7 @@
                       (dis/dispatch!
                        [:activity-modal-fade-in
                         (:board-slug activity-data)
-                        (:uuid activity-data)
-                        (:type activity-data)]))))}
+                        (:uuid activity-data)]))))}
       ; Card header
       [:div.activity-card-head.group
         {:class "entry-card"}
@@ -160,7 +159,6 @@
                                          [:activity-modal-fade-in
                                           (:board-slug activity-data)
                                           (:uuid activity-data)
-                                          (:type activity-data)
                                           true]))}
                           "Edit"])
                       (when share-link
@@ -250,5 +248,4 @@
                           [:activity-modal-fade-in
                            (:board-slug activity-data)
                            (:uuid activity-data)
-                           (:type activity-data)
                            true]))}])]]))

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -27,10 +27,10 @@
 ;; Unsaved edits handling
 
 (defn autosave []
-  (let [body-el (sel1 [:div.rich-body-editor])
-        cleaned-body (when body-el
-                      (utils/clean-body-html (.-innerHTML body-el)))]
-    (dis/dispatch! [:entry-save-on-exit :modal-editing-data cleaned-body])))
+  (when-let [body-el (sel1 [:div.rich-body-editor])]
+    (let [cleaned-body (when body-el
+                        (utils/clean-body-html (.-innerHTML body-el)))]
+      (dis/dispatch! [:entry-save-on-exit :modal-editing-data cleaned-body]))))
 
 (defn save-on-exit?
   "Locally save the current outstanding edits if needed."
@@ -95,10 +95,11 @@
 
 (defn- headline-on-change [state]
   (toggle-save-on-exit state true)
-  (when-let [headline (sel1 [:div.activity-modal-content-headline])]
-    (let [emojied-headline (utils/emoji-images-to-unicode (gobj/get (utils/emojify (.-innerHTML headline)) "__html"))]
-      (dis/dispatch! [:input [:modal-editing-data :headline] emojied-headline])
-      (dis/dispatch! [:input [:modal-editing-data :has-changes] true]))))
+  (utils/after 10
+    #(when-let [headline (sel1 [:div.activity-modal-content-headline])]
+      (let [emojied-headline (utils/emoji-images-to-unicode (gobj/get (utils/emojify (.-innerHTML headline)) "__html"))]
+        (dis/dispatch! [:input [:modal-editing-data :headline] emojied-headline])
+        (dis/dispatch! [:input [:modal-editing-data :has-changes] true])))))
 
 (defn- setup-headline [state]
   (when-let [headline-el  (rum/ref-node state "edit-headline")]
@@ -130,9 +131,7 @@
   (when-not (responsive/is-tablet-or-mobile?)
     (dis/dispatch! [:activity-modal-edit (first (:rum/args state)) true])
     (utils/after 100 #(setup-headline state))
-    (reset! (::autosave-timer state)
-     (utils/every 5000
-      #(autosave)))
+    (reset! (::autosave-timer state) (utils/every 5000 autosave))
     (.click (js/$ "div.rich-body-editor a") #(.stopPropagation %))
     (when focus
       (utils/after 1000
@@ -182,6 +181,7 @@
 (defn- dismiss-editing? [state dismiss-modal?]
   (let [modal-data @(drv/get-ref state :modal-data)
         dismiss-fn (fn []
+                     (dis/dispatch! [:entry-clear-local-cache :modal-editing-data])
                      (stop-editing state)
                      (when (or dismiss-modal?)
                        (close-clicked state)))]
@@ -205,7 +205,6 @@
                         :link-button-cb #(dis/dispatch! [:alert-modal-hide])
                         :solid-button-title "Yes"
                         :solid-button-cb #(do
-                                            (dis/dispatch! [:entry-clear-local-cache :modal-editing-data])
                                             (dis/dispatch! [:alert-modal-hide])
                                             (dismiss-fn))
                         }]
@@ -323,6 +322,9 @@
                                 (reset! (::window-resize-listener s) nil))
                               (set! (.-onbeforeunload js/window) nil)
                               s)
+                             :will-update (fn [s]
+                              (setup-editing-data s)
+                              s)
                              :did-remount (fn [_ s]
                               (let [modal-data @(drv/get-ref s :modal-data)]
                                 (let [save-on-exit (:entry-save-on-exit modal-data)]
@@ -333,6 +335,9 @@
                                       "Do you want to save before leaving?")
                                     nil)))
                                 (setup-editing-data s)
+                                (when (and (:modal-editing modal-data)
+                                           (nil? @(::autosave-timer s)))
+                                  (utils/after 1000 #(real-start-editing s :headline)))
                                 (when (and (:modal-editing modal-data)
                                            @(::entry-saving s))
                                   (let [entry-edit (:modal-editing-data modal-data)

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -203,9 +203,7 @@
                             js/window
                             EventType/RESIZE
                             #(calc-entry-edit-modal-height s true)))
-                          (reset! (::autosave-timer s)
-                           (utils/every 5000
-                            #(autosave)))
+                          (reset! (::autosave-timer s) (utils/every 5000 autosave))
                           s)
                          :before-render (fn [s] (calc-entry-edit-modal-height s) s)
                          :after-render  (fn [s] (should-show-divider-line s) s)

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -71,7 +71,7 @@
   (let [org-slug (router/current-org-slug)
         board-slug (router/current-board-slug)]
         ;; if we are coming from all-posts
-        (if (:from-all-posts @router/path)
+        (if (or (:from-all-posts @router/path) (= board-slug "all-posts"))
           ;; We need to update the entry in all-posts data, not in the board data
           (all-posts-key org-slug)
           (board-data-key org-slug board-slug))))


### PR DESCRIPTION
From [QADoc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#) feedback:

> Editing a post from All Posts doesn’t work either. When you close the post, you’ll actually see that it did save, but you don’t know it in real time when you pick it.

Also this addresses the case where the cached post wasn't removed from the local browser database even if the user was dismissing the editing view intentionally and asking to lose the edits.