### PR TITLE
Disable click to edit

### DIFF
--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -150,15 +150,6 @@
            (when-let [headline-el (rum/ref-node state "edit-headline")]
              (utils/to-end-of-content-editable headline-el)))))))
 
-(defn- start-editing? [state & [focus]]
-  (let [activity-data (first (:rum/args state))]
-    (when (and (not (responsive/is-tablet-or-mobile?))
-               (utils/link-for (:links activity-data) "partial-update")
-               (not @(::showing-dropdown state))
-               (not @(::move-activity state))
-               (not (.contains (.-classList (.-activeElement js/document)) "add-comment")))
-      (real-start-editing state focus))))
-
 (defn- stop-editing [state]
   (save-on-exit? state)
   (toggle-save-on-exit state false)
@@ -510,11 +501,9 @@
                   [:div.activity-modal-content
                     {:key "activity-modal-content"}
                     [:div.activity-modal-content-headline
-                      {:dangerouslySetInnerHTML (utils/emojify (:headline activity-data))
-                       :on-click #(start-editing? s :headline)}]
+                      {:dangerouslySetInnerHTML (utils/emojify (:headline activity-data))}]
                     [:div.activity-modal-content-body
                       {:dangerouslySetInnerHTML (utils/emojify (:body activity-data))
-                       :on-click #(start-editing? s :body)
                        :class (when (empty? (:headline activity-data)) "no-headline")}]
                     (when is-mobile?
                       (reactions activity-data))


### PR DESCRIPTION
Source: [QA doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit?pli=1#)

Item:
> Disable auto edit when you click into a post; users will need to click the pencil or Edit in the menu to start editing

To test:
- open a post in the modal
- click on the post headline
- [x] does it NOT switch to editing mode? Good
- click on the post body
- [x] does it NOT switch to editing mode? Good