### PR TITLE
Qa copy changes

### DIFF
--- a/src/oc/web/components/board_edit.cljs
+++ b/src/oc/web/components/board_edit.cljs
@@ -389,7 +389,9 @@
                                 {:icon "/img/ML/trash.svg"
                                  :action "delete-board"
                                  :message (str
-                                           "Are you sure? This will delete the board and ALL its posts, too.")
+                                           "Are you sure?"
+                                           (when (-> board-data :fixed-items count pos?)
+                                             " This will delete the board and all its posts, too."))
                                  :link-button-title "No"
                                  :link-button-cb #(dis/dispatch! [:alert-modal-hide])
                                  :solid-button-style :red

--- a/src/oc/web/components/board_edit.cljs
+++ b/src/oc/web/components/board_edit.cljs
@@ -384,19 +384,22 @@
                          (utils/link-for (:links board-data) "delete"))
                 [:button.mlb-reset.mlb-link-black.delete-board
                   {:on-click (fn []
-                              (dis/dispatch! [:alert-modal-show {:icon "/img/ML/trash.svg"
-                                                                 :action "delete-board"
-                                                                 :message (str "Delete this board?")
-                                                                 :link-button-title "No"
-                                                                 :link-button-cb #(dis/dispatch! [:alert-modal-hide])
-                                                                 :solid-button-title "Yes"
-                                                                 :solid-button-cb (fn []
-                                                                                    (dis/dispatch!
-                                                                                     [:board-delete
-                                                                                     (:slug board-data)])
-                                                                                    (dis/dispatch!
-                                                                                     [:alert-modal-hide])
-                                                                                    (close-clicked s))}]))}
+                              (dis/dispatch!
+                               [:alert-modal-show
+                                {:icon "/img/ML/trash.svg"
+                                 :action "delete-board"
+                                 :message (str
+                                           "Are you sure? This will delete the board and ALL it’s posts, too.")
+                                 :link-button-title "No"
+                                 :link-button-cb #(dis/dispatch! [:alert-modal-hide])
+                                 :solid-button-title "Yes"
+                                 :solid-button-cb (fn []
+                                                    (dis/dispatch!
+                                                     [:board-delete
+                                                     (:slug board-data)])
+                                                    (dis/dispatch!
+                                                     [:alert-modal-hide])
+                                                    (close-clicked s))}]))}
                   "Delete"])]
             [:div.board-edit-footer-right.group
               [:button.mlb-reset.mlb-default

--- a/src/oc/web/components/board_edit.cljs
+++ b/src/oc/web/components/board_edit.cljs
@@ -389,10 +389,11 @@
                                 {:icon "/img/ML/trash.svg"
                                  :action "delete-board"
                                  :message (str
-                                           "Are you sure? This will delete the board and ALL it’s posts, too.")
+                                           "Are you sure? This will delete the board and ALL its posts, too.")
                                  :link-button-title "No"
                                  :link-button-cb #(dis/dispatch! [:alert-modal-hide])
-                                 :solid-button-title "Yes"
+                                 :solid-button-style :red
+                                 :solid-button-title "Yes, I'm sure"
                                  :solid-button-cb (fn []
                                                     (dis/dispatch!
                                                      [:board-delete

--- a/src/oc/web/components/board_edit.cljs
+++ b/src/oc/web/components/board_edit.cljs
@@ -388,10 +388,10 @@
                                [:alert-modal-show
                                 {:icon "/img/ML/trash.svg"
                                  :action "delete-board"
-                                 :message (str
-                                           "Are you sure?"
-                                           (when (-> board-data :fixed-items count pos?)
-                                             " This will delete the board and all its posts, too."))
+                                 :message [:span
+                                            [:span "Are you sure?"]
+                                            (when (-> board-data :fixed-items count pos?)
+                                              [:span " This will delete the board and " [:strong "all"] " its posts, too."])]
                                  :link-button-title "No"
                                  :link-button-cb #(dis/dispatch! [:alert-modal-hide])
                                  :solid-button-style :red

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -211,4 +211,4 @@
                         (dis/dispatch! [:whats-new-modal-show])
                         (close-navigation-sidebar))}
           [:div.about-carrot-icon]
-          [:span "About Carrot"]]]]))
+          [:span "Support"]]]]))

--- a/src/oc/web/components/ui/whats_new_modal.cljs
+++ b/src/oc/web/components/ui/whats_new_modal.cljs
@@ -37,9 +37,7 @@
         [:div.whats-new-modal
           [:div.carrot-logo]
           [:div.about-title
-            (if (empty? whats-new-data)
-              "About Carrot"
-              "What’s New with Carrot")]
+            "Support"]
           [:div.about-links
             [:a.about-link
               {:href oc-urls/about


### PR DESCRIPTION
Source: [QA Doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit?pli=1#)

Items:
> Board delete prompt seems a bit too casual, “Delete this board?”, you’re really deleting all the content too. Could be dozens, hundreds of posts. Let’s use: “Are you sure? This will delete the board and ALL it’s posts, too.” as the copy.
 
> Change About Carrot link to “Support”; also when you click it the title should also change to “Support”

To test check the 2 copy changes.