### PR TITLE
Mobile search

### DIFF
--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -102,9 +102,9 @@ nav.oc-navbar {
         font-size: 26px;
 
         @include mobile() {
-          width: 256px;
+          width: 200px;
           height: 32px;
-          margin-left: -128px;
+          margin-left: -107px;
           top: 0px;
         }
 
@@ -130,8 +130,10 @@ nav.oc-navbar {
       height: 24px;
 
       @include mobile() {
-        margin-top: 8px;
+        margin-top: 10px;
         margin-left: 16px;
+        width: 150px;
+        height: 40px;
       }
 
       button.mobile-navigation-sidebar-ham-bt {
@@ -144,7 +146,7 @@ nav.oc-navbar {
           background-repeat: no-repeat;
           background-size: 18px 14px;
           background-position: 3px 5px;
-          display: block;
+          display: inline;
         }
       }
     }

--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -102,9 +102,9 @@ nav.oc-navbar {
         font-size: 26px;
 
         @include mobile() {
-          width: 200px;
+          width: 40%;
           height: 32px;
-          margin-left: -107px;
+          margin-left: -82px;
           top: 0px;
         }
 
@@ -132,7 +132,7 @@ nav.oc-navbar {
       @include mobile() {
         margin-top: 10px;
         margin-left: 16px;
-        width: 150px;
+        width: 40%;
         height: 40px;
       }
 

--- a/scss/partials/_search.scss
+++ b/scss/partials/_search.scss
@@ -3,40 +3,30 @@ div.search-box {
 
   @include mobile() {
     display: inline;
-    min-width: 150px;
+    width: 40px;
     min-height: 40px;
 
     &.active {
       position: absolute;
+      min-width: 160px;
       width: 100vw;
       height: calc(100vh - 13px);
-      top: 10px;
+      top: 0px;
       left: 0px;
       background-color: white;
       z-index: 1081;
-      padding: 0px 16px;
-    }
-  }
-
-  img.spyglass {
-    display: inline;
-    margin: 0px 0px 6px 0px;
-
-    @include mobile() {
-      width: 16px;
-      height: 16px;
-      margin: 0px 0px 6px 24px;
-      &.inactive {
-        margin: 0px 0px 11px 24px;
-      }
+      padding: 10px 16px;
     }
   }
 
   input.search {
-    margin: 5px 5px 0px 16px;
+    margin: 5px 0px 0px 0px;
     outline: none;
     border: none;
     caret-color: $carrot_text_blue_3;
+    background-image: cdnUrl("/img/ML/spyglass.svg");
+    background-repeat: no-repeat;
+    padding: 2px 0px 0px 31px;
     @include avenir_M();
     color: $carrot_dark_brown_1;
 
@@ -46,10 +36,13 @@ div.search-box {
     &:focus::placeholder {
       color: $carrot_dark_brown_1;
     }
-
     @include mobile() {
+      margin: 5px 0px 0px 26px;
+      padding: 2px 0px 0px 31px;
       &.inactive {
-        display: none;
+        padding: 6px 0px 0px 31px;
+        width: 20px;
+        height: 20px;
       }
     }
   }
@@ -93,7 +86,7 @@ div.search-results.inactive {
 
 div.triangle {
   position: absolute;
-  top: 81px;
+  top: 82px;
   left: 96px;
   background-color: white;
   border-top: 1px solid rgba(177,184,192,0.50);

--- a/scss/partials/_search.scss
+++ b/scss/partials/_search.scss
@@ -23,6 +23,8 @@ div.search-box {
     margin: 0px 0px 6px 0px;
 
     @include mobile() {
+      width: 16px;
+      height: 16px;
       margin: 0px 0px 6px 24px;
       &.inactive {
         margin: 0px 0px 11px 24px;

--- a/scss/partials/_search.scss
+++ b/scss/partials/_search.scss
@@ -1,11 +1,33 @@
-
 div.search-box {
   width: 400px;
 
+  @include mobile() {
+    display: inline;
+    min-width: 150px;
+    min-height: 40px;
+
+    &.active {
+      position: absolute;
+      width: 100vw;
+      height: calc(100vh - 13px);
+      top: 10px;
+      left: 0px;
+      background-color: white;
+      z-index: 1081;
+      padding: 0px 16px;
+    }
+  }
 
   img.spyglass {
     display: inline;
     margin: 0px 0px 6px 0px;
+
+    @include mobile() {
+      margin: 0px 0px 6px 24px;
+      &.inactive {
+        margin: 0px 0px 11px 24px;
+      }
+    }
   }
 
   input.search {
@@ -22,6 +44,12 @@ div.search-box {
     &:focus::placeholder {
       color: $carrot_dark_brown_1;
     }
+
+    @include mobile() {
+      &.inactive {
+        display: none;
+      }
+    }
   }
 
   button.search-close {
@@ -37,8 +65,12 @@ div.search-box {
     margin: 0px 24px 0px 0px;
     padding: 12px 0px 0px 0px;
 
+    @include mobile() {
+      margin: 0px;
+    }
+
     &:hover {
-        opacity: 1;
+      opacity: 1;
     }
 
     &.inactive {
@@ -71,6 +103,9 @@ div.triangle {
   &.inactive {
     display: none;
   }
+  @include mobile() {
+    display: none;
+  }
 }
 
 div.search-results {
@@ -80,6 +115,19 @@ div.search-results {
   margin: 41px 0px 0px 45px;
   width: 450px;
   box-shadow: 0 4px 6px 0 rgba(0,0,0,0.07);
+
+  @include mobile() {
+    position: absolute;
+    top: 63px;
+    left: 0px;
+    height: 100vh;
+    widght: 100vh;
+    background-color: white;
+    z-index: 1081;
+    margin: -1px;
+    padding: 0px;
+    border-radius: 0;
+  }
 
   div.header {
     background-color: white;
@@ -99,6 +147,10 @@ div.search-results {
   div.search-results-container {
     overflow-y: auto;
     max-height: calc(100vh - 180px - 47px);
+
+    @include mobile() {
+      max-height: calc(100vh - 80px - 47px);
+    }
 
     div.search-result {
       width: 100%;

--- a/src/oc/web/actions/search.cljs
+++ b/src/oc/web/actions/search.cljs
@@ -28,5 +28,8 @@
       (api/query (:uuid (dispatcher/org-data)) search-query query-finished))
     (reset)))
 
+(defn result-clicked [url]
+  (dispatcher/dispatch! [:search-result-clicked])
+  (utils/after 10 (router/nav! url)))
 
-(defn result-clicked [url] (utils/after 10 (router/nav! url)))
+

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -902,6 +902,7 @@
       (search-http (method-for-link search-link) (relative-href search-link)
                    {:headers (headers-for-link search-link)}
                    (fn [{:keys [status success body]}]
-                     (callback {:success success
+                     (callback {:query search-query
+                                :success success
                                 :error (when-not success body)
                                 :body (when (seq body) (json->cljs body))}))))))

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -4,6 +4,7 @@
             [oc.web.lib.jwt :as jwt]
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
+            [oc.web.stores.search :as search]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
             [oc.web.lib.responsive :as responsive]
@@ -38,6 +39,8 @@
 (rum/defcs org-dashboard < rum/static
                            rum/reactive
                            (drv/drv :org-dashboard-data)
+                           (drv/drv search/search-key)
+                           (drv/drv search/search-active?)
                            {:did-mount (fn [s]
                              (utils/after 100 #(set! (.-scrollTop (.-body js/document)) 0))
                              (refresh-board-data s)
@@ -60,7 +63,11 @@
                 is-showing-alert
                 media-input]} (drv/react s :org-dashboard-data)
         is-mobile? (responsive/is-tablet-or-mobile?)
-        should-show-onboard-overlay? (some #{nux} [:1 :7])]
+        should-show-onboard-overlay? (some #{nux} [:1 :7])
+        search-active? (drv/react s search/search-active?)
+        search-results? (pos?
+                         (count
+                          (:results (drv/react s search/search-key))))]
     ;; Show loading if
     (if (or ;; the org data are not loaded yet
             (not org-data)
@@ -112,6 +119,9 @@
           (and is-mobile?
                is-sharing-activity)
           (activity-share)
+          ;; Search results
+          (and is-mobile? (not (router/current-activity-id)))
+          (search-results-view)
           ;; Activity modal
           (and (router/current-activity-id)
                (not entry-edit-dissmissing))
@@ -139,7 +149,8 @@
                            is-sharing-activity))
           [:div.page
             (navbar)
-            (when is-mobile? (search-results-view))
             [:div.org-dashboard-container
               [:div.org-dashboard-inner
-                (dashboard-layout)]]])])))
+               (when-not (and is-mobile?
+                              (and search-active? search-results?))
+                 (dashboard-layout))]]])])))

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -120,7 +120,7 @@
                is-sharing-activity)
           (activity-share)
           ;; Search results
-          (and is-mobile? (not (router/current-activity-id)))
+          (and is-mobile? search-active? (not (router/current-activity-id)))
           (search-results-view)
           ;; Activity modal
           (and (router/current-activity-id)

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -13,6 +13,7 @@
             [oc.web.components.board-edit :refer (board-edit)]
             [oc.web.components.org-settings :refer (org-settings)]
             [oc.web.components.ui.alert-modal :refer (alert-modal)]
+            [oc.web.components.search :refer (search-results-view)]
             [oc.web.components.dashboard-layout :refer (dashboard-layout)]
             [oc.web.components.activity-modal :refer (activity-modal)]
             [oc.web.components.ui.onboard-overlay :refer (onboard-overlay)]
@@ -138,6 +139,7 @@
                            is-sharing-activity))
           [:div.page
             (navbar)
+            (when is-mobile? (search-results-view))
             [:div.org-dashboard-container
               [:div.org-dashboard-inner
                 (dashboard-layout)]]])])))

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -106,8 +106,8 @@
                                                  (count @store/savedsearch))
                                                 (not
                                                  @(::search-clicked? s)))
