### PR TITLE
Fix strip empty tags function

### DIFF
--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -633,7 +633,7 @@
 
 (defn strip-empty-tags [text]
   (when text
-    (let [reg (js/RegExp. "<[a-zA-Z]{1,}[ ]{0,}>[ ]{0,}</[a-zA-Z]{1,}[ ]{0,}>" "ig")]
+    (let [reg (js/RegExp. "<[a-zA-Z]{1,}[ ]{0,}(class)?[ ]{0,}([0-9a-zA-Z-]{0,}=\"[a-zA-Z\\s]{0,}\")?>[ ]{0,}</[a-zA-Z]{1,}[ ]{0,}>" "ig")]
       (.replace text reg ""))))
 
 (defn su-default-title []


### PR DESCRIPTION
From QA doc https://docs.google.com/document/d/1X3j869Y8n94zfqaGVhrWf8VOlr3qEa_4a1fxtIjH6fs/edit#

Ryan says:
> If I put an image before and body copy in a post, and look at it in the grid view, it creates additional unnecessary padding (the post on the left has an image at the beginning of the post body as where the post next to it does not).

The problem is that he's html looked like this:
`<p class><img ....></p>`
instead of
`<p><img ....></p>`

the post is this https://staging.carrot.io/18f/design/post/8643-4a89-8bc7
If you looked at it in the grid view you see a weird space above it (before this branch).

Now it should be fine since the regular expression now look for:
`<TAG (*=*)?></TAG>`
i added this `(*=*)?` part.