### PR TITLE
Fixed mobile edit

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -99,6 +99,7 @@ moment.tz = {};
 moment.tz.guess = function(){};
 
 var OCStaticMailchimpApiSubmit = function(){};
+var OCStaticStartFixFixedPositioning = function(){};
 
 var OnPaste_StripFormatting = function(){};
 var isSafari = function(){};

--- a/resources/public/js/static-js.js
+++ b/resources/public/js/static-js.js
@@ -156,13 +156,14 @@ function OCStaticGetParameterByName(name, url) {
 
 function isSafari(){
   var ua = navigator.userAgent.toLowerCase(); 
-  if (ua.indexOf('safari') != -1) { 
+  if (ua.indexOf('safari') > -1) { 
     if (ua.indexOf('chrome') > -1) {
       return false;
     } else {
       return true;
     }
   }
+  return false;
 }
 
 function isFireFox(){
@@ -217,5 +218,40 @@ if (oc_loading) {
     }else{
       item.classList.remove('setup-screen');
     }
+  });
+}
+
+
+function OCStaticStartFixFixedPositioning(sel) {
+  // Let's assume the fixed top navbar has id="navbar"
+  // Cache the fixed element
+  var $navbar = $(sel);
+
+  var fixFixedPosition = function() {
+    $navbar.css({
+      position: 'absolute',
+      top: document.body.scrollTop + 'px'
+    });
+  };
+  var resetFixedPosition = function() {
+    $navbar.css({
+      position: 'fixed',
+      top: ''
+    });
+    $(document).off('scroll', updateScrollTop);
+  };
+  var updateScrollTop = function() {
+    $navbar.css('top', document.body.scrollTop + 'px');
+  };
+
+  $('input, textarea, [contenteditable=true]').on({
+    focus: function() {
+      // NOTE: The delay is required.
+      setTimeout(fixFixedPosition, 100);
+      // Keep the fixed element absolutely positioned at the top
+      // when the keyboard is visible
+      $(document).scroll(updateScrollTop);
+    },
+    blur: resetFixedPosition
   });
 }

--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -52,6 +52,7 @@ div.entry-edit-modal-container {
         margin: 0px;
         border-radius: 0px;
         box-shadow: none;
+        position: initial;
         height: initial;
       }
 
@@ -60,7 +61,7 @@ div.entry-edit-modal-container {
 
         @include tablet() {
           display: block;
-          height: 112px;
+          height: 64px;
           background-color: white;
           width: 100vw;
           position: fixed;
@@ -68,6 +69,7 @@ div.entry-edit-modal-container {
           left: 0px;
           right: 0px;
           z-index: 1;
+          box-shadow: 0px 1px 4px 0px rgba(0,0,0,0.12);
 
           div.mobile-header {
             height: 64px;
@@ -151,61 +153,6 @@ div.entry-edit-modal-container {
                     background-size: 20px 20px;
                   }
                 }
-              }
-            }
-          }
-
-          div.mobile-posting-in {
-            @include avenir_M();
-            font-size: 15px;
-            color: $carrot_text_blue_3;
-            height: 48px;
-            padding: 14px 24px 0px;
-            background-color: $carrot_light_blue_2;
-
-            &.active {
-              background-color: $carrot_text_blue_3;
-
-              div.boards-dropdown-caret.no-nux {
-                color: white;
-                &:after {
-                  background-image: cdnUrl("/img/ML/board_blue_chevron_white.svg");
-                }
-              }
-            }
-
-            span {
-              float: left;
-            }
-
-            div.boards-dropdown-caret.no-nux {
-              @include avenir_H();
-              color: $carrot_text_blue_3;
-
-              &:after {
-                width: 8px 5px;
-                background-size: 8px 5px;
-                background-image: cdnUrl("/img/ML/board_blue_chevron.svg");
-              }
-            }
-
-            div.dropdown-list-container {
-              width: 100vw;
-              height: calc(100vh - 64px - 48px);
-              top: 112px;
-              left: 0px;
-              text-align: left;
-
-              div.triangle {
-                display: none;
-              }
-
-              div.dropdown-list-content {
-                border: none;
-                border-radius: 0px;
-                padding: 24px;
-                margin: 0px;
-                box-shadow: none;
               }
             }
           }
