### PR TITLE
Do not focus headline if already focused

### DIFF
--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -123,7 +123,8 @@
     (js/replaceSelectedText pasted-data)
     ; call the headline-on-change to check for content length
     (headline-on-change state)
-    (when-not (responsive/is-tablet-or-mobile?)
+    (when (and (not (responsive/is-tablet-or-mobile?))
+               (= (.-activeElement js/document) (.-body js/document)))
       (when-let [headline-el (rum/ref-node state "headline")]
         ; move cursor at the end
         (utils/to-end-of-content-editable headline-el)))))

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -92,9 +92,10 @@
     (js/replaceSelectedText pasted-data)
     ; call the headline-on-change to check for content length
     (headline-on-change state)
-    (when-let [headline-el   (rum/ref-node state "edit-headline")]
-      ; move cursor at the end
-      (utils/to-end-of-content-editable headline-el))))
+    (when (= (.-activeElement js/document) (.-body js/document))
+      (when-let [headline-el   (rum/ref-node state "edit-headline")]
+        ; move cursor at the end
+        (utils/to-end-of-content-editable headline-el)))))
 
 (defn- add-emoji-cb [state]
   (headline-on-change state)


### PR DESCRIPTION
Card: https://trello.com/c/gTrE27XK
Item:
> Click edit on a post (pencil or dropdown), click the body to start editing the body, focus jumps to the title

To test:
- start editing (new or existing post)
- focus the body right away (as quickly as possible)
- [x] do you NOT see the focus moving to the headline? Good
- start editing (new or existing post)
- do nothing, just wait
- [x] do you see the headline getting focused? Good