### PR TITLE
Fix All Posts loading screen

### DIFF
--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -62,12 +62,14 @@
               (oc-urls/board org board))))))))
 
 (defn close-clicked [s & [board-filters]]
-  (if (:from-all-posts @router/path)
-    ;; Remove AP data from the DB to avoid showing results before loading and results again
-    (when-not (string? board-filters)
-      (dis/dispatch! [:all-posts-reset]))
-    ;; Make sure the seen-at is not reset when navigating back to the board so NEW is still visible
-    (dis/dispatch! [:input [:no-reset-seen-at] true]))
+  (let [ap-initial-at (:ap-initial-at @(drv/get-ref s :modal-data))]
+    (if (:from-all-posts @router/path)
+      ;; Remove AP data from the DB to avoid showing results before loading and results again
+      (when (and (not (string? board-filters))
+                 ap-initial-at)
+        (dis/dispatch! [:all-posts-reset]))
+      ;; Make sure the seen-at is not reset when navigating back to the board so NEW is still visible
+      (dis/dispatch! [:input [:no-reset-seen-at] true])))
   (dis/dispatch! [:input [:dismiss-modal-on-editing-stop] false])
   (reset! (::dismiss s) true)
   (utils/after 180 #(dismiss-modal s board-filters)))

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -45,7 +45,9 @@
         org-data (dis/org-data data)
         all-posts-data (dis/all-posts-data data)
         board-data (dis/board-data data)
-        is-mobile? (responsive/is-tablet-or-mobile?)]
+        is-mobile? (responsive/is-tablet-or-mobile?)
+        ap-initial-at (:ap-initial-at data)
+        should-show-onboard-overlay? (some #{(:nux data)} [:1 :7])]
     ;; Show loading if
     (if (or ;; the org data are not loaded yet
             (not org-data)
@@ -54,9 +56,14 @@
                  ;; but there are some
                  (pos? (count (:boards org-data))))
             ;; Board specified
-            (and (router/current-board-slug)
-                 ;; But no board/all-posts data yet
-                 (not board-data)
+            (and (not= (router/current-board-slug) "all-posts")
+                 (not ap-initial-at)
+                 ;; But no board data yet
+                 (not board-data))
+            ;; All posts
+            (and (or (= (router/current-board-slug) "all-posts")
+                     ap-initial-at)
+                 ;; But no all-posts data yet
                  (not all-posts-data))
             ;; First ever user nux, not enough time
             (and (:nux-loading data)

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -239,8 +239,8 @@
                                 (get-in base (vec (conj (board-data-key org-slug edit-board-slug) :topics))))))]
    :activity-share        [[:base] (fn [base] (:activity-share base))]
    :activity-shared-data  [[:base] (fn [base] (:activity-shared-data base))]
-   :modal-data          [[:base :org-data :entry-edit-topics :activity-share :add-comment-focus :comment-edit]
-                          (fn [base org-data entry-edit-topics activity-share add-comment-focus comment-edit]
+   :modal-data          [[:base :org-data :entry-edit-topics :activity-share :add-comment-focus :comment-edit :ap-initial-at]
+                          (fn [base org-data entry-edit-topics activity-share add-comment-focus comment-edit ap-initial-at]
                             {:org-data org-data
                              :activity-modal-fade-in (:activity-modal-fade-in base)
                              :board-filters (:board-filters base)
@@ -251,7 +251,8 @@
                              :activity-share activity-share
                              :entry-save-on-exit (:entry-save-on-exit base)
                              :add-comment-focus add-comment-focus
-                             :comment-edit comment-edit})]
+                             :comment-edit comment-edit
+                             :ap-initial-at ap-initial-at})]
    :navbar-data         [[:base :org-data :board-data]
                           (fn [base org-data board-data]
                             (let [navbar-data (select-keys base [:mobile-menu-open


### PR DESCRIPTION
Source: [QA Doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#)

While investigating:
> https://www.useloom.com/share/7127de01106d49f8940c36c5f6d197a7 open a post from AP, add a new reaction, and then go back to AP

that looks to not be a problem anymore i found out that now we see a loading screen every time we open and then dismiss a post from All Posts. This behaviour should only be visible when the user open a post from the digest.
They land to the post page with an `at` parameter specifying the published at of the post. This is needed to make sure the UI go back to that exact post when the post modal is dismissed: ie load the all posts view with that same post visible and some post before and some after it.

We need to show a loading screen in this case because we can't directly scroll to the post, we need to render them first so the user will see a jump.

To test:
- open /org/all-posts
- open a post
- dismiss the post clicking the X or out of the modal
- [x] are you back to AP (at the top, the scroll position is lost)? Good
- [x] did you NOT see a loading screen between the modal and AP? Good
- now copy the published-at of a post (better if it's not in the first 30/40 posts
- visit /{org}/{board}/post/{activity-id}?at={published-at}
- [x] do you see the post? Good
- dismiss the post
- [x] do you see a loading screen? Good
- [x] are you back to AP with the previous post visible at the top? Good