### PR TITLE
Always show All Posts

### DIFF
--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -99,7 +99,7 @@
         create-link (utils/link-for (:links org-data) "create")
         show-boards (or create-link (pos? (count boards)))
         show-all-posts (and (jwt/user-is-part-of-the-team (:team-id org-data))
-                            (> (count (:boards org-data)) 1))
+                            (utils/link-for (:links org-data) "activity"))
         show-create-new-board (and (not (responsive/is-tablet-or-mobile?))
                                    create-link)
         drafts-board (first (filter #(= (:slug %) utils/default-drafts-board-slug) all-boards))


### PR DESCRIPTION
From: [QA doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#)

> Always show AP

To test:
- do you see AP in the left nav bar even if you have only one board?

You only need to be part of the team and have an "activity" link in order to see it.