### PR TITLE
Goodbye Om

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -18,20 +18,17 @@
     ;; NB: Can't go past ClojureScript 1.9.908 right now due to issues w/ React
     [org.clojure/clojurescript "1.9.908"] ; ClojureScript compiler https://github.com/clojure/clojurescript
 
-    ;; Om and Rum React Frameworks
-    ;; Didn't update to 15.5.4+ just yet since it requires some changes to oc.web.rum-utils to remove .-PropTypes acecss
+    ;; Rum React Frameworks
+    ;; Didn't update to 15.5.4+ just yet since it requires some changes to oc.web.rum-utils to remove .-PropTypes access
     ;; and some change to omcljs/om to not use createClass anymore. See React docs for more info.
     [cljsjs/react "15.4.2-2"] ; A Javascript library for building user interfaces https://github.com/cljsjs/packages
     [cljsjs/react-dom "15.4.2-2"] ; A Javascript library for building user interfaces https://github.com/cljsjs/packages
-    [org.omcljs/om "1.0.0-beta1" :excludes [cljsjs/react]] ; Cljs interface to React https://github.com/omcljs/om
-    [org.clojars.martinklepsch/om-tools "0.4.0-w-select"] ; Tools for Om https://github.com/plumatic/om-tools/pull/91
     [rum "0.10.8" :exclusions [cljsjs/react]] ; https://github.com/tonsky/rum
     [org.martinklepsch/derivatives "0.3.0"] ; Chains of derived data https://github.com/martinklepsch/derivatives
     [cljs-flux "0.1.2"] ; Flux implementation for Om https://github.com/kgann/cljs-flux
     
     ;; ClojureScript libraries
     [cljs-http "0.1.44"] ; HTTP for cljs https://github.com/r0man/cljs-http
-    [prismatic/schema "1.1.7"] ; Dependency of om-tools https://github.com/Prismatic/schema
     [secretary "2.0.0.1-41b949"] ; Client-side router https://github.com/gf3/secretary
     [prismatic/dommy "1.1.0"] ; DOM manipulation and event library https://github.com/Prismatic/dommy
     [com.cognitect/transit-cljs "0.8.243"] ; ClojureScript wrapper for JavaScript JSON https://github.com/cognitect/transit-cljs

--- a/site/oc/pages.clj
+++ b/site/oc/pages.clj
@@ -15,7 +15,7 @@
 (defn carrot-box-thanks [carrot-box-class]
   [:div.carrot-box-container.group
     {:class carrot-box-class
-     :style #js {:display "none"}}
+     :style {:display "none"}}
     ; [:img.carrot-box {:src (cdn "/img/ML/carrot_box.svg")}]
     [:div.carrot-box-thanks
       [:div.thanks-headline "Thanks!"]
@@ -85,7 +85,7 @@
             "Get started for free"]]
         (carrot-box-thanks "carrot-box-thanks-top")
         [:div.carrot-box-container.confirm-thanks.group
-          {:style #js {:display "none"}}
+          {:style {:display "none"}}
           [:div.carrot-box-thanks
             [:div.thanks-headline "You are Confirmed!"]
             [:div.thanks-subheadline "Thank you for subscribing."]]]

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -89,7 +89,8 @@
 (defn bot-auth [org-data team-data user-data]
   (let [current (router/get-token)
         auth-link (utils/link-for (:links team-data) "bot")
-        fixed-auth-url (utils/slack-link-with-state (:href auth-link) (:user-id user-data) (:id team-data) (router/get-token))]
+        fixed-auth-url (utils/slack-link-with-state (:href auth-link) (:user-id user-data) (:id team-data)
+                        (router/get-token))]
     (router/redirect! fixed-auth-url)))
 
 (defn auth-with-token-failed [error]

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -1,7 +1,6 @@
 (ns oc.web.components.org-dashboard
-  (:require [om.core :as om :include-macros true]
-            [om-tools.core :as om-core :refer-macros (defcomponent)]
-            [om-tools.dom :as dom :include-macros true]
+  (:require [rum.core :as rum]
+            [org.martinklepsch.derivatives :as drv]
             [oc.web.lib.jwt :as jwt]
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
@@ -34,87 +33,90 @@
                                 (some #(when (= (:slug %) (router/current-board-slug)) %) (:boards (dis/org-data))))]
          (dis/dispatch! [:board-get (utils/link-for (:links fixed-board-data) ["item" "self"] "GET")])))))))
 
