### PR TITLE
Fix edit view title.

### DIFF
--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -50,10 +50,14 @@ div.entry-edit-modal-container {
       @include avenir_H();
       font-size: 18px;
       color: $deep_navy;
-      width: 105px;
+      width: 162px;
       text-align: right;
       position: relative;
       margin: 0px auto;
+
+      &.editing {
+        width: 105px;
+      }
 
       &:before {
         content: "";

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -294,7 +294,10 @@
         [:button.mlb-reset.mobile-modal-close-bt
           {:on-click #(cancel-clicked s)}]
         [:div.entry-edit-modal-header-title
-          "Edit post"]
+          {:class (when (:uuid entry-editing) "editing")}
+          (if (:uuid entry-editing)
+            "Editing post"
+            "Create new post")]
         (let [should-show-save-button? (and (not @(::publishing s))
                                             (not published?))]
           [:div.entry-edit-modal-header-right


### PR DESCRIPTION
From the QA doc: https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#

Item:
> https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#

Fix the title of the entry-edit view.
Use "Create new post" if the post is brand new, use "Editing post" in case it's an existing post (a draft or a published post on mobile).