### PR TITLE
REFACTOR: Use core.async pub/sub for the websocket clients.

### DIFF
--- a/src/oc/web/actions/comment.cljs
+++ b/src/oc/web/actions/comment.cljs
@@ -6,7 +6,6 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.json :refer (json->cljs)]
-            [oc.web.lib.ws-interaction-client :as ws-ic]
             [oc.web.actions.activity :as activity-actions]))
 
 (defn add-comment-focus [activity-data]
@@ -94,17 +93,11 @@
         (api/get-board (utils/link-for (:links (dis/board-data)) ["item" "self"] "GET")))))
   (dis/dispatch! [:ws-interaction/comment-add interaction-data]))
 
-(defmethod ws-ic/event-handler :interaction-comment/add
-  [_ body]
-  (timbre/debug "Comment add event" body)
-  (ws-comment-add body))
-
-(defmethod ws-ic/event-handler :interaction-comment/update
-  [_ body]
-  (timbre/debug "Comment update event" body)
-  (ws-comment-update body))
-
-(defmethod ws-ic/event-handler :interaction-comment/delete
-  [_ body]
-  (timbre/debug "Comment delete event" body)
-  (ws-comment-delete body))
+;; Pass in the subscriber until we sort out the namespaces in actions.cljs
+(defn subscribe [subscriber]
+  (subscriber :interaction-comment/add
+              #(ws-comment-add (:data %)))
+  (subscriber :interaction-comment/update
+              #(ws-comment-update (:data %)))
+  (subscriber :interaction-comment/delete
+              #(ws-comment-delete (:data %))))

--- a/src/oc/web/actions/reaction.cljs
+++ b/src/oc/web/actions/reaction.cljs
@@ -6,7 +6,6 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.json :refer (json->cljs)]
-            [oc.web.lib.ws-interaction-client :as ws-ic]
             [oc.web.actions.activity :as activity-actions]))
 
 (defn react-from-picker [activity-data emoji]
@@ -78,14 +77,9 @@
       (refresh-if-needed org-slug board-slug interaction-data)))
   (dis/dispatch! [:ws-interaction/reaction-delete interaction-data]))
 
-;; WS-interactions
-
-(defmethod ws-ic/event-handler :interaction-reaction/add
-  [_ body]
-  (timbre/debug "Reaction add event" body)
-  (ws-interaction-reaction-add body))
-
-(defmethod ws-ic/event-handler :interaction-reaction/delete
-  [_ body]
-  (timbre/debug "Reaction delete event" body)
-  (ws-interaction-reaction-delete body))
+(defn subscribe [subscriber]
+  (subscriber :interaction-reaction/add
+              #(ws-interaction-reaction-add (:data %)))
+  (subscriber :interaction-reaction/delete
+              #(ws-interaction-reaction-delete (:data %))))
+  


### PR DESCRIPTION
This changes the web socket interaction and change client. The change uses `core.async`'s publish / subscribe features to support one to many event handlers.

The subscribe functions are a bit strange because of the namespace issues in `actions.cljs`.  These will be cleaned up during the refactor changes.

To test:

Login with different users A/B
- As user B, open up a single section url.
- As user A , add a new post to the section above.
- [x] Does the new post show up in user B's section list?
- As user A, add a comment to the post.
- [x] Does the comment show up in user B's post?
- As user A, add a reaction to the post.
- [x] Does the reaction show up in user B's post?
- As user A, remove the same reaction from the post.
- [x] Does it get removed in user B's post?
- As user A, react to the comment.
- [x] Does it the reaction show on the comment in user B's display?
- As user A, remove the reaction to the comment.
- [x] Does it remove the reaction on the comment in user B's display?
- As user A, edit the comment.
- [ ] Does the update show in user B's display?
- As user A, remove the comment.
- [ ] Does the comment get removed in user B's display?
