### PR TITLE
Fix all posts placement in the app shell container.

### DIFF
--- a/scss/partials/_all_posts.scss
+++ b/scss/partials/_all_posts.scss
@@ -1,6 +1,5 @@
 div.all-posts {
   width: 932px;
-  margin-left: 16px;
 
   @include mobile() {
     width: 100%;

--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -24,14 +24,14 @@ div.dashboard-layout {
       }
 
       &.all-posts-container {
-        width: 948px;
+        width: 932px;
 
         @include mobile() {
           width: 100%;
         }
 
         div.board-name-container {
-          padding: 0px 0px 0px 12px;
+          padding: 0px;
 
           @include mobile() {
             padding: 0px;

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -99,13 +99,16 @@
                           (zero? (count (:fixed-items board-data))))
         sidebar-width (+ responsive/left-navigation-sidebar-width
                          responsive/left-navigation-sidebar-minimum-right-margin)
+        container-width (if (utils/in? (:route route) "all-posts")
+                          responsive/all-posts-container-width
+                          responsive/board-container-width)
         board-container-style {:marginLeft (if is-mobile-size?
                                              "0px"
                                              (str (max
                                                    sidebar-width
                                                    (+
                                                     (/
-                                                     (- @(::ww s) responsive/board-container-width sidebar-width)
+                                                     (- @(::ww s) container-width sidebar-width)
                                                      2)
                                                    sidebar-width))
                                              "px"))}

--- a/src/oc/web/lib/responsive.cljs
+++ b/src/oc/web/lib/responsive.cljs
@@ -85,6 +85,7 @@
 (def left-navigation-sidebar-minimum-right-margin 40)
 (def left-navigation-sidebar-width 200)
 (def board-container-width 912)
+(def all-posts-container-width 932)
 
 (defn is-tablet-or-mobile? []
   ;; check if it's test env, can't import utils to avoid circular dependencies


### PR DESCRIPTION
From GDoc: https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#

> The AP feed should automatically centre itself in the available space

Check the image in the doc.