-                                           (.click
-                                            (rum/ref-node s "spyglass")))
+                                           (.focus
+                                            (rum/ref-node s "search-input")))
                                          s)
                          :will-mount (fn [s]
                           (search/inactive)
@@ -136,23 +136,19 @@
         [:button.search-close {:class (when (not @(::search-clicked? s))
                                         "inactive")
                                :on-click #(search-inactive s)}]
-        [:img.spyglass {:src (utils/cdn "/img/ML/spyglass.svg")
-                        :ref "spyglass"
-                        :class (when (not @(::search-clicked? s)) "inactive")
-                        :on-click (fn [e]
-                                    (let [searchel
-                                          (rum/ref-node s "search-input")]
-                                      (.remove (.-classList searchel)
-                                               "inactive")
-                                      (utils/after 100 #(.focus searchel))
-                                      (reset! (::search-clicked? s) true)))}]
         [:input.search
           {:class (when (not @(::search-clicked? s)) "inactive")
            :ref "search-input"
-           :placeholder "Search"
+           :placeholder (when-not (responsive/is-mobile-size?) "Search")
            :value @store/savedsearch
            :on-click #(reset! (::search-clicked? s) true)
-           :on-focus #(let [search-query (.-value (rum/ref-node s "search-input"))]
+           :on-blur #(when (responsive/is-mobile-size?)
+                       (set! (.-placehoder (rum/ref-node s "search-input")) ""))
+           :on-focus #(let [search-input (rum/ref-node s "search-input")
+                            search-query (.-value search-input)]
+                        (reset! (::search-clicked? s) true)
+                        (when (and (responsive/is-mobile-size?) (zero? (count search-query)))
+                          (set! (.-placeholder search-input) "Search"))
                         (search/query search-query))
            :on-key-down #(when (= "Enter" (.-key %)) (.preventDefault %))
            :on-change #(search/query

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -7,6 +7,7 @@
             [goog.events.EventType :as EventType]
             [oc.web.lib.utils :as utils]
             [oc.web.urls :as oc-urls]
+            [oc.web.lib.responsive :as responsive]
             [oc.web.components.ui.user-avatar :refer (user-avatar-image)]
             [oc.web.actions.search :as search]
             [oc.web.stores.search :as store]))
@@ -47,9 +48,43 @@
       ]
      ]))
 
