### PR TITLE
Independent topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ provided in the table below:
 |  :entry-save/failed | API | Save entry reuqest finish but failed. |
 |  :entry-save/finish | API | Save entry reuqest finish, refresh the board data. |
 |  :entry-toggle-save-on-exit | UI | Toggle save on exit to avoid losing edits on page unload or edit exit. |
+|  :entry-topic-change | UI | Change the topic of the given topic. |
 |  :error-banner-show | UI | Given an error message and a time, show the specified error for that time, if the time is 0 stick the message. |
 |  :input | UI | Generic input action, it's used passing in a path and the value. The value is saved at the specified path of the app-state. |
 |  :invitation-confirmed | API | Confirm invitation request succeeded. |

--- a/scss/partials/_topics_dropdown.scss
+++ b/scss/partials/_topics_dropdown.scss
@@ -3,7 +3,7 @@ div.entry-card-dd-container {
   float: right;
   display: inline-block;
   max-width: 50%;
-  z-index: 1133;
+  z-index: 1235;
 
   button.entry-card-dd-button:not(.has-topic) {
     color: $carrot_light_gray_3;

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -229,6 +229,18 @@
         (reset! (::initial-headline s) initial-headline)
         (reset! (::edited-data-loaded s) true)))))
 
+(defn topic-did-change [s editing topic-map]
+  (let [activity-data (first (:rum/args s))]
+    (if editing
+      (do
+        (dis/dispatch! [:input [:modal-editing-data :topic-slug] (:slug topic-map)])
+        (dis/dispatch! [:input [:modal-editing-data :topic-name] (:name topic-map)])
+        (dis/dispatch! [:input [:modal-editing-data :has-changes] true])
+        (toggle-save-on-exit s true))
+      (dis/dispatch! [:entry-topic-change (merge activity-data
+                                           {:topic-slug (:slug topic-map)
+                                            :topic-name (:name topic-map)})]))))
+
 (rum/defcs activity-modal < rum/reactive
                             ;; Derivatives
                             (drv/drv :modal-data)
@@ -457,17 +469,21 @@
                                       :on-change #(close-clicked s nil)}))]))
               (when-not is-mobile?
                 (activity-attachments activity-data false))
-              (if editing
+              ; (if editing
+
+              ;   (when (:topic-slug activity-data)
+              ;     (let [topic-name (or (:topic-name activity-data) (string/upper (:topic-slug activity-data)))]
+              ;       [:div.activity-tag.on-gray
+              ;         {:on-click #(close-clicked s (:topic-slug activity-data))}
+              ;         topic-name])))
+              (let [topics (distinct (:entry-edit-topics modal-data))
+                    entry-data (if editing (:modal-editing-data modal-data) activity-data)]
                 (topics-dropdown
-                 (distinct (:entry-edit-topics modal-data))
-                 (:modal-editing-data modal-data)
-                 :modal-editing-data
-                 #(toggle-save-on-exit s true))
-                (when (:topic-slug activity-data)
-                  (let [topic-name (or (:topic-name activity-data) (string/upper (:topic-slug activity-data)))]
-                    [:div.activity-tag.on-gray
-                      {:on-click #(close-clicked s (:topic-slug activity-data))}
-                      topic-name])))]]
+                 (:board-slug entry-data)
+                 topics
+                 {:slug (:topic-slug entry-data)
+                  :name (:topic-name entry-data)}
+                 #(topic-did-change s editing %)))]]
           [:div.activity-modal-columns
             ;; Left column
             [:div.activity-left-column

--- a/src/oc/web/components/activity_modal.cljs
+++ b/src/oc/web/components/activity_modal.cljs
@@ -471,13 +471,6 @@
                                       :on-change #(close-clicked s nil)}))]))
               (when-not is-mobile?
                 (activity-attachments activity-data false))
-              ; (if editing
-
-              ;   (when (:topic-slug activity-data)
-              ;     (let [topic-name (or (:topic-name activity-data) (string/upper (:topic-slug activity-data)))]
-              ;       [:div.activity-tag.on-gray
-              ;         {:on-click #(close-clicked s (:topic-slug activity-data))}
-              ;         topic-name])))
               (let [topics (distinct (:entry-edit-topics modal-data))
                     entry-data (if editing (:modal-editing-data modal-data) activity-data)]
                 (topics-dropdown

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -144,6 +144,12 @@
   (and (seq (:board-slug entry-editing))
        (seq (:headline entry-editing))))
 
+(defn- topic-did-change [s entry-editing topic-map]
+  (toggle-save-on-exit s true)
+  (dis/dispatch! [:input [:entry-editing] (merge entry-editing {:topic-slug (:slug topic-map)
+                                                                :topic-name (:name topic-map)
+                                                                :has-changes true})]))
+
 (rum/defcs entry-edit < rum/reactive
                         ;; Derivatives
                         (drv/drv :org-data)
@@ -327,7 +333,12 @@
                                      (dis/dispatch! [:input [:entry-editing :board-slug] (:value item)])
                                      (dis/dispatch! [:input [:entry-editing :board-name] (:label item)]))}))]]
                 (when-not nux
-                  (topics-dropdown board-topics entry-editing :entry-editing #(toggle-save-on-exit s true)))]]
+                  (topics-dropdown
+                   (:board-slug entry-editing)
+                   board-topics
+                   {:slug (:topic-slug entry-editing)
+                    :name (:topic-name entry-editing)}
+                   #(topic-did-change s entry-editing %)))]]
             [:div.entry-edit-modal-header.group
               (user-avatar-image current-user-data)
               [:div.posting-in
@@ -352,7 +363,12 @@
                                    (dis/dispatch! [:input [:entry-editing :board-slug] (:value item)])
                                    (dis/dispatch! [:input [:entry-editing :board-name] (:label item)]))}))]]
               (when-not nux
-                (topics-dropdown board-topics entry-editing :entry-editing #(toggle-save-on-exit s true)))])
+                (topics-dropdown
+                 (:board-slug entry-editing)
+                 board-topics
+                 {:slug (:topic-slug entry-editing)
+                  :name (:topic-name entry-editing)}
+                 #(topic-did-change s entry-editing %)))])
         [:div.entry-edit-modal-body
           {:ref "entry-edit-modal-body"}
           ; Headline element

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -106,6 +106,7 @@
    :comment-add-finish  [[:base] (fn [base] (:comment-add-finish base))]
    :comment-edit        [[:base] (fn [base] (:comment-edit base))]
    :add-comment-height  [[:base] (fn [base] (:add-comment-height base))]
+   :entry-topic-loading [[:base] (fn [base] (:entry-topic-loading base))]
    :email-verification  [[:base :auth-settings]
                           (fn [base auth-settings]
                             {:auth-settings auth-settings


### PR DESCRIPTION
Source: [QA doc]()

Item:
> You should be able to add/change topic name without going into Edit mode or needing to Save. It should be independent just as comments are independent.

Also this:
> Also notice what happens when you go into edit a topic. You see the last topic used on a diff card for a second before it clears out. https://www.useloom.com/share/37673cf34cc24001b32fb41e12f8e4a3

seems to be already solved, keep an eye open while you review this.

To test:
- open a board
- click New post
- add headline and body
- add a topic
- hit save as draft
- [x] did it save the draft with the correct topic? Good
- now edit the draft: change the topic
- post it
- [x] did it post with the correct topic? Good
- now expand the newly published post
- click on the topic
- remove the topic
- [x] do you see the post w/o the topic in the board? Good (refresh the board to make sure)
- expand the topic again
- click on + Add a topic
- add another topic
- save
- [x] did it save? Good