### PR TITLE
Mobile add section tooltip.

### DIFF
--- a/scss/partials/_sections_picker.scss
+++ b/scss/partials/_sections_picker.scss
@@ -223,6 +223,39 @@ div.sections-picker-container {
           }
         }
       }
+
+      @include mobile() {
+        div.add-section-tooltip-container {
+          display: block !important;
+          width: 100%;
+          text-align: center;
+          margin-top: 32px;
+
+          div.add-section-tooltip-arrow {
+            width: 20px;
+            height: 38px;
+            @include image-2x("/img/ML/section_tooltip_arrow");
+            background-size: 20px 38px;
+            background-position: center;
+            background-repeat: no-repeat;
+            margin: 0 auto;
+          }
+
+          div.add-section-tooltip {
+            width: 100%;
+            margin: 24px auto;
+            @include avenir_M();
+            font-size: 18px;
+            color: $ui_grey;
+            text-align: center;
+            max-width: 311px;
+          }
+        }
+      }
+
+      div.add-section-tooltip-container {
+        display: none;
+      }
     }
   }
 }

--- a/src/oc/web/components/ui/sections_picker.cljs
+++ b/src/oc/web/components/ui/sections_picker.cljs
@@ -97,4 +97,12 @@
           [:div.sections-picker-content
             (sections-group s fixed-team-sections should-show-headers?)
             (sections-group s fixed-public-sections should-show-headers?)
-            (sections-group s fixed-private-sections should-show-headers?)]])]))
+            (sections-group s fixed-private-sections should-show-headers?)
+            (when (and (= (count all-sections) 1)
+                       (= (:slug (first all-sections)) "general"))
+              [:div.add-section-tooltip-container
+                [:div.add-section-tooltip-arrow]
+                [:div.add-section-tooltip
+                  (str
+                   "Keep posts organized by sections, e.g., "
+                   "Announcements, and Design, Sales, and Marketing.")]])]])]))


### PR DESCRIPTION
Card: https://trello.com/c/gTrE27XK
Item:
> Add back the NUX section tooltip

To test:
- signup from mobile
- add a new post
- tap on the General section
- [x] do you see the prompt to add a new section with an arrow pointing up? Good
- publish the post into a new section
- create a new post
- tap on the section name as before
- [x] do you NOT see the prompt with the arrow pointing up anymore? Good