@@ -295,6 +242,10 @@ div.entry-edit-modal-container {
         background-color: $carrot_light_gray_1;
         opacity: 0.3;
 
+        @include mobile() {
+          display: none;
+        }
+
         &.not-visible {
           opacity: 0;
         }
@@ -310,11 +261,69 @@ div.entry-edit-modal-container {
         margin-left: -22px;
 
         @include tablet() {
-          min-height: calc(100vh - 112px - 1px);
+          min-height: 100vh;
           max-height: initial;
-          padding: 0px;
+          padding: 64px 0px 0px;
           width: 100%;
-          margin: 112px 0px 0px;
+          margin: 0px;
+        }
+
+        div.mobile-posting-in {
+          @include avenir_M();
+          font-size: 15px;
+          color: $carrot_text_blue_3;
+          // height: 112px;
+          // padding: 78px 24px 0px;
+          height: 48px;
+          padding: 14px 24px 0px;
+          background-color: $carrot_light_blue_2;
+
+          &.active {
+            background-color: $carrot_text_blue_3;
+
+            div.boards-dropdown-caret.no-nux {
+              color: white;
+              &:after {
+                background-image: cdnUrl("/img/ML/board_blue_chevron_white.svg");
+              }
+            }
+          }
+
+          span {
+            float: left;
+          }
+
+          div.boards-dropdown-caret.no-nux {
+            @include avenir_H();
+            color: $carrot_text_blue_3;
+
+            &:after {
+              width: 8px 5px;
+              background-size: 8px 5px;
+              background-image: cdnUrl("/img/ML/board_blue_chevron.svg");
+            }
+          }
+
+          div.dropdown-list-container {
+            width: 100vw;
+            height: calc(100vh - 64px - 48px);
+            top: 112px;
+            left: 0px;
+            text-align: left;
+            background-color: white;
+
+            div.triangle {
+              display: none;
+            }
+
+            div.dropdown-list-content {
+              border: none;
+              border-radius: 0px;
+              padding: 24px;
+              margin: 0px;
+              box-shadow: none;
+            }
+          }
         }
 
         div.entry-edit-headline {

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -205,6 +205,8 @@
                             EventType/RESIZE
                             #(calc-entry-edit-modal-height s true)))
                           (reset! (::autosave-timer s) (utils/every 5000 #(autosave s)))
+                          (when (and (responsive/is-tablet-or-mobile?) (js/isSafari))
+                            (js/OCStaticStartFixFixedPositioning "div.entry-edit-modal-header-mobile"))
                           s)
                          :before-render (fn [s]
                           (calc-entry-edit-modal-height s)
@@ -366,32 +368,7 @@
                             (small-loading)
                             [:div.button-icon
                               {:class (when disabled? "disabled")}])
-                          "Save draft"]))])]
-              (when is-mobile?
-                [:div.mobile-posting-in
-                  [:span
-                    (if (:uuid entry-editing)
-                      (if (= (:status entry-editing) "published")
-                        "Posted in: "
-                        "Draft for: ")
-                      "Posting in: ")]
-                  [:div.boards-dropdown-caret
-                    {:on-click #(reset! (::show-boards-dropdown s) (not @(::show-boards-dropdown s)))
-                     :class (when (not nux) "no-nux")}
-                    (:board-name entry-editing)]
-                  (when (and (not nux) @(::show-boards-dropdown s))
-                    (dropdown-list
-                     {:items (map
-                              #(clojure.set/rename-keys % {:name :label :slug :value})
-                              (vals all-boards))
-                      :value (:board-slug entry-editing)
-                      :on-blur #(reset! (::show-boards-dropdown s) false)
-                      :on-change (fn [item]
-                                   (toggle-save-on-exit s true)
-                                   (reset! (::show-boards-dropdown s) false)
-                                   (dis/dispatch! [:input [:entry-editing :has-changes] true])
-                                   (dis/dispatch! [:input [:entry-editing :board-slug] (:value item)])
-                                   (dis/dispatch! [:input [:entry-editing :board-name] (:label item)]))}))])]
+                          "Save draft"]))])]]
             [:div.entry-edit-modal-header.group
               (user-avatar-image current-user-data)
               [:div.posting-in
@@ -421,6 +398,31 @@
                                    (dis/dispatch! [:input [:entry-editing :board-name] (:label item)]))}))]]])
         [:div.entry-edit-modal-body
           {:ref "entry-edit-modal-body"}
+          (when is-mobile?
+            [:div.mobile-posting-in
+              [:span
+                (if (:uuid entry-editing)
+                  (if (= (:status entry-editing) "published")
+                    "Posted in: "
+                    "Draft for: ")
+                  "Posting in: ")]
+              [:div.boards-dropdown-caret
+                {:on-click #(reset! (::show-boards-dropdown s) (not @(::show-boards-dropdown s)))
+                 :class (when (not nux) "no-nux")}
+                (:board-name entry-editing)]
+              (when (and (not nux) @(::show-boards-dropdown s))
+                (dropdown-list
+                 {:items (map
+                          #(clojure.set/rename-keys % {:name :label :slug :value})
+                          (vals all-boards))
+                  :value (:board-slug entry-editing)
+                  :on-blur #(reset! (::show-boards-dropdown s) false)
+                  :on-change (fn [item]
+                               (toggle-save-on-exit s true)
+                               (reset! (::show-boards-dropdown s) false)
+                               (dis/dispatch! [:input [:entry-editing :has-changes] true])
+                               (dis/dispatch! [:input [:entry-editing :board-slug] (:value item)])
+                               (dis/dispatch! [:input [:entry-editing :board-name] (:label item)]))}))])
           ; Headline element
           [:div.entry-edit-headline.emoji-autocomplete.emojiable.group
             {:content-editable (not nux)


### PR DESCRIPTION
Sourced (mixed): [QA doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#) and Slack discussion

Items:
> Header is fixed until you start editing; then it’s no longer fixed
> Move back to only the first white bar fixed in mobile edit, not the board blue bar

Since Safari mobile on purpose disabled the fixed positioned elements when the software keyboard is visible to save some space i used a workaround that checks when an element gets focused (ie: the keyboard pops up) and change the fixed positioning of the specified element to absolute. Then it listen for scrolls and reposition that element every time the scroll changes so it's always in the same place.

NB: make sure we are ok with this before merging this