### PR TITLE
Required headline

### DIFF
--- a/scss/partials/_atomic.scss
+++ b/scss/partials/_atomic.scss
@@ -32,14 +32,16 @@
   padding: .2em 1em;
   transition: opacity 230ms, color 230ms, background-color 230ms;
 
-  &:hover, &:focus {
-    background-color: $carrot_green_2;
-    color: #FFFFFF;
-  }
+  &:not(.disabled) {
+    &:hover, &:focus {
+      background-color: $carrot_green_2;
+      color: #FFFFFF;
+    }
 
-  &:active, &.active {
-    background-color: $carrot_green_1;
-    color: white;
+    &:active, &.active {
+      background-color: $carrot_green_1;
+      color: white;
+    }
   }
 
   &:disabled, &.disabled {

--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -306,6 +306,10 @@ div.entry-edit-modal-container {
           margin: 16px;
         }
 
+        div.tooltip {
+          max-width: 170px;
+        }
+
         div.emoji-picker {
           float: left;
           margin-top: 4px;
@@ -344,4 +348,8 @@ div.entry-edit-modal-container {
       }
     }
   }
+}
+
+div.tooltip.post-btn-tooltip {
+  max-width: 175px;
 }

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -487,7 +487,7 @@
                     [:div.activity-modal-content-headline.emoji-autocomplete.emojiable
                       {:content-editable true
                        :ref "edit-headline"
-                       :placeholder "Add a title"
+                       :placeholder utils/default-headline
                        :on-paste    #(headline-on-paste s %)
                        :on-key-down #(headline-on-change s)
                        :on-click    #(headline-on-change s)

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -141,8 +141,7 @@
     (dis/dispatch! [:input [:entry-editing :body] (utils/clean-body-html (.-innerHTML body-el))])))
 
 (defn- is-publishable? [entry-editing]
-  (and (seq (:board-slug entry-editing))
-       (seq (:headline entry-editing))))
+  (seq (:board-slug entry-editing)))
 
 (rum/defcs entry-edit < rum/reactive
                         ;; Derivatives
@@ -359,7 +358,7 @@
           [:div.entry-edit-headline.emoji-autocomplete.emojiable
             {:content-editable (not nux)
              :ref "headline"
-             :placeholder "Add a title"
+             :placeholder utils/default-headline
              :on-paste    #(headline-on-paste s %)
              :on-key-down #(headline-on-change s)
              :on-click    #(headline-on-change s)
@@ -401,17 +400,32 @@
                            :message "Click the green Post button to see how it works."
                            :width 494})))
           [:button.mlb-reset.mlb-default.form-action-bt.post-btn
-            {:on-click #(do
-                          (clean-body)
-                          (if published?
-                            (do
-                             (reset! (::saving s) true)
-                             (dis/dispatch! [:entry-save]))
-                            (do
-                             (reset! (::publishing s) true)
-                             (dis/dispatch! [:entry-publish]))))
-             :disabled (or @(::publishing s)
-                           (not (is-publishable? entry-editing)))}
+            {:ref "post-btn"
+             :on-click (fn [_]
+                         (clean-body)
+                         (if (and (is-publishable? entry-editing)
+                                  (not (zero? (count (:headline entry-editing)))))
+                           (if published?
+                             (do
+                               (reset! (::saving s) true)
+                               (dis/dispatch! [:entry-save]))
+                             (do
+                               (reset! (::publishing s) true)
+                               (dis/dispatch! [:entry-publish])))
+                           (when (zero? (count (:headline entry-editing)))
+                             (when-let [$post-btn (js/$ (rum/ref-node s "post-btn"))]
+                               (when-not (.data $post-btn "bs.tooltip")
+                                 (.tooltip $post-btn
+                                  (clj->js {:container "body"
+                                            :placement "top"
+                                            :trigger "manual"
+                                            :template "<div class=\"tooltip post-btn-tooltip\"><div class=\"tooltip-arrow\"></div><div class=\"tooltip-inner\"></div></div>"
+                                            :title "A title is required in order to save or share this post."})))
+                               (utils/after 10 #(.tooltip $post-btn "show"))
+                               (utils/after 5000 #(.tooltip $post-btn "hide"))))))
+             :class (when (or @(::publishing s)
+                              (not (is-publishable? entry-editing)))
+                      "disabled")}
             (when (or (and published?
                            @(::saving s))
                       (and (not published?)

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -1216,6 +1216,8 @@
       (nth parts 4)
       (nth parts 2))))
 
+(def default-headline "Untitled post")
+
 (def default-drafts-board-name "Drafts")
 
 (def default-drafts-board-slug "drafts")


### PR DESCRIPTION
Source: [QA Doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit?pli=1#)

Item:
> Now that headline is required:
> -  Change placeholder back to “Untitled post” instead of “Add a title”
> - We’ll use a tooltip like shown here https://invis.io/Q3ERX9GCB. We can use our standard black tooltip for now to be consistent.

To test:
- click on New post
- [x] do you see the new headline placeholder? Good
- without changing anything, click on Post
- [x] do you see the tooltip? is it centred with the button? Good
- now add a body
- click Post
- [x] do you see the tooltip again? Good
- [x] does the tooltip disappear automatically after some time? was it enough to read it? Good
- now add a title
- click Post
- [x] did it post? Good
- merge