### PR TITLE
Don't ignore the same user's comment updates.  

### DIFF
--- a/src/oc/web/actions/comment.cljs
+++ b/src/oc/web/actions/comment.cljs
@@ -4,7 +4,6 @@
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
-            [oc.web.actions :as actions]
             [oc.web.lib.json :refer (json->cljs)]))
 
 (defn add-comment-focus [activity-data]
@@ -66,3 +65,12 @@
   (api/toggle-reaction reaction-data reacting?
     (fn [{:keys [status success body]}]
       (get-comments activity-data))))
+
+(defn save-comment
+  [comment-data new-body]
+  (api/save-comment comment-data new-body)
+  (dis/dispatch! [:comment-save comment-data new-body]))
+
+(defn ws-comment-update
+  [interaction-data]
+  (dis/dispatch! [:ws-interaction/comment-update interaction-data]))

--- a/src/oc/web/components/comments.cljs
+++ b/src/oc/web/components/comments.cljs
@@ -45,7 +45,7 @@
       (do
         (stop-editing s)
         (set! (.-innerHTML new-comment) comment-text)
-        (dis/dispatch! [:comment-save c comment-text]))
+        (comment-actions/save-comment c comment-text))
       (cancel-edit e s c))))
 
 (defn start-editing [s]

--- a/src/oc/web/lib/ws_interaction_client.cljs
+++ b/src/oc/web/lib/ws_interaction_client.cljs
@@ -9,6 +9,7 @@
             [oc.web.lib.jwt :as j]
             [oc.web.local-settings :as ls]
             [oc.web.actions.reaction :as reaction-actions]
+            [oc.web.actions.comment :as comment-actions]
             [goog.Uri :as guri]))
 
 (def current-board-path (atom nil))
@@ -54,7 +55,7 @@
 (defmethod event-handler :interaction-comment/update
   [_ body]
   (timbre/debug "Comment update event" body)
-  (dis/dispatch! [:ws-interaction/comment-update body]))
+  (comment-actions/ws-comment-update body))
 
 (defmethod event-handler :interaction-comment/delete
   [_ body]

--- a/src/oc/web/stores/comment.cljs
+++ b/src/oc/web/stores/comment.cljs
@@ -114,14 +114,18 @@
         comments-data (get-in db comments-key)
         comment-idx (utils/index-of comments-data #(= item-uuid (:uuid %)))]
     (if comment-idx
-      (let [old-comment-data (get comments-data comment-idx)
-            body-comment-data (assoc old-comment-data
-                                :body (:body comment-data))
-            update-comment-data (assoc body-comment-data
-                                  :updated-at (:updated-at comment-data))
-            new-comment-data (if (contains? update-comment-data :reactions)
-                               update-comment-data
-                               (assoc update-comment-data :reactions (:reactions old-comment-data)))
-            new-comments-data (assoc comments-data comment-idx new-comment-data)]
-        (assoc-in db comments-key new-comments-data))
+      (let [old-comment-data (get comments-data comment-idx)]
+        (if (<= (utils/js-date
+                 (:updated-at old-comment-data))
+                (utils/js-date (:updated-at comment-data)))
+          (let [body-comment-data (assoc old-comment-data
+                                    :body (:body comment-data))
+                update-comment-data (assoc body-comment-data
+                                      :updated-at (:updated-at comment-data))
+                new-comment-data (if (contains? update-comment-data :reactions)
+                                   update-comment-data
+                                   (assoc update-comment-data :reactions (:reactions old-comment-data)))
+                new-comments-data (assoc comments-data comment-idx new-comment-data)]
+            (assoc-in db comments-key new-comments-data))
+          db))
       db)))


### PR DESCRIPTION

Previously we would ignore a web socket comment update if from the same user.  This change no longer ignores it and only updates the body and updated-at fields.

To test:
open a browser with one user
open a browser with the same user.
add a comment to a post
- [x] When you edit a comment does it show up the same in both browsers?
- [x] Can you edit again in the different browser?

- [x] merge
