### PR TITLE
Disable hover states for reactions.

### DIFF
--- a/scss/partials/_reactions.scss
+++ b/scss/partials/_reactions.scss
@@ -57,16 +57,19 @@ div.reactions {
       &.can-react {
         cursor: pointer;
 
-        &.reacted:hover {
-          background-color: rgba(#FED157, 0.4);
-        }
+        @include big_web() {
 
-        &:hover {
-          background-color: #EBE9E3;
+          &.reacted:hover {
+            background-color: rgba(#FED157, 0.4);
+          }
 
-          span.reaction {
-            -webkit-filter: grayscale(0%);
-            filter: grayscale(0%);
+          &:hover {
+            background-color: #EBE9E3;
+
+            span.reaction {
+              -webkit-filter: grayscale(0%);
+              filter: grayscale(0%);
+            }
           }
         }
       }


### PR DESCRIPTION
From this card:
https://trello.com/c/nKpWC0GP

To address this:
- Hover state cleanup

but only for reactions