### PR TITLE
Fix comments in public sections

### DIFF
--- a/src/oc/web/components/stream_view_item.cljs
+++ b/src/oc/web/components/stream_view_item.cljs
@@ -64,7 +64,8 @@
                               (get (:uuid activity-data))
                               :sorted-comments)
                           (:comments activity-data))
-        activity-attachments (:attachments activity-data)]
+        activity-attachments (:attachments activity-data)
+        comment-link (utils/link-for (:links activity-data) "comments")]
     [:div.stream-view-item
       {:class (utils/class-set {(str "stream-view-item-" (:uuid activity-data)) true
                                 :expanded expanded?})}
@@ -122,12 +123,14 @@
               (when-not (zero? (count comments-data))
                 (comments-summary activity-data false))])
           (when (and is-mobile?
+                     comment-link
                      @(::should-show-comments s))
             [:div.stream-mobile-comments
               {:class (when (drv/react s :add-comment-focus) "add-comment-expanded")}
               (rum/with-key (add-comment activity-data) (str "add-comment-mobile-" (:uuid activity-data)))
               (stream-comments activity-data comments-data)])]
-        (when-not is-mobile?
+        (when (and (not is-mobile?)
+                   comment-link)
           [:div.stream-body-right
             {:class (when expanded? "expanded")}
             [:div.stream-body-comments


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby
Item:
> Can see the comment add field as anonymous in public section

To test:
- change a section with some posts to public audience
- logout
- visit the section url
- [x] do you see the posts? Good
- [x] do you NOT see the add comment box? Good
- [x] do you NOT see the list of comments? Good
- switch to mobile device
- logout here too
- visit the section url
- [x] do you see the list of posts? Good
- [x] do you NOT see the add comment box? Good
- [x] do you NOT see the list of comments? Good