### PR TITLE
Edit comment paste bug

### DIFF
--- a/scss/partials/_comments.scss
+++ b/scss/partials/_comments.scss
@@ -326,16 +326,10 @@ div.comments {
           margin-top: 4px;
 
           div.save-cancel-edit-buttons {
-            display: none;
-
-            @include mobile() {
-              display: block;
-
-              button {
-                height: 20px;
-                float: right;
-                margin-left: 8px;
-              }
+            button {
+              height: 20px;
+              float: right;
+              margin-left: 8px;
             }
           }
 

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -96,10 +96,10 @@
   (dis/dispatch! [:input [:comment-edit] (:uuid (first (:rum/args s)))])
   (let [comment-node (rum/ref-node s "comment-body")
         medium-editor (setup-medium-editor comment-node)]
-    (.subscribe medium-editor
-     "editableBlur"
-     (fn [e editable]
-       (edit-finished e s (first (:rum/args s)))))
+    ; (.subscribe medium-editor
+    ;  "editableBlur"
+    ;  (fn [e editable]
+    ;    (edit-finished e s (first (:rum/args s)))))
     (reset! (::esc-key-listener s)
      (events/listen
       js/window
@@ -107,7 +107,8 @@
       (fn [e]
         (when (and (= "Enter" (.-key e))
                    (not (.-shiftKey e)))
-          (.blur (rum/ref-node s "comment-body"))
+          ; (.blur (rum/ref-node s "comment-body"))
+          (edit-finished e s (first (:rum/args s)))
           (.preventDefault e))
         (when (= "Escape" (.-key e))
           (cancel-edit e s (first (:rum/args s)))))))
@@ -157,10 +158,6 @@
                               js/window
                               EventType/CLICK
                               (fn [e]
-                                (when (and @(::editing? s)
-                                       (not (utils/event-inside? e (rum/ref-node s "comment-edit-delete")))
-                                       (not (utils/event-inside? e (rum/ref-node s "comment-body"))))
-                                  (stop-editing s))
                                 (when (and @(::show-more-dropdown s)
                                            (not (utils/event-inside? e (rum/ref-node s "comment-edit-delete"))))
                                   (reset! (::show-more-dropdown s) false)))))
@@ -205,8 +202,7 @@
           [:div.comment-footer-container.group
             (when should-show-comment-reaction?
               (comment-reactions/comment-reactions c))
-            (when (and (responsive/is-tablet-or-mobile?)
-                       @(::editing? s))
+            (when @(::editing? s)
               [:div.save-cancel-edit-buttons
                 [:button.mlb-reset.mlb-link-green
                   {:on-click #(edit-finished % s c)}
@@ -214,7 +210,8 @@
                 [:button.mlb-reset.mlb-link-black
                   {:on-click #(cancel-edit % s c)}
                   "Cancel"]])
-            (when editable
+            (when (and editable
+                       (not @(::editing? s)))
               [:div.edit-delete-button
                 {:ref "comment-edit-delete"
                  :class (when @(::editing? s) "editing")}

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -96,10 +96,6 @@
   (dis/dispatch! [:input [:comment-edit] (:uuid (first (:rum/args s)))])
   (let [comment-node (rum/ref-node s "comment-body")
         medium-editor (setup-medium-editor comment-node)]
-    ; (.subscribe medium-editor
-    ;  "editableBlur"
-    ;  (fn [e editable]
-    ;    (edit-finished e s (first (:rum/args s)))))
     (reset! (::esc-key-listener s)
      (events/listen
       js/window
@@ -107,7 +103,6 @@
       (fn [e]
         (when (and (= "Enter" (.-key e))
                    (not (.-shiftKey e)))
-          ; (.blur (rum/ref-node s "comment-body"))
           (edit-finished e s (first (:rum/args s)))
           (.preventDefault e))
         (when (= "Escape" (.-key e))
@@ -134,14 +129,9 @@
 
 (defn is-emoji
   [body]
-  ; (let [ranges #js ["\\ud83c[\\udf00-\\udfff]"  ;; U+1F300 to U+1F3FF
-  ;                   "\\ud83d[\\udc00-\\ude4f]"  ;; U+1F400 to U+1F64F
-  ;                   "\\ud83d[\\ude80-\\udeff]"]] ;; U+1F680 to U+1F6FF
-  ;   (.match body (.join ranges "|")))
   (let [r (js/RegExp "^([\ud800-\udbff])([\udc00-\udfff])" "g")]
     (and ;; emojis can have up to 11 codepoints
          (<= (count body) 11)
-         ;;
          (.match body r)
          (not (.match body (js/RegExp "[a-zA-Z0-9\\s!?@#\\$%\\^&(())_=\\-<>,\\.\\*;':\"]" "g"))))))
 


### PR DESCRIPTION
Source: [QA Doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit?pli=1#)

Item:
> Bug: can’t paste in comment while editing since it lose focus and it’s interpreted as an edit cancel

To test:
- open a post
- add a comment
- enter edit mode for the added comment
- paste something with CMD+v (not with mouse right click since it was working already)
- [x] did it work? Good
- enter edit mode again
- edit the comment
- press Enter
- [x] did it save the comment edits? Good
- enter edit mode again
- edit the comment
- press Escape
- [x] did it NOT save the comment edits? Good