### PR TITLE
Fix textcomplete error

### DIFF
--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -371,9 +371,11 @@
                                                   :board-name (:name section-data)})])))))]]
               [:div.fullscreen-post-box-content-board
                 {:dangerouslySetInnerHTML (utils/emojify (str "Posted in " (:board-name activity-data)))}])
-            [:div.fullscreen-post-box-content-headline.emoji-autocomplete.emojiable
+            [:div.fullscreen-post-box-content-headline
               {:content-editable editing
                :ref "edit-headline"
+               :class (utils/class-set {:emoji-autocomplete editing
+                                        :emojiable editing})
                :placeholder utils/default-headline
                :on-paste    #(headline-on-paste s %)
                :on-key-down #(headline-on-change s)


### PR DESCRIPTION
Sentry: https://sentry.io/opencompany/oc-staging-web/issues/508146384/

To test:
- go to AP or single section
- switch to grid view
- click on a tile (not edit)
- [ ] do you NOT see an error referencing Textcomplete in the console? Good
- click the vertical ellipses in top right
- click edit
- [ ] can you add emojis with autocomplete to the headline? Good
- dismiss edit
- [ ] still no errors in the console? Good