### PR TITLE
Mobile regressions

### DIFF
--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -19,11 +19,23 @@ div.dashboard-layout {
       background-color: $oc_gray_8;
       position: relative;
 
+      @include mobile() {
+        width: 100%;
+      }
+
       &.all-posts-container {
         width: 948px;
 
+        @include mobile() {
+          width: 100%;
+        }
+
         div.board-name-container {
           padding: 0px 0px 0px 12px;
+
+          @include mobile() {
+            padding: 0px;
+          }
         }
       }
 

--- a/src/oc/web/components/ui/interactions_summary.cljs
+++ b/src/oc/web/components/ui/interactions_summary.cljs
@@ -56,7 +56,7 @@
           (for [user-data (take 4 comments-authors)]
             [:div.is-comments-author
               {:key (str "entry-comment-author-" (:uuid entry-data) "-" (:user-id user-data))}
-              (user-avatar-image user-data true)])]
+              (user-avatar-image user-data (not (responsive/is-tablet-or-mobile?)))])]
         ; Comments count
         [:div.is-comments-summary
           {:class (str "comments-count-" (:uuid entry-data))}

--- a/src/oc/web/components/ui/user_avatar.cljs
+++ b/src/oc/web/components/ui/user_avatar.cljs
@@ -49,7 +49,7 @@
                          rum/reactive
                          (drv/drv :current-user-data)
   [s {:keys [classes click-cb disable-menu]}]
-  (let [not-mobile? (not (responsive/is-mobile-size?))]
+  (let [not-mobile? (not (responsive/is-tablet-or-mobile?))]
     [:button.user-avatar-button.group
       {:type "button"
        :class (str classes)
@@ -58,4 +58,4 @@
        :on-click (when (fn? click-cb) (click-cb))
        :aria-haspopup true
        :aria-expanded false}
-      (user-avatar-image (drv/react s :current-user-data))]))
+      (user-avatar-image (drv/react s :current-user-data) not-mobile?)]))


### PR DESCRIPTION
Card: https://trello.com/c/aPBu5ghm

Fix some regressions on the mobile All Posts:
- width of the post itself overflow the screen width
- images overflow the screen width
- All Posts title is not visible anymore
- clicking on the comments summary at the bottom of a post in AP shows the user name tooltip instead of opening the comments