+(def default-page-size
+  (if (responsive/is-mobile-size?) 300 5))
+
+(rum/defcs search-results-view < (drv/drv store/search-key)
+                                 (drv/drv store/search-active?)
+                                 rum/reactive
+                                 rum/static
+                                 (rum/local default-page-size ::page-size)
+  [s]
+  (let [search-results (drv/react s store/search-key)
+        search-active? (drv/react s store/search-active?)]
+    (when (and (not search-active?) (= @(::page-size s) default-page-size))
+      (reset! (::page-size s) default-page-size))
+    [:div.search-results {:ref "results"
+                          :class (when (not search-active?) "inactive")}
+        [:div.header
+          [:span "SEARCH RESULTS"]
+          (when (pos? (:count search-results))
+            [:span.count (str "(" (:count search-results) ")")])]
+        [:div.search-results-container
+          (if (pos? (:count search-results))
+            (let [results (reverse (:results search-results))]
+              (for [sr (take @(::page-size s) results)]
+                (let [key (str "result-" (:uuid (:_source sr)))]
+                  (case (:type (:_source sr))
+                    "entry" (rum/with-key (entry-display sr) key)
+                    "board" (rum/with-key (board-display sr) key)))))
+            [:div.empty-result
+              [:div.message "No matching results..."]])]
+        (when (< @(::page-size s) (:count search-results))
+          [:div.show-more
+            {:on-click (fn [e] (reset! (::page-size s)
+                                       (+ @(::page-size s) 15)))}
+            [:button] "Show More"])]))
+
 (defn search-inactive [s]
   (reset! (::search-clicked? s) false)
-  (reset! (::page-size s) 5)
   (set! (.-value (rum/ref-node s "search-input")) "")
   (search/inactive))
 
