### PR TITLE
Search components optimizations

### DIFF
--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -64,7 +64,7 @@
                                  rum/static
                                  (rum/local default-page-size ::page-size)
                                  {:before-render (fn [s]
-                                  (when (and (not search-active?)
+                                  (when (and (not @(drv/get-ref s store/search-active?))
                                              (not= @(::page-size s) default-page-size))
                                     (reset! (::page-size s) default-page-size))
                                   s)}
@@ -119,7 +119,7 @@
                              js/window
                              EventType/CLICK
                              (fn [e]
-                               (when (and @(drv/get-ref s store/search-active?)
+                               (when (and @(::search-clicked? s)
                                           (not
                                            (utils/event-inside? e
                                              (sel1 [:div.search-box]))))

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -63,11 +63,14 @@
                                  rum/reactive
                                  rum/static
                                  (rum/local default-page-size ::page-size)
+                                 {:before-render (fn [s]
+                                  (when (and (not search-active?)
+                                             (not= @(::page-size s) default-page-size))
+                                    (reset! (::page-size s) default-page-size))
+                                  s)}
   [s]
   (let [search-results (drv/react s store/search-key)
         search-active? (drv/react s store/search-active?)]
-    (when (and (not search-active?) (= @(::page-size s) default-page-size))
-      (reset! (::page-size s) default-page-size))
     [:div.search-results {:ref "results"
                           :class (when (not search-active?) "inactive")}
       (when-not (responsive/is-mobile-size?) (results-header search-results))
@@ -116,13 +119,11 @@
                              js/window
                              EventType/CLICK
                              (fn [e]
-                               (when (not
-                                      (utils/event-inside? e
-                                        (sel1 [:div.search-box])))
-                                 (do
-                                   (.stopPropagation e)
-                                   (search-inactive s)))
-                               e)))
+                               (when (and @(drv/get-ref s store/search-active?)
+                                          (not
+                                           (utils/event-inside? e
+                                             (sel1 [:div.search-box]))))
+                                 (search-inactive s)))))
                           s)
                          :will-unmount (fn [s]
                            (when @(::window-click s)


### PR DESCRIPTION
A couple of minor fixes to avoid not needed render cycle and app-state changes.

To test:
- [x] check that the search is inactivated when you click out of the results and search box
- [x] check that the page size is reset to the deafult value after showing all the results and then clicking out of the results view
- [x] check the code and make all the tests you think can be impacted by this changes