### PR TITLE
update to derivatives 0.3.0

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -26,7 +26,7 @@
     [org.omcljs/om "1.0.0-beta1" :excludes [cljsjs/react]] ; Cljs interface to React https://github.com/omcljs/om
     [org.clojars.martinklepsch/om-tools "0.4.0-w-select"] ; Tools for Om https://github.com/plumatic/om-tools/pull/91
     [rum "0.10.8" :exclusions [cljsjs/react]] ; https://github.com/tonsky/rum
-    [org.martinklepsch/derivatives "0.2.0"] ; Chains of derived data https://github.com/martinklepsch/derivatives
+    [org.martinklepsch/derivatives "0.3.0"] ; Chains of derived data https://github.com/martinklepsch/derivatives
     [cljs-flux "0.1.2"] ; Flux implementation for Om https://github.com/kgann/cljs-flux
     
     ;; ClojureScript libraries

--- a/src/oc/web/rum_utils.cljs
+++ b/src/oc/web/rum_utils.cljs
@@ -9,9 +9,8 @@
   (defn- om-derivatives [pool]
     (->> {:childContextTypes {get-k js/React.PropTypes.func
                               release-k js/React.PropTypes.func}
-          :getChildContext (fn [] (let [pool]
-                                    (clj->js {get-k     (partial drv/get! pool)
-                                              release-k (partial drv/release! pool)})))}
+          :getChildContext (fn [] (clj->js {get-k     (partial drv/get! pool)
+                                            release-k (partial drv/release! pool)}))}
          (merge om/pure-methods)
          clj->js
          om/specify-state-methods!)))

--- a/src/oc/web/rum_utils.cljs
+++ b/src/oc/web/rum_utils.cljs
@@ -6,12 +6,12 @@
 
 (let [get-k "org.martinklepsch.derivatives/get"
       release-k "org.martinklepsch.derivatives/release"]
-  (defn om-derivatives [mngr]
+  (defn- om-derivatives [pool]
     (->> {:childContextTypes {get-k js/React.PropTypes.func
                               release-k js/React.PropTypes.func}
-          :getChildContext (fn [] (let [{:keys [release! get!]} mngr]
-                                    (clj->js {get-k get!
-                                              release-k release!})))}
+          :getChildContext (fn [] (let [pool]
+                                    (clj->js {get-k     (partial drv/get! pool)
+                                              release-k (partial drv/release! pool)})))}
          (merge om/pure-methods)
          clj->js
          om/specify-state-methods!)))


### PR DESCRIPTION
I haven't tested this code but think it should work.
Derivatives 0.3.0 contains a breaking change which affects
the Om utilities in `rum-utils`. [Changelog](https://github.com/martinklepsch/derivatives/blob/master/CHANGES.md#030)