@@ -59,8 +94,6 @@
                         rum/static
                         (rum/local nil ::window-click)
                         (rum/local false ::search-clicked?)
-                        (rum/local 5 ::page-size)
-                        (rum/local 0 ::page-start)
                         {:will-mount (fn [s]
                           (search/inactive)
                           (reset! (::window-click s)
@@ -83,46 +116,31 @@
                            s)}
   [s]
   (when (store/should-display)
-    (let [search-results (drv/react s store/search-key)
-          search-active? (drv/react s store/search-active?)]
+    (let [search-active? (drv/react s store/search-active?)]
       [:div.search-box {:class (when @(::search-clicked? s) "active")}
         [:button.search-close {:class (when (not @(::search-clicked? s))
                                         "inactive")
                                :on-click #(search-inactive s)}]
         [:img.spyglass {:src (utils/cdn "/img/ML/spyglass.svg")
+                        :class (when (not @(::search-clicked? s)) "inactive")
                         :on-click (fn [e]
-                                    (reset! (::search-clicked? s) true)
-                                    (.focus (rum/ref-node s "search-input")))}]
-       [:input.search
-         {:ref "search-input"
-          :placeholder "Search"
-          :on-click #(reset! (::search-clicked? s) true)
-          :on-focus #(let [search-query (.-value (rum/ref-node s "search-input"))]
-                       (search/query search-query))
-          :on-key-down #(when (= "Enter" (.-key %)) (.preventDefault %))
-          :on-change #(search/query
-                       (.-value (rum/ref-node s "search-input")))
-          }]
-        [:div.triangle {:class (when (not search-active?) "inactive")}]
-        [:div.search-results {:ref "results"
-                              :class (when (not search-active?) "inactive")}
-          [:div.header
-            [:span "SEARCH RESULTS"]
-            (when (pos? (:count search-results))
-              [:span.count (str "(" (:count search-results) ")")])]
-          [:div.search-results-container
-            (if (pos? (:count search-results))
-              (let [results (reverse (:results search-results))]
-                (for [sr (take @(::page-size s) results)]
-                  (let [key (str "result-" (:uuid (:_source sr)))]
-                    (case (:type (:_source sr))
-                      "entry" (rum/with-key (entry-display sr) key)
-                      "board" (rum/with-key (board-display sr) key)))))
-              [:div.empty-result
-                [:div.message "No matching results..."]])]
-         (when (< @(::page-size s) (:count search-results))
-            [:div.show-more
-              {:on-click (fn [e] (reset! (::page-size s)
-                                         (+ @(::page-size s) 15)))}
-              [:button] "Show More"])
-         ]])))
+                                    (let [searchel
+                                          (rum/ref-node s "search-input")]
+                                      (.remove (.-classList searchel)
+                                               "inactive")
+                                      (utils/after 100 #(.focus searchel))
+                                      (reset! (::search-clicked? s) true)))}]
+        [:input.search
+          {:class (when (not @(::search-clicked? s)) "inactive")
+           :ref "search-input"
+           :placeholder "Search"
+           :on-click #(reset! (::search-clicked? s) true)
+           :on-focus #(let [search-query (.-value (rum/ref-node s "search-input"))]
+                        (search/query search-query))
+           :on-key-down #(when (= "Enter" (.-key %)) (.preventDefault %))
+           :on-change #(search/query
+                        (.-value (rum/ref-node s "search-input")))
+           }]
+       (when (not (responsive/is-mobile-size?))
+         [:div.triangle {:class (when (not search-active?) "inactive")}]
+         (search-results-view))])))

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -84,8 +84,8 @@
             [:button] "Show More"])]))
 
 (defn search-inactive [s]
-  (reset! (::search-clicked? s) false)
   (set! (.-value (rum/ref-node s "search-input")) "")
+  (reset! (::search-clicked? s) false)
   (search/inactive))
 
 (rum/defcs search-box < (drv/drv store/search-key)
@@ -94,7 +94,16 @@
                         rum/static
                         (rum/local nil ::window-click)
                         (rum/local false ::search-clicked?)
-                        {:will-mount (fn [s]
+                        {:after-render (fn [s]
+                                         (when (and
+                                                (pos?
+                                                 (count @store/savedsearch))
+                                                (not
+                                                 @(::search-clicked? s)))
+                                           (.click
+                                            (rum/ref-node s "spyglass")))
+                                         s)
+                         :will-mount (fn [s]
                           (search/inactive)
                           (reset! (::window-click s)
                             (events/listen
@@ -122,6 +131,7 @@
                                         "inactive")
                                :on-click #(search-inactive s)}]
         [:img.spyglass {:src (utils/cdn "/img/ML/spyglass.svg")
+                        :ref "spyglass"
                         :class (when (not @(::search-clicked? s)) "inactive")
                         :on-click (fn [e]
                                     (let [searchel
@@ -134,6 +144,7 @@
           {:class (when (not @(::search-clicked? s)) "inactive")
            :ref "search-input"
            :placeholder "Search"
+           :value @store/savedsearch
            :on-click #(reset! (::search-clicked? s) true)
            :on-focus #(let [search-query (.-value (rum/ref-node s "search-input"))]
                         (search/query search-query))

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -158,6 +158,5 @@
            :on-change #(search/query
                         (.-value (rum/ref-node s "search-input")))
            }]
-       (when-not (responsive/is-mobile-size?)
-         [:div.triangle {:class (when-not search-active? "inactive")}]
-         (search-results-view))])))
+       [:div.triangle {:class (when-not search-active? "inactive")}]
+       (when-not (responsive/is-mobile-size?)(search-results-view))])))

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -49,7 +49,8 @@
               [:button.mlb-reset.mobile-navigation-sidebar-ham-bt
                 {:on-click #(do
                               (dis/dispatch! [:input [:mobile-menu-open] false])
-                              (dis/dispatch! [:input [:mobile-navigation-sidebar] (not mobile-navigation-sidebar)]))}]]
+                              (dis/dispatch! [:input [:mobile-navigation-sidebar] (not mobile-navigation-sidebar)]))}]
+             (search-box)]
             [:div.nav.navbar-nav.navbar-left
               (search-box)])
           [:div.nav.navbar-nav.navbar-center

--- a/src/oc/web/stores/search.cljs
+++ b/src/oc/web/stores/search.cljs
@@ -3,6 +3,9 @@
             [oc.web.lib.jwt :as jwt]
             [oc.web.dispatcher :as dispatcher]))
 
