### PR TITLE
Fix share spinner

### DIFF
--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -82,7 +82,7 @@
                                    (js/$ slack-button)
                                    #js {:trigger "manual"})))
                               s)
-                             :did-remount (fn [o s]
+                             :before-render (fn [s]
                               ;; When we have a sharing response
                               (when-let [shared-data @(drv/get-ref s :activity-shared-data)]
                                 (when (compare-and-set! (::sharing s) true false)


### PR DESCRIPTION
https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit)

Items:
> Infinite spin when sharing a post to Slack; it actually shared, but without a confirmation and just a spinner it seems broken

To test:
- from FoC click the vertical ellipsis and then share
- share on slack
- [x] did you see the spinner in the share button? Good
- [x] did it go away after a bit? Good
- open a post modal
- share on slack from here too
- [x] did you see the spinner in the share button? Good
- [x] did it go away after a bit? Good
- merge