### PR TITLE
Redirects on post creation

### DIFF
--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -836,6 +836,7 @@
     (dissoc :section-editing)
     (update-in [:entry-editing] dissoc :publishing)
     (assoc-in [:entry-editing :board-slug] (:slug fixed-board-data))
+    (assoc-in [:entry-editing :new-section] true)
     (dissoc :entry-toggle-save-on-exit))))
 
 (defmethod dispatcher/action :entry-publish/finish

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -242,12 +242,10 @@
                                       (utils/after
                                        180
                                        #(let [from-ap (or (:from-all-posts @router/path)
-                                                          (= (router/current-board-slug) "all-posts"))
-                                              go-to-ap (or from-ap
-                                                           (not= (:status entry-editing) "published"))]
+                                                          (= (router/current-board-slug) "all-posts"))]
                                           ;; Redirect to AP if coming from it or if the post is not published
                                           (router/nav!
-                                            (if go-to-ap
+                                            (if from-ap
                                               (oc-urls/all-posts (router/current-org-slug))
                                               (oc-urls/board (router/current-org-slug)
                                                (:board-slug entry-editing))))))))))))

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -242,10 +242,12 @@
                                       (utils/after
                                        180
                                        #(let [from-ap (or (:from-all-posts @router/path)
-                                                          (= (router/current-board-slug) "all-posts"))]
+                                                          (= (router/current-board-slug) "all-posts"))
+                                              go-to-ap (and (not (:new-section entry-editing))
+                                                            from-ap)]
                                           ;; Redirect to AP if coming from it or if the post is not published
                                           (router/nav!
-                                            (if from-ap
+                                            (if go-to-ap
                                               (oc-urls/all-posts (router/current-org-slug))
                                               (oc-urls/board (router/current-org-slug)
                                                (:board-slug entry-editing))))))))))))


### PR DESCRIPTION
Card: https://trello.com/c/gTrE27XK
Item:
> When you create a new post, you should end up where you started, e.g., start in AP, post, end up in AP; start in a section, post, end up in that section; or create a post in a new section, end up in that new section
