### PR TITLE
Always open All Posts

### DIFF
--- a/resources/public/js/static-js.js
+++ b/resources/public/js/static-js.js
@@ -63,7 +63,9 @@ function OCStaticGetYourBoardsUrl (decoded_jwt) {
       if ( user_id ) {
         org_slug = OCStaticGetCookie(OCStaticCookieName("last-org-" + user_id));
         if ( org_slug ) {
-          board_slug = OCStaticGetCookie(OCStaticCookieName("last-board-" + user_id + "-" + org_slug));
+          board_slug = "all-posts";
+          // Replace all-posts above withe the following to go back to the last visited board
+          // OCStaticGetCookie(OCStaticCookieName("last-board-" + user_id + "-" + org_slug));
           if ( board_slug ){
             your_board_url = "/" + org_slug + "/" + board_slug;
           } else {

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -1050,7 +1050,9 @@
 
 (defn your-boards-url []
   (if-let [org-slug (cook/get-cookie (router/last-org-cookie))]
-    (if-let [board-slug (cook/get-cookie (router/last-board-cookie org-slug))]
+    (if-let [board-slug "all-posts"]
+      ;; Repalce all-posts above with the following to go back to the last visited board
+      ;; (cook/get-cookie (router/last-board-cookie org-slug))]
       (oc-urls/board org-slug board-slug)
       (oc-urls/org org-slug))
     oc-urls/login))

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -1023,10 +1023,12 @@
 
 ;; Get the board to show counting the last accessed and the last created
 
-(def default-board "welcome")
+(def default-board "all-posts")
 
 (defn get-default-board [org-data]
-  (let [last-board-slug (or (cook/get-cookie (router/last-board-cookie (:slug org-data))) default-board)]
+  (let [last-board-slug default-board]
+    ; Replace default-board with the following to go back to the last visited board
+    ; (or (cook/get-cookie (router/last-board-cookie (:slug org-data))) default-board)]
     (if (and (= last-board-slug "all-posts")
              (link-for (:links org-data) "activity"))
       {:slug "all-posts"}


### PR DESCRIPTION
From: [QA doc](https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#)

> Always go back to AP

To test:
- point your browser to /org
- [x] check that it opens AP
- switch to a board
- close the browser tab
- point again to /org
- [x] check that it redirects you to AP
- switch to a board
- visit our homepage
- click Go to team (or Your digest depends if the PR was merged)
- [x] check that it sends you to AP, not to the last visited board