### PR TITLE
Lose changes prompt

### DIFF
--- a/scss/partials/_alert_modal.scss
+++ b/scss/partials/_alert_modal.scss
@@ -90,12 +90,29 @@ div.alert-modal-container {
         }
 
         button {
-          width: calc(50% - 14px);
+          // width: calc(50% - 14px);
           float: left;
           height: 40px;
+          padding: 0px 12%;
 
           &:not(:first-child) {
             margin-left: 14px;
+            float: right;
+          }
+
+          &.mlb-default.red {
+            background-color: $carrot_orange_light;
+            color: $carrot_orange;
+
+            &:hover, &:focus {
+              background-color: $carrot_orange;
+              color: white;
+            }
+
+            &:active, &.active {
+              background-color: $carrot_orange;
+              color: white;
+            }
           }
         }
       }

--- a/scss/partials/_alert_modal.scss
+++ b/scss/partials/_alert_modal.scss
@@ -93,7 +93,7 @@ div.alert-modal-container {
           // width: calc(50% - 14px);
           float: left;
           height: 40px;
-          padding: 0px 12%;
+          padding: 0px 11%;
 
           &:not(:first-child) {
             margin-left: 14px;

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -197,8 +197,8 @@
     (if (:has-changes (:modal-editing-data modal-data))
       (let [alert-data {:icon "/img/ML/trash.svg"
                         :action "dismiss-edit-dirty-data"
-                        :message (str "Cancel without saving your changes?")
-                        :link-button-title "No"
+                        :message (str "Leave without saving your changes?")
+                        :link-button-title "Stay"
                         :link-button-cb #(dis/dispatch! [:alert-modal-hide])
                         :solid-button-style :red
                         :solid-button-title "Lose changes"

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -196,7 +196,8 @@
                       :message (str "Cancel before finishing upload?")
                       :link-button-title "No"
                       :link-button-cb #(dis/dispatch! [:alert-modal-hide])
-                      :solid-button-title "Yes"
+                      :solid-button-style :red
+                      :solid-button-title "Cancel upload"
                       :solid-button-cb #(do
                                           (dis/dispatch! [:alert-modal-hide])
                                           (dismiss-fn))
@@ -208,7 +209,8 @@
                         :message (str "Cancel without saving your changes?")
                         :link-button-title "No"
                         :link-button-cb #(dis/dispatch! [:alert-modal-hide])
-                        :solid-button-title "Yes"
+                        :solid-button-style :red
+                        :solid-button-title "Lose changes"
                         :solid-button-cb #(do
                                             (dis/dispatch! [:alert-modal-hide])
                                             (dismiss-fn))

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -184,8 +184,8 @@
   (if @(::uploading-media state)
     (let [alert-data {:icon "/img/ML/trash.svg"
                       :action "dismiss-edit-uploading-media"
-                      :message (str "Cancel before finishing upload?")
-                      :link-button-title "No"
+                      :message (str "Leave before finishing upload?")
+                      :link-button-title "Stay"
                       :link-button-cb #(dis/dispatch! [:alert-modal-hide])
                       :solid-button-style :red
                       :solid-button-title "Cancel upload"

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -85,8 +85,8 @@
     (if (:has-changes @(drv/get-ref s :entry-editing))
       (let [alert-data {:icon "/img/ML/trash.svg"
                         :action "dismiss-edit-dirty-data"
-                        :message (str "Cancel without saving your changes?")
-                        :link-button-title "No"
+                        :message (str "Leave without saving your changes?")
+                        :link-button-title "Stay"
                         :link-button-cb #(dis/dispatch! [:alert-modal-hide])
                         :solid-button-style :red
                         :solid-button-title "Lose changes"

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -75,7 +75,8 @@
                       :message (str "Cancel before finishing upload?")
                       :link-button-title "No"
                       :link-button-cb #(dis/dispatch! [:alert-modal-hide])
-                      :solid-button-title "Yes"
+                      :solid-button-style :red
+                      :solid-button-title "Cancel upload"
                       :solid-button-cb #(do
                                           (dis/dispatch! [:alert-modal-hide])
                                           (real-close s))
@@ -87,7 +88,8 @@
                         :message (str "Cancel without saving your changes?")
                         :link-button-title "No"
                         :link-button-cb #(dis/dispatch! [:alert-modal-hide])
-                        :solid-button-title "Yes"
+                        :solid-button-style :red
+                        :solid-button-title "Lose changes"
                         :solid-button-cb #(do
                                             (dis/dispatch! [:entry-clear-local-cache :entry-editing])
                                             (dis/dispatch! [:alert-modal-hide])

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -72,8 +72,8 @@
   (if @(::uploading-media s)
     (let [alert-data {:icon "/img/ML/trash.svg"
                       :action "dismiss-edit-uploading-media"
-                      :message (str "Cancel before finishing upload?")
-                      :link-button-title "No"
+                      :message (str "Leave before finishing upload?")
+                      :link-button-title "Stay"
                       :link-button-cb #(dis/dispatch! [:alert-modal-hide])
                       :solid-button-style :red
                       :solid-button-title "Cancel upload"

--- a/src/oc/web/components/ui/alert_modal.cljs
+++ b/src/oc/web/components/ui/alert_modal.cljs
@@ -44,6 +44,7 @@
    :message A description message to show in the view.
    :link-button-title The title for the first button, it's black link styled.
    :link-button-cb The function to execute when the first button is clicked.
+   :solid-button-style The style of the button: default green, :red.
    :solid-button-title The title for the second button, it's green solid styled.
    :solid-button-cb The function to execute when the second button is clicked."
   [s]
@@ -80,5 +81,6 @@
                   (:link-button-title alert-modal)])
               (when (:solid-button-title alert-modal)
                 [:button.mlb-reset.mlb-default
-                  {:on-click #(solid-button-clicked alert-modal %)}
+                  {:on-click #(solid-button-clicked alert-modal %)
+                   :class (when (= (:solid-button-style alert-modal) :red) "red")}
                   (:solid-button-title alert-modal)])])]]]))


### PR DESCRIPTION
Source: [QA doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit?pli=1#)

Item:
> Our “Cancel without saving your changes?” dialog should have a red primary button, not green, and the copy should say “Lose changes” rather than “Yes”. This is much clearer.

To test:
- click New post
- add a headline
- click on the white X (top left of the modal)
- [x] do you see the prompt? Good
- [x] does it prompt you to "Lose changes" in red instead of only "Yes" in green? Good
- now click on an existing post
- click edit
- change the headline or the body
- click Cancel
- [x] do you see the red Lose changes button? Good
- click it
- [x] did it lose your outstanding changes? Good