### PR TITLE
Mobile comments improvements

### DIFF
--- a/scss/partials/_activity_modal.scss
+++ b/scss/partials/_activity_modal.scss
@@ -8,6 +8,13 @@ div.activity-modal-container {
   z-index: #{$navbar_zindex + 100};
   transition: opacity 180ms ease-in;
 
+  @include mobile() {
+    position: unset;
+    top: unset;
+    left: unset;
+    height: auto;
+  }
+
   &.will-appear {
     opacity: 0;
   }
@@ -75,7 +82,7 @@ div.activity-modal-container {
     @include mobile() {
       width: 100%;
       min-height: initial;
-      margin-top: 123px;
+      max-height: initial;
     }
 
     div.activity-modal {
@@ -92,6 +99,8 @@ div.activity-modal-container {
         margin: 0px;
         box-shadow: none;
         border-radius: 0px;
+        overflow-x: hidden;
+        overflow-y: auto;
       }
 
       div.activity-modal-mobile-header {
@@ -99,15 +108,12 @@ div.activity-modal-container {
 
         @include mobile() {
           display: block;
-          position: fixed;
-          top: 0px;
           height: 64px;
           background-color: $carrot_light_gray_7;
-          left: 0px;
           width: 100%;
           padding: 12px 18px;
           text-align: center;
-          position: relativel
+          position: relative;
         }
 
         button.mobile-modal-close-bt {
@@ -140,9 +146,6 @@ div.activity-modal-container {
 
         @include mobile() {
           height: 59px;
-          position: fixed;
-          top: 64px;
-          left: 0px;
           width: 100%;
           border-radius: 0px;
           padding: 14px 17px;
@@ -314,7 +317,11 @@ div.activity-modal-container {
             width: 100%;
             min-height: initial;
             border-radius: 0px;
-            height: calc(100vh - 123px);
+            height: auto;
+            max-height: initial;
+            min-height: initial;
+            flex-shrink: unset;
+            flex-basis: unset;
           }
 
           div.activity-left-column-content {
@@ -331,6 +338,7 @@ div.activity-modal-container {
               @include mobile() {
                 padding: 0px 24px;
                 height: 100%;
+                overflow-y: visible;
               }
 
 

--- a/scss/partials/_base.scss
+++ b/scss/partials/_base.scss
@@ -105,6 +105,7 @@ a:hover, a:hover *{
   content: "";
   display: table;
   clear: both;
+  white-space: nowrap;
 }
 
 /*

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -499,10 +499,16 @@ div.comments {
 
             @include mobile() {
               width: 100%;
+              resize: vertical;
+              height: auto;
             }
 
             &.show-buttons {
               height: 58px;
+
+              @include mobile() {
+                height: auto;
+              }
             }
 
             .emojione {

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -205,8 +205,10 @@ div.comments {
       padding: 4px 14px 4px 0px;
       position: relative;
 
-      &:hover div.comment-content div.comment-footer-container div.edit-delete-button button.more-button {
-        opacity: 1;
+      @include big_web() {
+        &:hover div.comment-content div.comment-footer-container div.edit-delete-button button.more-button {
+          opacity: 1;
+        }
       }
 
       div.comment-avatar-container {
@@ -543,8 +545,10 @@ div.comments {
                 height: 32px;
                 width: 59px;
 
-                &:hover {
-                  color: white;
+                @include big_web() {
+                  &:hover {
+                    color: white;
+                  }
                 }
               }
             }

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -397,8 +397,7 @@ div.comments {
       @include mobile() {
         padding: 16px 0px 0px;
         width: 100%;
-        position: absolute;
-        bottom: 0px;
+        position: relative;
       }
 
       div.add-comment-label {

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -258,7 +258,7 @@ div.comments {
         &.single-emoji {
           div.comment-body-container {
             height: 50px;
-            p.comment-body {
+            div.comment-body {
               background-color: transparent;
               font-size: 50px;
               padding: 0px;
@@ -277,7 +277,7 @@ div.comments {
         div.comment-body-container {
           margin-top: 4px;
 
-          p.comment-body {
+          div.comment-body {
             @include avenir_M();
             font-size: 13px;
             color: rgba(78,90,107,0.8);

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -395,9 +395,9 @@ div.comments {
       width: 316px;
 
       @include mobile() {
-        padding: 0px;
-        width: calc(100% - 64px);
-        position: fixed;
+        padding: 16px 0px 0px;
+        width: 100%;
+        position: absolute;
         bottom: 0px;
       }
 

--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -7,7 +7,7 @@ div.comments {
   height: 100%;
 
   @include mobile() {
-    margin: 32px auto 80px;
+    margin: 32px auto;
     height: auto;
   }
 
@@ -394,7 +394,9 @@ div.comments {
 
       @include mobile() {
         padding: 0px;
-        width: 100%;
+        width: calc(100% - 64px);
+        position: fixed;
+        bottom: 0px;
       }
 
       div.add-comment-label {
@@ -404,6 +406,10 @@ div.comments {
         line-height: 14px;
         margin-bottom: 8px;
         color: $carrot_light_gray_3;
+
+        @include mobile() {
+          display: none;
+        }
       }
 
       &:before {

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -501,7 +501,8 @@
                   (if editing
                     [:div.activity-modal-footer.group
                       {:class (when @(::show-bottom-border s) "scrolling-content")}
-                      (when-not (js/isIE)
+                      (when (and (not (js/isIE))
+                                 (not is-mobile?))
                         (emoji-picker {:add-emoji-cb (partial add-emoji-cb s)
                                        :container-selector "div.activity-modal-content"}))
                       [:div.activity-modal-footer-right

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -256,7 +256,8 @@
                             (rum/local false ::edited-data-loaded)
                             (rum/local nil ::autosave-timer)
                             ;; Mixins
-                            mixins/no-scroll-mixin
+                            (when-not (responsive/is-mobile-size?)
+                              mixins/no-scroll-mixin)
                             mixins/first-render-mixin
 
                             {:before-render (fn [s]

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -74,12 +74,12 @@
   (let [inner-html (.-innerHTML add-comment-div)
         with-emojis-html (utils/emoji-images-to-unicode (gobj/get (utils/emojify inner-html) "__html"))
         replace-br (.replace with-emojis-html (js/RegExp. "<br[ ]{0,}/?>" "ig") "\n")
-        cleaned-text (.replace replace-br (js/RegExp. "<div?[^>]+(>|$)" "ig") "\n")
-        cleaned-text-1 (.replace cleaned-text (js/RegExp. "</div?[^>]+(>|$)" "ig") "")
+        cleaned-text (.replace replace-br (js/RegExp. "<div?[^>]+(>|$)" "ig") "")
+        cleaned-text-1 (.replace cleaned-text (js/RegExp. "</div?[^>]+(>|$)" "ig") "\n")
         final-node (.html (js/$ "<div/>") cleaned-text-1)
         final-text (.trim (.text final-node))]
     (when (pos? (count final-text))
-      (.trim (.html final-node)))))
+      (string/trim (.html final-node)))))
 
 (defn edit-finished
   [e s c]
@@ -193,7 +193,7 @@
           [:div.comment-timestamp
             (utils/time-since (:created-at c))]]
         [:div.comment-body-container
-          [:p.comment-body.group
+          [:div.comment-body.group
            {:ref "comment-body"
             :class (utils/class-set {:editable can-edit?
                                      :is-owner is-owner?
@@ -333,7 +333,7 @@
                               (reset! (::show-buttons s) false)
                               (dis/dispatch! [:input [:add-comment-focus] false])
                               (dis/dispatch! [:comment-add activity-data (add-comment-content add-comment-div)])
-                              (set! (.-innerHTML add-comment-div) ""))
+                              (set! (.-innerHTML add-comment-div) "<p><br/></p>"))
                  :disabled @(::add-button-disabled s)}
                 "Add"]]])]
        (when (and (not (js/isIE))

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -326,7 +326,8 @@
                               (set! (.-innerHTML add-comment-div) ""))
                  :disabled @(::add-button-disabled s)}
                 "Add"]]])]
-       (when-not (js/isIE)
+       (when (and (not (js/isIE))
+                  (not (responsive/is-tablet-or-mobile?)))
          (emoji-picker {:width 32
                         :height 32
                         :add-emoji-cb (fn [active-element emoji already-added?]

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -392,6 +392,7 @@
                         (load-comments-if-needed s)
                         (when @(drv/get-ref s :comment-add-finish)
                           (reset! (::scroll-bottom-after-render s) true)
+                          (dis/dispatch! [:input [:comment-add-finish] false])
                           (utils/after 500 #(scroll-to-bottom s true)))
                         (let [add-comment-focus @(drv/get-ref s :add-comment-focus)
                               scrolled-on-add-focus (::scrolled-on-add-focus s)]

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -385,7 +385,8 @@
                         (load-comments-if-needed s)
                         s)
                        :did-mount (fn [s]
-                        (utils/after 1000 #(scroll-to-bottom s true))
+                        (when-not (responsive/is-tablet-or-mobile?)
+                          (utils/after 1000 #(scroll-to-bottom s true)))
                         s)
                        :did-remount (fn [o s]
                         (load-comments-if-needed s)

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -405,7 +405,8 @@
                           (when (and (not @(::initially-scrolled s))
                                      (not show-loading))
                             (reset! (::initially-scrolled s) true)
-                            (utils/after 230 #(scroll-to-bottom s true))))
+                            (when-not (responsive/is-tablet-or-mobile?)
+                              (utils/after 230 #(scroll-to-bottom s true)))))
                         s)}
   [s activity-data]
   (let [is-mobile? (responsive/is-tablet-or-mobile?)

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -243,9 +243,12 @@
     (when (not= next-add-bt-disabled @(::add-button-disabled s))
       (reset! (::add-button-disabled s) next-add-bt-disabled))))
 
+(defn- save-add-comment-height
+  [s]
+  (dis/dispatch! [:input [:add-comment-height] (+ (.height (js/$ (rum/dom-node s))) 16)]))
+
 (defn editable-input-change [s editable event]
-  (utils/after 10
-    #(dis/dispatch! [:input [:add-comment-height] (.height (js/$ (rum/dom-node s)))]))
+  (utils/after 10 save-add-comment-height)
   (enable-add-comment? s))
 
 (rum/defcs add-comment < rum/reactive
@@ -276,8 +279,7 @@
                                  (enable-add-comment? s)
                                  (dis/dispatch! [:input [:add-comment-focus] true])
                                  (reset! (::show-buttons s) true)
-                                 (utils/after 10
-                                  #(dis/dispatch! [:input [:add-comment-height] (.height (js/$ (rum/dom-node s)))])))))
+                                 (utils/after 10 save-add-comment-height))))
                              (reset! (::blur-listener s)
                               (events/listen add-comment-node EventType/BLUR
                                (fn [e]
@@ -285,8 +287,7 @@
                                  (when (zero? (count (.-innerText add-comment-node)))
                                    (dis/dispatch! [:input [:add-comment-focus] false])
                                    (reset! (::show-buttons s) false))
-                                 (utils/after 10
-                                  #(dis/dispatch! [:input [:add-comment-height] (.height (js/$ (rum/dom-node s)))])))))
+                                 (utils/after 10 save-add-comment-height))))
                              (reset! (::esc-key-listener s)
                                (events/listen
                                 js/window
@@ -294,7 +295,7 @@
                                 #(when (and (= (.-key %) "Escape")
                                             (= (.-activeElement js/document) add-comment-node))
                                    (.blur add-comment-node)))))
-                            (dis/dispatch! [:input [:add-comment-height] (.height (js/$ (rum/dom-node s)))])
+                            (save-add-comment-height s)
                            s)
                           :will-unmount (fn [s]
                            (when @(::medium-editor s)

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -293,30 +293,21 @@
               (zero? (count (:boards org-data)))
               (empty-org)
               ;; All Posts
-              (and is-all-posts
-                   (or (and is-mobile-size?
-                            (not current-activity-id))
-                       (not is-mobile-size?)))
+              is-all-posts
               (rum/with-key
                (all-posts all-posts-data)
                (str "all-posts-" (clojure.string/join (keys (:fixed-items all-posts-data)))))
               ;; Empty board
-              (and (not current-activity-id)
-                   empty-board?)
+              empty-board?
               (empty-board)
               ;; Layout boards activities
               :else
               (cond
                 ;; Drafts
-                (and is-drafts-board
-                     (or (and is-mobile-size?
-                              (not current-activity-id))
-                         (not is-mobile-size?)))
+                is-drafts-board
                 (drafts-layout board-data)
                 ;; Entries
-                (or (and is-mobile-size?
-                         (not current-activity-id))
-                    (not is-mobile-size?))
+                :else
                 (entries-layout board-data board-filters)))
             ;; Add entry floating button
             (when (and (not (:read-only org-data))

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -347,6 +347,7 @@
           {:class (when-not @(::show-divider-line s) "not-visible")}]
         [:div.entry-edit-modal-footer.group
           (when (and (not nux)
+                     (not (responsive/is-tablet-or-mobile?))
                      (not (js/isIE)))
             (emoji-picker {:add-emoji-cb (partial add-emoji-cb s)
                            :container-selector "div.entry-edit-modal"}))

--- a/src/oc/web/components/mobile_boards_list.cljs
+++ b/src/oc/web/components/mobile_boards_list.cljs
@@ -15,7 +15,7 @@
         loading (drv/react s :loading)]
     [:div.mobile-boards-list-container
       (if loading
-        [:div.org-dashboard.main-scroll
+        [:div.org-dashboard
           (loading {:loading true})]
         [:div.mobile-boards-list
           (navbar)

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -57,15 +57,14 @@
               ;; First ever user nux, not enough time
               (and (:nux-loading data)
                    (not (:nux-end data))))
-        (dom/div {:class (utils/class-set {:org-dashboard true
-                                           :main-scroll true})}
+        (dom/div {:class "org-dashboard"}
           (loading {:loading true :nux (or (cook/get-cookie :nux) (:nux-loading data))}))
         (dom/div {:class (utils/class-set {:org-dashboard true
                                            :mobile-dashboard (responsive/is-mobile-size?)
                                            :modal-activity-view (router/current-activity-id)
                                            :mobile-or-tablet (responsive/is-tablet-or-mobile?)
-                                           :main-scroll true
-                                           :no-scroll (router/current-activity-id)})}
+                                           :no-scroll (and (not (responsive/is-mobile-size?))
+                                                           (router/current-activity-id))})}
           ;; Use cond for the next components to exclud each other and avoid rendering all of them
           (cond
             (some #{(:nux data)} [:1 :7])
@@ -110,11 +109,10 @@
           (when (and (:media-input data)
                      (:media-chart (:media-input data)))
             (media-chart-modal))
-          (dom/div {:class "page"}
-            ;; Navbar
-            (when-not (and (responsive/is-tablet-or-mobile?)
+          (when-not (and (responsive/is-tablet-or-mobile?)
                            (router/current-activity-id))
-              (navbar))
-            (dom/div {:class "dashboard-container"}
-              (dom/div {:class "topic-list"}
-                (dashboard-layout)))))))))
+            (dom/div {:class "page"}
+              (navbar)
+              (dom/div {:class "dashboard-container"}
+                (dom/div {:class "topic-list"}
+                  (dashboard-layout))))))))))

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -104,6 +104,7 @@
    :add-comment-focus   [[:base] (fn [base] (:add-comment-focus base))]
    :comment-add-finish  [[:base] (fn [base] (:comment-add-finish base))]
    :comment-edit        [[:base] (fn [base] (:comment-edit base))]
+   :add-comment-height  [[:base] (fn [base] (:add-comment-height base))]
    :email-verification  [[:base :auth-settings]
                           (fn [base auth-settings]
                             {:auth-settings auth-settings


### PR DESCRIPTION
From this card:
https://trello.com/c/nKpWC0GP

Try to address these items:
- Stick comment box to keyboard (look for technical solution)
- Chrono order for comments, not reverse chrono
- Remove all fixed headers, allow all to scroll
- Given all the changes above, look into inertia scrolling, possible?
- Hover state cleanup (only for comments)

To test hover state please use your mobile device or a simulator.

About this:
> Stick comment box to keyboard (look for technical solution)

Because of an iOS bug with editable field into fixed container (the caret is shown in a different place, usually not visible at all) we decided to move the add comment box at the bottom of the modal after all the comments.

Fixed 2 issues Stuart's found:
- when adding a comment the view doesn't scroll to the bottom (the newly added comment should be visible)
- when adding a comment, if you manually (or automatically) scroll to the bottom the add comment box partially cover the last comment