### PR TITLE
Fix digest links

### DIFF
--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -41,7 +41,8 @@
   (vec (concat (org-key org-slug) [:secure-activities secure-id])))
 
 (defn activity-key [org-slug board-slug activity-uuid]
-  (let [board-key (if (= board-slug :all-posts)
+  (let [from-all-posts (or (= board-slug :all-posts) (:from-all-posts @router/path))
+        board-key (if from-all-posts
                     (all-posts-key org-slug)
                     (board-data-key org-slug board-slug))]
     (vec (concat board-key [:fixed-items activity-uuid]))))


### PR DESCRIPTION
https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit)

Items:
> Opening a digest link gives you a blank post: http://take.ms/PimfN8
> Adding a custom reaction from all posts doesn’t update the reaction in the modal (works on boards)

To test:
- open a digest link
- [x] do you see the activity data? Good
- dismiss the activity modal
- [x] are you back to AP with that same post visible? Good
- visit a normal board
- open a post
- add a reaction to it with the picker
- add a comment
- [x] do you see it both in the modal? Good
- dismiss the modal
- [x] do you see the reaction and the comment in FoC? Good
- now go to AP
- open a post that has no comments/reactions
- add a comment
- add a reaction with the picker
- [x] are both correctly added? Good
- dismiss the modal
- [x] do you see the reaction and the comment in the FoC? Good
- merge