### PR TITLE
Fix grid/stream view on mobile

### DIFF
--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -106,8 +106,11 @@
                                  (events/listen js/window EventType/RESIZE #(reset! (::ww s) (responsive/ww))))
                                 (let [board-view-cookie (router/last-board-view-cookie (router/current-org-slug))
                                       cookie-value (cook/get-cookie board-view-cookie)
-                                      board-view (or (keyword cookie-value) :stream)]
-                                  (reset! (::board-switch s) board-view))
+                                      board-view (or (keyword cookie-value) :stream)
+                                      fixed-board-view (if (responsive/is-tablet-or-mobile?)
+                                                        :stream
+                                                        board-view)]
+                                  (reset! (::board-switch s) fixed-board-view))
                                 s)
                                :did-mount (fn [s]
                                 (when-not (utils/is-test-env?)


### PR DESCRIPTION
Card: https://trello.com/c/gTrE27XK
Item:
> Bug: very corner case, switch to grid on desktop, now resize to mobile and refresh, notice you see the grid view that shouldn't be visible on mobile.