+(def lastsearch (atom nil))
+(def savedsearch (atom nil))
+
 (defonce search-key :search-results)
 (defonce search-active? :search-active)
 
@@ -30,9 +33,12 @@
             results)))
 
 (defmethod dispatcher/action :search-query/finish
-  [db [_ {:keys [success error body]}]]
+  [db [_ {:keys [success error body query]}]]
   (let [total-hits (:total body)
         results (vec (sort-by #(:created-at (:_source %)) (:hits body)))]
+    (when success
+      (reset! savedsearch nil)
+      (reset! lastsearch query))
     (if success
       (assoc db search-key {:count total-hits :results (cleanup-uuid results)})
       db)))
@@ -47,6 +53,13 @@
 
 (defmethod dispatcher/action :search-reset
   [db [_]]
+  (reset! lastsearch nil)
+  (reset! savedsearch nil)
   (-> db
       (assoc search-active? false)
       (assoc search-key [])))
+
+(defmethod dispatcher/action :search-result-clicked
+  [db [_]]
+  (reset! savedsearch @lastsearch)
+  db)


### PR DESCRIPTION
Changes to have the search look good on a small device.

Additional functionality to show search results when a user hits the back button or closes the clicked on result.

To test:

* open in a mobile device or mobile mode in your browser.
- [x] do you only see the spyglass?
* click on the spy glass
- [x] You should now see the X on the left and focus should be in the search input.
* search for something 
- [x] The screen should be white with "SEARCH RESULTS  No matching results"
- [x] when there are results there should be a scrollable list.
- [x] clicking on a result should open the post.
- [x] hitting the back button or the x will bring you back to the search results.
- [x] You can start a new search or clear the current search.