### PR TITLE
API request cleanup. 

### DIFF
--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -14,7 +14,6 @@
             [oc.web.lib.utils :as utils]
             [oc.web.lib.json :refer (json->cljs cljs->json)]
             [oc.web.lib.raven :as sentry]
-            [oc.web.actions.error-banner :as error-banner-actions]
             [goog.Uri :as guri]))
 
 (def ^:private web-endpoint ls/web-server-domain)
@@ -45,6 +44,16 @@
 
 (defn- content-type [type]
   (str "application/vnd.open-company." type ".v1+json;charset=UTF-8"))
+
+(declare jwt-refresh-handler)
+(declare jwt-refresh-error-hn)
+(declare network-error-handler)
+
+(defn config-request
+  [jwt-refresh-hn jwt-error-handler network-error-hn]
+  (def jwt-refresh-handler jwt-refresh-hn)
+  (def jwt-refresh-error-hn jwt-error-handler)
+  (def network-error-handler network-error-hn))
 
 (defn complete-params [params]
   (if-let [jwt (j/jwt)]
@@ -128,8 +137,8 @@
     (timbre/debug jwt expired?)
     (go
       (when (and jwt expired?)
-        (jwt-refresh #(oc.web.actions.user/update-jwt (:body %))
-                     #(router/redirect! oc-urls/logout)))
+        (jwt-refresh #(jwt-refresh-handler (:body %))
+                     #(jwt-refresh-error-hn)))
 
       (let [{:keys [status body] :as response} (<! (method (str endpoint path) (complete-params params)))]
         (timbre/debug "Resp:" (method-name method) (str endpoint path) status)
@@ -141,7 +150,7 @@
         ; If it was a 5xx or a 0 show a banner for network issues
         (when (or (zero? status)
                   (and (>= status 500) (<= status 599)))
-          (error-banner-actions/show-banner utils/generic-network-error 10000))
+          (network-error-handler))
         ; report all 5xx to sentry
         (when (or (and (>= status 500) (<= status 599))
                   (= status 400)

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -128,13 +128,8 @@
     (timbre/debug jwt expired?)
     (go
       (when (and jwt expired?)
-        (if-let [refresh-url (j/get-key :refresh-url)]
-          (let [res (<! (refresh-jwt refresh-url))]
-            (timbre/debug "jwt-refresh" res)
-            (if (:success res)
-              (oc.web.actions.user/update-jwt (:body res))
-              (oc.web.actions.user/logout)))
-          (oc.web.actions.user/logout)))
+        (jwt-refresh #(oc.web.actions.user/update-jwt (:body %))
+                     #(router/redirect! oc-urls/logout)))
 
       (let [{:keys [status body] :as response} (<! (method (str endpoint path) (complete-params params)))]
         (timbre/debug "Resp:" (method-name method) (str endpoint path) status)

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -22,6 +22,7 @@
             [oc.web.actions.comment]
             [oc.web.actions.reaction]
             [oc.web.actions.user :as user-actions]
+            [oc.web.actions.error-banner :as error-banner-actions]
             [oc.web.api :as api]
             [oc.web.urls :as urls]
             [oc.web.router :as router]
@@ -554,6 +555,13 @@
 (defn init []
   ;; Setup timbre log level
   (logging/config-log-level! (or (:log-level (:query-params @router/path)) ls/log-level))
+  ;; Setup API requests
+  (api/config-request
+   #(user-actions/update-jwt %) ;; success jwt refresh after expire
+   #(user-actions/logout) ;; failed to refresh jwt
+   ;; network error
+   #(error-banner-actions/show-banner utils/generic-network-error 10000))
+
   ;; Persist JWT in App State
   (user-actions/dispatch-jwt)
   ;; on any click remove all the shown tooltips to make sure they don't get stuck


### PR DESCRIPTION
Removes the errors on compile time about undefined namespaces.

Removes unused code.

I wasn't sure of the best approach here.  We don't have a hierarchy so I don't think multi methods work. I went ahead and made the handlers configurable but required by using `declare`. They will error if they aren't redefined.  

I also don't think a pub/sub works here since there is only one subscriber.


To test:

- Shut down the search service.  
- Try to search
- [x] Does the error banner show?

To test the jwt-refresh I always set the expired conditional to be true.
Change this line https://github.com/open-company/open-company-web/blob/api-cleanup/src/oc/web/api.cljs#L140 
to `(when true ;;(and jwt expired?)`
- [x] In the console you will see `jwt-refresh` followed by the token.