### PR TITLE
Fix continue reading

### DIFF
--- a/scss/partials/_stream_view_item.scss
+++ b/scss/partials/_stream_view_item.scss
@@ -6,7 +6,7 @@ div.stream-view-item {
     width: 100%;
   }
 
-  &:not(.expanded).body-fade-out {
+  &:not(.expanded).show-continue-reading {
     div.stream-view-item-body {
       div.stream-body-left {
         div.stream-item-body-container {
@@ -16,6 +16,10 @@ div.stream-view-item {
             &:after {
               display: block;
             }
+          }
+
+          button.expand-button {
+            display: block;
           }
         }
       }
@@ -236,6 +240,7 @@ div.stream-view-item {
           @include avenir_M();
           font-size: 16px;
           text-align: center;
+          display: none;
         }
       }
 

--- a/src/oc/web/components/stream_view_item.cljs
+++ b/src/oc/web/components/stream_view_item.cljs
@@ -37,7 +37,8 @@
   (when-not @(::expanded s)
     (let [item-body (rum/ref-node s "item-body")
           dom-node (rum/dom-node s)]
-      (if (> (.-clientHeight item-body) 400)
+      (if (or (responsive/is-tablet-or-mobile?)
+              (> (.-clientHeight item-body) 400))
         (.add (.-classList dom-node) "body-fade-out")
         (.remove (.-classList dom-node) "body-fade-out")))))
 
@@ -91,8 +92,7 @@
         activity-attachments (au/get-attachments-from-body (:body activity-data))]
     [:div.stream-view-item
       {:class (utils/class-set {(str "stream-view-item-" (:uuid activity-data)) true
-                                :expanded expanded?
-                                :show-continue-reading (not expanded?)})}
+                                :expanded expanded?})}
       [:div.stream-view-item-header
         [:div.stream-header-head-author
           (user-avatar-image (:publisher activity-data))
@@ -179,10 +179,9 @@
               [:div.stream-item-body-inner
                 {:ref "item-body"
                  :dangerouslySetInnerHTML (utils/emojify (:body activity-data))}]]
-            (when-not expanded?
-              [:button.mlb-reset.expand-button
-                {:on-click #(reset! (::expanded s) true)}
-                "Continue reading"])]
+            [:button.mlb-reset.expand-button
+              {:on-click #(reset! (::expanded s) true)}
+              "Continue reading"]]
           (stream-view-attachments activity-attachments)
           [:div.stream-item-reactions.group
             {:ref "stream-item-reactions"}

--- a/src/oc/web/components/stream_view_item.cljs
+++ b/src/oc/web/components/stream_view_item.cljs
@@ -39,8 +39,8 @@
           dom-node (rum/dom-node s)]
       (if (or (responsive/is-tablet-or-mobile?)
               (> (.-clientHeight item-body) 400))
-        (.add (.-classList dom-node) "body-fade-out")
-        (.remove (.-classList dom-node) "body-fade-out")))))
+        (.add (.-classList dom-node) "show-continue-reading")
+        (.remove (.-classList dom-node) "show-continue-reading")))))
 
 (rum/defcs stream-view-item < rum/reactive
                               ;; Derivatives


### PR DESCRIPTION
No card, quick fix for a bug identified by @thepug , assigning this to him.

Continue reading button should show up:
- always on mobile: it's needed to show the add comment and all the comments
- on desktop only if the entry body is too long
- hide it on both when the user clicks it