### PR TITLE
Minor fixes

### DIFF
--- a/src/oc/web/components/entries_layout.cljs
+++ b/src/oc/web/components/entries_layout.cljs
@@ -37,12 +37,6 @@
                   (> published-at too-old)
                   (or (> published-at seen-at)
                       (nil? seen-at)))]
-    (timbre/debug "New'ness in board test for:" (:uuid entry)
-                  "in-team?:" in-team?
-                  "user-id / author-id:" user-id author-id
-                  "created:" published-at
-                  "seen:" seen-at
-                  "new?:" new?)
     new?))
 
 (defn is-share-thoughts? [entry changes]

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -41,11 +41,6 @@
         new? (and in-team?
                   (or (and change-at nav-at (> change-at nav-at))
                       (and change-at (not nav-at))))]
-    (timbre/debug "New'ness in nav. test for:" (:slug board)
-                  "in-team?:" in-team?
-                  "change:" change-at
-                  "nav:" nav-at
-                  "new?:" new?)
     new?))
 
 (def sidebar-top-margin 122)

--- a/src/oc/web/components/ui/empty_board.cljs
+++ b/src/oc/web/components/ui/empty_board.cljs
@@ -35,8 +35,9 @@
                  :max-width (str (if mobile? (:width mobile-image-size) 416) "px")
                  :max-height (str (if mobile? (:height mobile-image-size) 424) "px")}}]
       (when mobile?
-        [:div.empty-board-footer
-          {:dangerouslySetInnerHTML (utils/emojify (str "Shoot, looks like there aren’t any posts in " (:name board-data) " yet...."))}])
+        (let [empty-board-copy (str "Shoot, looks like there aren’t any posts in " (:name board-data) " yet....")]
+          [:div.empty-board-footer
+            {:dangerouslySetInnerHTML (utils/emojify empty-board-copy)}]))
       (when false ;; mobile?
         [:button.mlb-reset.empty-board-create-first-post
           [:div.empty-board-first-post-container

--- a/src/oc/web/components/ui/onboard_overlay.cljs
+++ b/src/oc/web/components/ui/onboard_overlay.cljs
@@ -40,8 +40,8 @@
             [:div.onboard-overlay-step-description
               (if first-ever-user?
                 (str
-                 "Carrot posts make your announcements, updates and "
-                 "plans visible and engaging.")
+                 "Team announcements, updates and plans should never "
+                 "get lost in the noise!")
                 (str
                  "Carrot posts make announcements, updates and plans"
                  " visible and engaging."))]


### PR DESCRIPTION
A couple of small improvements:
- remove 2 debug logs that are not needed anymore
- make bikeshed happy cutting a long line of code

Also from the [QADoc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#):

> NUX copy change, after you go thru three set up steps, change “Carrot posts make your announcements, updates and plans visible and engaging.” to “Team announcements, updates and plans should never get lost in the noise!”