### PR TITLE
BUG: can't create post with new section

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -171,7 +171,8 @@
 
 (defn entry-modal-save [activity-data board-slug section-editing]
   (timbre/debug section-editing)
-  (if (= (:board-slug activity-data) utils/default-section-slug)
+  (if (and (= (:board-slug activity-data) utils/default-section-slug)
+           section-editing)
     (let [fixed-entry-data (dissoc activity-data :board-slug :board-name)
           final-board-data (assoc section-editing :entries [fixed-entry-data])]
       (api/create-board final-board-data

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -147,6 +147,7 @@
                         (drv/drv :org-data)
                         (drv/drv :current-user-data)
                         (drv/drv :entry-editing)
+                        (drv/drv :section-editing)
                         (drv/drv :editable-boards)
                         (drv/drv :media-input)
                         (drv/drv :entry-save-on-exit)
@@ -304,14 +305,19 @@
                              (if (and (is-publishable? entry-editing)
                                       (not (zero? (count fixed-headline))))
                                 (let [_ (dis/dispatch! [:input [:entry-editing :headline] fixed-headline])
-                                      updated-entry-editing @(drv/get-ref s :entry-editing)]
+                                      updated-entry-editing @(drv/get-ref s :entry-editing)
+                                      section-editing @(drv/get-ref s :section-editing)
+                                      section-data (if (and (= (:board-slug updated-entry-editing) utils/default-section-slug)
+                                                            (= (:slug section-editing) utils/default-section-slug))
+                                                     section-editing
+                                                     nil)]
                                   (if published?
                                     (do
                                       (reset! (::saving s) true)
                                       (activity-actions/entry-save updated-entry-editing))
                                     (do
                                       (reset! (::publishing s) true)
-                                      (activity-actions/entry-publish updated-entry-editing nil))))
+                                      (activity-actions/entry-publish updated-entry-editing section-data))))
                                 (when (zero? (count fixed-headline))
                                   (when-let [$post-btn (js/$ (rum/ref-node s "mobile-post-btn"))]
                                     (when-not (.data $post-btn "bs.tooltip")

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -306,18 +306,14 @@
                                       (not (zero? (count fixed-headline))))
                                 (let [_ (dis/dispatch! [:input [:entry-editing :headline] fixed-headline])
                                       updated-entry-editing @(drv/get-ref s :entry-editing)
-                                      section-editing @(drv/get-ref s :section-editing)
-                                      section-data (if (and (= (:board-slug updated-entry-editing) utils/default-section-slug)
-                                                            (= (:slug section-editing) utils/default-section-slug))
-                                                     section-editing
-                                                     nil)]
+                                      section-editing @(drv/get-ref s :section-editing)]
                                   (if published?
                                     (do
                                       (reset! (::saving s) true)
                                       (activity-actions/entry-save updated-entry-editing))
                                     (do
                                       (reset! (::publishing s) true)
-                                      (activity-actions/entry-publish updated-entry-editing section-data))))
+                                      (activity-actions/entry-publish updated-entry-editing section-editing))))
                                 (when (zero? (count fixed-headline))
                                   (when-let [$post-btn (js/$ (rum/ref-node s "mobile-post-btn"))]
                                     (when-not (.data $post-btn "bs.tooltip")


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby
Item:
> Can't create post with a new section (`Error: No matching clause: [nil]`)

To test:
- click compose
- add title and body
- click on the section chevron
- click Add new section
- enter a new section name and click create
- click Post
- [x] do you see the new section with the new post? Good
- click compose again
- add title and body
- click on the section chevron
- click Add new section
- enter a new section name and click create
- click the section chevron again
- select an existing section (not the one you just created)
- click Post
- [x] do you see the post created in the existing section? Good
- [x] do you NOT see the section you tried creating but then changed? Good
- [x] repeat the above while editing a post