-(defcomponent org-dashboard [data owner]
-
-  (did-mount [_]
-    (utils/after 100 #(set! (.-scrollTop (.-body js/document)) 0))
-    (refresh-board-data))
-
-  (render-state [_ {:keys [columns-num card-width] :as state}]
-    (let [org-data (dis/org-data data)
-          all-posts-data (dis/all-posts-data data)
-          board-data (dis/board-data data)]
-      ;; Show loading if
-      (if (or ;; the org data are not loaded yet
-              (not org-data)
-              ;; No board specified
-              (and (not (router/current-board-slug))
-                   ;; but there are some
-                   (pos? (count (:boards org-data))))
-              ;; Board specified
-              (and (router/current-board-slug)
-                   ;; But no board/all-posts data yet
-                   (not board-data)
-                   (not all-posts-data))
-              ;; First ever user nux, not enough time
-              (and (:nux-loading data)
-                   (not (:nux-end data))))
-        (dom/div {:class "org-dashboard"}
-          (loading {:loading true :nux (or (cook/get-cookie :nux) (:nux-loading data))}))
-        (dom/div {:class (utils/class-set {:org-dashboard true
-                                           :mobile-dashboard (responsive/is-mobile-size?)
-                                           :modal-activity-view (router/current-activity-id)
-                                           :mobile-or-tablet (responsive/is-tablet-or-mobile?)
-                                           :no-scroll (and (not (responsive/is-mobile-size?))
-                                                           (router/current-activity-id))})}
-          ;; Use cond for the next components to exclud each other and avoid rendering all of them
-          (cond
-            (some #{(:nux data)} [:1 :7])
-            (onboard-overlay (:nux data))
-            ;; Org settings
-            (:org-settings data)
-            (org-settings)
-            ;; About carrot
-            (:whats-new-modal data)
-            (whats-new-modal)
-            ;; Made with carrot modal
-            (:made-with-carrot-modal data)
-            (made-with-carrot-modal)
-            ;; Entry editing
-            (:entry-editing data)
-            (entry-edit)
-            ;; Board editing
-            (:board-editing data)
-            (board-edit)
-            ;; Activity modal
-            (and (router/current-activity-id)
-                 (not (:entry-edit-dissmissing data)))
-            (let [from-ap (:from-all-posts @router/path)
-                  board-slug (if from-ap :all-posts (router/current-board-slug))]
-              (activity-modal
-               (dis/activity-data
-                (router/current-org-slug)
-                board-slug
-                (router/current-activity-id)
-                data))))
-          ;; Activity share modal
-          (when (:activity-share data)
-            (activity-share))
-          ;; Alert modal
-          (when (:alert-modal data)
-            (alert-modal))
-          ;; Media video modal for entry editing
-          (when (and (:media-input data)
-                     (:media-video (:media-input data)))
-            (media-video-modal))
-          ;; Media chart modal for entry editing
-          (when (and (:media-input data)
-                     (:media-chart (:media-input data)))
-            (media-chart-modal))
-          (when-not (and (responsive/is-tablet-or-mobile?)
-                           (router/current-activity-id))
-            (dom/div {:class "page"}
-              (navbar)
-              (dom/div {:class "dashboard-container"}
-                (dom/div {:class "topic-list"}
-                  (dashboard-layout))))))))))
+(rum/defcs org-dashboard < rum/static
+                           rum/reactive
+                           (drv/drv :base)
+                           {:did-mount (fn [s]
+                             (utils/after 100 #(set! (.-scrollTop (.-body js/document)) 0))
+                             (refresh-board-data)
+                             s)}
+  [s]
+  (let [data (drv/react s :base)
+        org-data (dis/org-data data)
+        all-posts-data (dis/all-posts-data data)
+        board-data (dis/board-data data)]
+    ;; Show loading if
+    (if (or ;; the org data are not loaded yet
+            (not org-data)
+            ;; No board specified
+            (and (not (router/current-board-slug))
+                 ;; but there are some
+                 (pos? (count (:boards org-data))))
+            ;; Board specified
+            (and (router/current-board-slug)
+                 ;; But no board/all-posts data yet
+                 (not board-data)
+                 (not all-posts-data))
+            ;; First ever user nux, not enough time
+            (and (:nux-loading data)
+                 (not (:nux-end data))))
+      [:div.org-dashboard
+        (loading {:loading true :nux (or (cook/get-cookie :nux) (:nux-loading data))})]
+      [:div
+        {:class (utils/class-set {:org-dashboard true
+                                  :mobile-dashboard (responsive/is-mobile-size?)
+                                  :modal-activity-view (router/current-activity-id)
+                                  :mobile-or-tablet (responsive/is-tablet-or-mobile?)
+                                  :no-scroll (and (not (responsive/is-mobile-size?))
+                                                  (router/current-activity-id))})}
+        ;; Use cond for the next components to exclud each other and avoid rendering all of them
+        (cond
+          (some #{(:nux data)} [:1 :7])
+          (onboard-overlay (:nux data))
+          ;; Org settings
+          (:org-settings data)
+          (org-settings)
+          ;; About carrot
+          (:whats-new-modal data)
+          (whats-new-modal)
+          ;; Made with carrot modal
+          (:made-with-carrot-modal data)
+          (made-with-carrot-modal)
+          ;; Entry editing
+          (:entry-editing data)
+          (entry-edit)
+          ;; Board editing
+          (:board-editing data)
+          (board-edit)
+          ;; Activity modal
+          (and (router/current-activity-id)
+               (not (:entry-edit-dissmissing data)))
+          (let [from-ap (:from-all-posts @router/path)
+                board-slug (if from-ap :all-posts (router/current-board-slug))]
+            (activity-modal
+             (dis/activity-data
+              (router/current-org-slug)
+              board-slug
+              (router/current-activity-id)
+              data))))
+        ;; Activity share modal
+        (when (:activity-share data)
+          (activity-share))
+        ;; Alert modal
+        (when (:alert-modal data)
+          (alert-modal))
+        ;; Media video modal for entry editing
+        (when (and (:media-input data)
+                   (:media-video (:media-input data)))
+          (media-video-modal))
+        ;; Media chart modal for entry editing
+        (when (and (:media-input data)
+                   (:media-chart (:media-input data)))
+          (media-chart-modal))
+        (when-not (and (responsive/is-tablet-or-mobile?)
+                         (router/current-activity-id))
+          [:div.page
+            (navbar)
+            [:div.dashboard-container
+              [:div.topic-list
+                (dashboard-layout)]]])])))

--- a/src/oc/web/components/ui/loading.cljs
+++ b/src/oc/web/components/ui/loading.cljs
@@ -1,8 +1,5 @@
 (ns oc.web.components.ui.loading
-  (:require [om.core :as om]
-            [om-tools.core :as om-core :refer-macros (defcomponent)]
-            [om-tools.dom :as dom :include-macros true]
-            [rum.core :as rum]
+  (:require [rum.core :as rum]
             [oc.web.lib.utils :as utils]))
 
 (rum/defc loading < rum/static

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -1,6 +1,5 @@
 (ns oc.web.lib.utils
-  (:require [om.core :as om :include-macros true]
-            [clojure.string]
+  (:require [clojure.string]
             [dommy.core :as dommy :refer-macros (sel1)]
             [cljs.core.async :refer (put!)]
             [cljs-time.format :as cljs-time-format]
@@ -50,14 +49,6 @@
 
 (defn remove-channel [channel-name]
   (swap! channel-coll dissoc channel-name))
-
-(defn handle-change [cursor value key]
-  (if (array? key)
-    (om/transact! cursor assoc-in key (fn [_] value))
-    (om/transact! cursor key (fn [_] value))))
-
-(defn change-value [cursor e key]
-  (handle-change cursor (.. e -target -value) key))
 
 (defn save-values [channel-name]
   (let [save-channel (get-channel channel-name)]

--- a/src/oc/web/lib/ws_interaction_client.cljs
+++ b/src/oc/web/lib/ws_interaction_client.cljs
@@ -1,8 +1,6 @@
 (ns oc.web.lib.ws-interaction-client
   (:require-macros [cljs.core.async.macros :refer [go]])
-  (:require [om.core :as om :include-macros true]
-            [om.dom :as dom :include-macros true]
-            [sablono.core :as html :refer-macros [html]]
+  (:require [sablono.core :as html :refer-macros [html]]
             [taoensso.sente :as s]
             [taoensso.timbre :as timbre]
             [cljs.core.async :as async :refer [<! >! chan]]

--- a/src/oc/web/rum_utils.cljs
+++ b/src/oc/web/rum_utils.cljs
@@ -1,25 +1,13 @@
 (ns oc.web.rum-utils
   (:require [org.martinklepsch.derivatives :as drv]
-            [rum.core :as rum]
-            [om.core :as om :include-macros true]
-            [om-tools.dom :as dom :include-macros true]))
+            [rum.core :as rum]))
 
-(let [get-k "org.martinklepsch.derivatives/get"
-      release-k "org.martinklepsch.derivatives/release"]
-  (defn- om-derivatives [pool]
-    (->> {:childContextTypes {get-k js/React.PropTypes.func
-                              release-k js/React.PropTypes.func}
-          :getChildContext (fn [] (clj->js {get-k     (partial drv/get! pool)
-                                            release-k (partial drv/release! pool)}))}
-         (merge om/pure-methods)
-         clj->js
-         om/specify-state-methods!)))
+(rum/defc app < (drv/rum-derivatives* first)
+  [spec component]
+  (component))
 
 (defn drv-root [{:keys [state drv-spec target component]}]
   ; unmount rum component if mounted to the same node
   (rum/unmount target)
   ; mount component
-  (om/root component
-           state
-           {:target target
-            :descriptor (om-derivatives (drv/derivatives-pool drv-spec))}))
+  (rum/mount (app drv-spec component) target))

--- a/test/test/oc/web/components/ui/loading.cljs
+++ b/test/test/oc/web/components/ui/loading.cljs
@@ -1,8 +1,6 @@
 (ns test.oc.web.components.ui.loading
   (:require [cljs-react-test.utils :as tu]
             [cljs-react-test.simulate :as sim]
-            [om.core :as om :include-macros true]
-            [om.dom :as dom :include-macros true]
             [dommy.core :as dommy :refer-macros [sel1 sel]]
             [cljs.test :refer-macros [deftest async testing is are use-fixtures]]
             [oc.web.rum-utils :as ru]
@@ -23,6 +21,6 @@
       (ru/drv-root {:state test-atom
                     :drv-spec (dis/drv-spec test-atom (atom {}))
                     :target c
-                    :component #(om/component (loading))})
+                    :component loading})
       (is (not (nil? (sel1 c [:div.oc-loading]))))
       (tu/unmount! c))))

--- a/test/test/oc/web/components/ui/login_button.cljs
+++ b/test/test/oc/web/components/ui/login_button.cljs
@@ -1,8 +1,6 @@
 (ns test.oc.web.components.ui.login-button
   (:require [cljs-react-test.utils :as tu]
             [cljs-react-test.simulate :as sim]
-            [om.core :as om :include-macros true]
-            [om.dom :as dom :include-macros true]
             [dommy.core :as dommy :refer-macros [sel1 sel]]
             [cljs.test :refer-macros [deftest async testing is are use-fixtures]]
             [oc.web.rum-utils :as ru]
@@ -23,6 +21,6 @@
       (ru/drv-root {:state test-atom
                     :drv-spec (dis/drv-spec test-atom (atom {}))
                     :target c
-                    :component #(om/component (login-button))})
+                    :component login-button})
       (is (not (nil? (sel1 c [:button]))))
       (tu/unmount! c))))

--- a/test/test/oc/web/components/ui/org_avatar.cljs
+++ b/test/test/oc/web/components/ui/org_avatar.cljs
@@ -1,8 +1,6 @@
 (ns test.oc.web.components.ui.org-avatar
   (:require [cljs-react-test.utils :as tu]
             [cljs-react-test.simulate :as sim]
-            [om.core :as om :include-macros true]
-            [om.dom :as dom :include-macros true]
             [dommy.core :as dommy :refer-macros [sel1 sel]]
             [cljs.test :refer-macros [deftest async testing is are use-fixtures]]
             [oc.web.rum-utils :as ru]
@@ -38,7 +36,7 @@
         (ru/drv-root {:state test-atom
                       :drv-spec (dis/drv-spec test-atom (atom {}))
                       :target c
-                      :component #(om/component (org-avatar (:org-data test-atom) true))})
+                      :component #(org-avatar (:org-data test-atom) true)})
         (is (not (nil? (sel1 c [:div.org-avatar]))))
         (is (not (nil? (sel1 c [:div.org-avatar :a.org-link]))))
         (is (nil? (sel1 c [:div.org-avatar :img.org-avatar-img])))
@@ -50,7 +48,7 @@
         (ru/drv-root {:state test-atom
                       :drv-spec (dis/drv-spec test-atom (atom {}))
                       :target c
-                      :component #(om/component (org-avatar (:org-data test-atom) false))})
+                      :component #(org-avatar (:org-data test-atom) false)})
         (is (not (nil? (sel1 c [:div.org-avatar]))))
         (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
         (is (not (nil? (sel1 c [:div.org-avatar :img.org-avatar-img]))))
@@ -62,7 +60,7 @@
         (ru/drv-root {:state test-atom
                       :drv-spec (dis/drv-spec test-atom (atom {}))
                       :target c
-                      :component #(om/component (org-avatar (:org-data test-atom) false :always))})
+                      :component #(org-avatar (:org-data test-atom) false :always)})
         (is (not (nil? (sel1 c [:div.org-avatar]))))
         (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
         (is (not (nil? (sel1 c [:div.org-avatar :img.org-avatar-img]))))
@@ -74,7 +72,7 @@
         (ru/drv-root {:state test-atom
                       :drv-spec (dis/drv-spec test-atom (atom {}))
                       :target c
-                      :component #(om/component (org-avatar (:org-data test-atom) false :always))})
+                      :component #(org-avatar (:org-data test-atom) false :always)})
         (is (not (nil? (sel1 c [:div.org-avatar]))))
         (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
         (is (nil? (sel1 c [:div.org-avatar :img.org-avatar-img])))
@@ -86,7 +84,7 @@
         (ru/drv-root {:state test-atom
                       :drv-spec (dis/drv-spec test-atom (atom {}))
                       :target c
-                      :component #(om/component (org-avatar (:org-data test-atom) false :never))})
+                      :component #(org-avatar (:org-data test-atom) false :never)})
         (is (not (nil? (sel1 c [:div.org-avatar]))))
         (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
         (is (not (nil? (sel1 c [:div.org-avatar :img.org-avatar-img]))))
@@ -98,7 +96,7 @@
         (ru/drv-root {:state test-atom
                       :drv-spec (dis/drv-spec test-atom (atom {}))
                       :target c
-                      :component #(om/component (org-avatar (:org-data test-atom) false :never))})
+                      :component #(org-avatar (:org-data test-atom) false :never)})
         (is (not (nil? (sel1 c [:div.org-avatar]))))
         (is (nil? (sel1 c [:div.org-avatar :a.org-link])))
         (is (nil? (sel1 c [:div.org-avatar :img.org-avatar-img])))

--- a/test/test/oc/web/components/ui/user_avatar.cljs
+++ b/test/test/oc/web/components/ui/user_avatar.cljs
@@ -1,8 +1,6 @@
 (ns test.oc.web.components.ui.user-avatar
   (:require [cljs-react-test.utils :as tu]
             [cljs-react-test.simulate :as sim]
-            [om.core :as om :include-macros true]
-            [om.dom :as dom :include-macros true]
             [dommy.core :as dommy :refer-macros [sel1 sel]]
             [cljs.test :refer-macros [deftest async testing is are use-fixtures]]
             [oc.web.rum-utils :as ru]
@@ -23,6 +21,6 @@
       (ru/drv-root {:state test-atom
                     :drv-spec (dis/drv-spec test-atom (atom {}))
                     :target c
-                    :component #(om/component (user-avatar))})
+                    :component user-avatar})
       (is (not (nil? (sel1 c [:button.user-avatar-button]))))
       (tu/unmount! c))))

--- a/test/test/oc/web/components/user_profile.cljs
+++ b/test/test/oc/web/components/user_profile.cljs
@@ -1,8 +1,6 @@
 (ns test.oc.web.components.user-profile
   (:require [cljs-react-test.utils :as tu]
             [cljs-react-test.simulate :as sim]
-            [om.core :as om :include-macros true]
-            [om.dom :as dom :include-macros true]
             [dommy.core :as dommy :refer-macros [sel1 sel]]
             [cljs.test :refer-macros [deftest async testing is are use-fixtures]]
             [oc.web.rum-utils :as ru]
@@ -24,6 +22,6 @@
       (ru/drv-root {:state test-atom
                     :drv-spec (dis/drv-spec test-atom (atom {}))
                     :target c
-                    :component #(om/component (user-profile))})
+                    :component user-profile})
       (is (not (nil? (sel1 c [:div.user-profile]))))
       (tu/unmount! c))))


### PR DESCRIPTION
This branch is intended to lose our Om dependency. Until now we were using an om component as mount point that was bridging the app state derivatives to all our Rum components.
That was necessary because we had mixed Rum and Om components and we wanted to be able to use both.

At this point we have only 2 remaining Om components: org-dashboard and org-editing. I moved those 2 to Rum and remove the code that was bridging the app state to Om and then to Rum cursor (and to Martin's derivatives).

This is needed to simplify our code in preparation to use React 16. We can't upgrade to it right now because Rum is not ready yet. There is a PR open, still under discussion for some reason, but it will be ready soon.

To test build this branch and use the apps how you would normally do, try to use any feature you can think of.