### PR TITLE
Whitelist xhr with 0 status

### DIFF
--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -137,15 +137,14 @@
         (when (and (j/jwt)
                    (= status 401))
           (router/redirect! oc-urls/logout))
-        ; report all 5xx to sentry
+        ; If it was a 5xx or a 0 show a banner for network issues
         (when (or (zero? status)
-                  (and (>= status 500) (<= status 599))
+                  (and (>= status 500) (<= status 599)))
+          (dispatcher/dispatch! [:error-banner-show utils/generic-network-error 10000]))
+        ; report all 5xx to sentry
+        (when (or (and (>= status 500) (<= status 599))
                   (= status 400)
                   (= status 422))
-          ; If it was a 5xx or a 0 show a banner for network issues
-          (when (or (zero? status)
-                    (and (>= status 500) (<= status 599)))
-            (dispatcher/dispatch! [:error-banner-show utils/generic-network-error 10000]))
           (let [report {:response response
                         :path path
                         :method (method-name method)


### PR DESCRIPTION
We currently report all network request that return statuses 0 and 5xx. Since 0 are most likely caused by client side network issues we see no value in reporting those so we are removing the support for it.
We want to keep the red banner though to let the user know that something is not working.

To test:
- load a board
- turn off your network
- change board
- [x] do you see the red error banner? Good
- [x] do you NOT see a sentry attempted request in the network tab of the dev tools? Good