### PR TITLE
BUG: Fix video dismiss check

### DIFF
--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -129,7 +129,7 @@
    (str "https://player.vimeo.com/video/" (:id video))))
 
 (defn media-video-add [s editable video-data]
-  (if (= :dismiss video-data)
+  (if (nil? video-data)
     (.addVideo editable nil nil nil nil)
     (.addVideo
      editable


### PR DESCRIPTION
BUG: Can't dismiss the add video modal w/o throwing and error on post edit/create.

When dismissing the video add modal check against the correct value of the app-state to avoid missing the dismiss and erroring.

To test:
- click compose
- enter a title
- enter a body and Enter
- click on the plus at the bottom
- click on Video
- write something in the url field
- dismiss the with cancel or the X
- [ ] do you NOT see an error in the console? Good
- click again the plus button
- click again on video
- add a youtube video url
- click add
- [ ] did it work? Good
- post the edits
- [ ] did it work? Good