### PR TITLE
Emoji comments

### DIFF
--- a/scss/partials/_stream_comments.scss
+++ b/scss/partials/_stream_comments.scss
@@ -118,6 +118,16 @@ div.stream-comments {
           &>*:last-child {
             margin-bottom: 0px;
           }
+
+          &.emoji-comment {
+            font-size: 50px;
+            height: 50px;
+
+            // & > * {
+            //   line-height: 20px;
+            //   margin-top: 20px;
+            // }
+          }
         }
       }
 

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -27,46 +27,44 @@
                                       (scroll-to-bottom s))))
                                s)}
   [s activity-data comments-data]
-  (let [sorted-comments (cu/sort-comments comments-data)]
-    [:div.stream-comments
-      {:class (utils/class-set {:bottom-gradient @(::bottom-gradient s)})}
-      [:div.stream-comments-inner
-        {:ref "stream-comments-inner"}
-        (when (pos? (count comments-data))
-          [:div.stream-comments-title
-            (str (count comments-data) " Comment" (when (> (count comments-data) 1) "s"))])
-        (if (pos? (count comments-data))
-          (for [comment-data sorted-comments
-                :let [is-emoji-comment? (cu/is-emoji (:body comment-data))]]
-            [:div.stream-comment
-              {:key (str "stream-comment-" (:created-at comment-data))}
-              [:div.stream-comment-header.group
-                [:div.stream-comment-author-avatar
-                  {:style {:background-image (str "url(" (:avatar-url (:author comment-data)) ")")}}]
-                [:div.stream-comment-author-right
-                  [:div.stream-comment-author-name
-                    (:name (:author comment-data))]
-                  [:div.stream-comment-author-timestamp
-                    (utils/time-since (:created-at comment-data))]]]
-              [:div.stream-comment-content
-                [:div.stream-comment-body
-                  {:dangerouslySetInnerHTML (utils/emojify (:body comment-data))
-                   :class (utils/class-set {:emoji-comment is-emoji-comment?})}]]
-              (when-not is-emoji-comment?
-                [:div.stream-comment-footer.group
-                  (let [reaction-data (first (:reactions comment-data))
-                        can-react? (utils/link-for (:links reaction-data) "react"  ["PUT" "DELETE"])]
-                    (when (or can-react?
-                              (pos? (:count reaction-data)))
-                      [:div.stream-comment-reaction
-                        {:class (utils/class-set {:reacted (:reacted reaction-data)
-                                                  :can-react can-react?})}
-                          (when (or (pos? (:count reaction-data))
-                                    can-react?)
-                            [:div.stream-comment-reaction-icon
-                              {:on-click #(comment-actions/comment-reaction-toggle activity-data comment-data
-                                reaction-data (not (:reacted reaction-data)))}])
-                          (when (pos? (:count reaction-data))
-                            [:div.stream-comment-reaction-count
-                              (:count reaction-data)])]))])])
-          [:div.stream-comments-empty])]]))
+  [:div.stream-comments
+    {:class (utils/class-set {:bottom-gradient @(::bottom-gradient s)})}
+    [:div.stream-comments-inner
+      {:ref "stream-comments-inner"}
+      (when (pos? (count comments-data))
+        [:div.stream-comments-title
+          (str (count comments-data) " Comment" (when (> (count comments-data) 1) "s"))])
+      (if (pos? (count comments-data))
+        (for [comment-data comments-data]
+          [:div.stream-comment
+            {:key (str "stream-comment-" (:created-at comment-data))}
+            [:div.stream-comment-header.group
+              [:div.stream-comment-author-avatar
+                {:style {:background-image (str "url(" (:avatar-url (:author comment-data)) ")")}}]
+              [:div.stream-comment-author-right
+                [:div.stream-comment-author-name
+                  (:name (:author comment-data))]
+                [:div.stream-comment-author-timestamp
+                  (utils/time-since (:created-at comment-data))]]]
+            [:div.stream-comment-content
+              [:div.stream-comment-body
+                {:dangerouslySetInnerHTML (utils/emojify (:body comment-data))
+                 :class (utils/class-set {:emoji-comment (:is-emoji comment-data)})}]]
+            (when-not (:is-emoji comment-data)
+              [:div.stream-comment-footer.group
+                (let [reaction-data (first (:reactions comment-data))
+                      can-react? (utils/link-for (:links reaction-data) "react"  ["PUT" "DELETE"])]
+                  (when (or can-react?
+                            (pos? (:count reaction-data)))
+                    [:div.stream-comment-reaction
+                      {:class (utils/class-set {:reacted (:reacted reaction-data)
+                                                :can-react can-react?})}
+                        (when (or (pos? (:count reaction-data))
+                                  can-react?)
+                          [:div.stream-comment-reaction-icon
+                            {:on-click #(comment-actions/comment-reaction-toggle activity-data comment-data
+                              reaction-data (not (:reacted reaction-data)))}])
+                        (when (pos? (:count reaction-data))
+                          [:div.stream-comment-reaction-count
+                            (:count reaction-data)])]))])])
+        [:div.stream-comments-empty])]])

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -36,7 +36,8 @@
           [:div.stream-comments-title
             (str (count comments-data) " Comment" (when (> (count comments-data) 1) "s"))])
         (if (pos? (count comments-data))
-          (for [comment-data sorted-comments]
+          (for [comment-data sorted-comments
+                :let [is-emoji-comment? (cu/is-emoji (:body comment-data))]]
             [:div.stream-comment
               {:key (str "stream-comment-" (:created-at comment-data))}
               [:div.stream-comment-header.group
@@ -49,21 +50,23 @@
                     (utils/time-since (:created-at comment-data))]]]
               [:div.stream-comment-content
                 [:div.stream-comment-body
-                  {:dangerouslySetInnerHTML (utils/emojify (:body comment-data))}]]
-              [:div.stream-comment-footer.group
-                (let [reaction-data (first (:reactions comment-data))
-                      can-react? (utils/link-for (:links reaction-data) "react"  ["PUT" "DELETE"])]
-                  (when (or can-react?
-                            (pos? (:count reaction-data)))
-                    [:div.stream-comment-reaction
-                      {:class (utils/class-set {:reacted (:reacted reaction-data)
-                                                :can-react can-react?})}
-                        (when (or (pos? (:count reaction-data))
-                                  can-react?)
-                          [:div.stream-comment-reaction-icon
-                            {:on-click #(comment-actions/comment-reaction-toggle activity-data comment-data
-                              reaction-data (not (:reacted reaction-data)))}])
-                        (when (pos? (:count reaction-data))
-                          [:div.stream-comment-reaction-count
-                            (:count reaction-data)])]))]])
+                  {:dangerouslySetInnerHTML (utils/emojify (:body comment-data))
+                   :class (utils/class-set {:emoji-comment is-emoji-comment?})}]]
+              (when-not is-emoji-comment?
+                [:div.stream-comment-footer.group
+                  (let [reaction-data (first (:reactions comment-data))
+                        can-react? (utils/link-for (:links reaction-data) "react"  ["PUT" "DELETE"])]
+                    (when (or can-react?
+                              (pos? (:count reaction-data)))
+                      [:div.stream-comment-reaction
+                        {:class (utils/class-set {:reacted (:reacted reaction-data)
+                                                  :can-react can-react?})}
+                          (when (or (pos? (:count reaction-data))
+                                    can-react?)
+                            [:div.stream-comment-reaction-icon
+                              {:on-click #(comment-actions/comment-reaction-toggle activity-data comment-data
+                                reaction-data (not (:reacted reaction-data)))}])
+                          (when (pos? (:count reaction-data))
+                            [:div.stream-comment-reaction-count
+                              (:count reaction-data)])]))])])
           [:div.stream-comments-empty])]]))

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -2,7 +2,6 @@
   (:require [rum.core :as rum]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.lib.utils :as utils]
-            [oc.web.utils.comment :as cu]
             [oc.web.actions.comment :as comment-actions]))
 
 (defn scroll-to-bottom [s]

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -96,7 +96,7 @@
                 {:on-click #(let [add-comment-div (rum/ref-node s "add-comment")
                                   comment-body (cu/add-comment-content add-comment-div)]
                               (comment-actions/add-comment activity-data comment-body)
-                              (set! (.-innerHTML add-comment-div) "<p><br/></p>"))
+                              (set! (.-innerHTML add-comment-div) ""))
                  :disabled @(::add-button-disabled s)}
                 "Post"]]])]
        (when (and (not (js/isIE))

--- a/src/oc/web/stores/comment.cljs
+++ b/src/oc/web/stores/comment.cljs
@@ -18,7 +18,7 @@
 
 (defn- is-emoji
   [body]
-  (let [plain-text (.text (js/$ body))
+  (let [plain-text (.text (js/$ (str "<div>" body "</div>")))
         is-emoji? (js/RegExp "^([\ud800-\udbff])([\udc00-\udfff])" "g")
         is-text-message? (js/RegExp "[a-zA-Z0-9\\s!?@#\\$%\\^&(())_=\\-<>,\\.\\*;':\"]" "g")]
     (and ;; emojis can have up to 11 codepoints
@@ -44,12 +44,12 @@
         board-slug (router/current-board-slug)
         comments-key (dispatcher/activity-comments-key org-slug board-slug (:uuid activity-data))
         comments-data (get-in db comments-key)
-        new-comments-data (sort-comments (conj comments-data
-                                          (parse-comment {:body comment-body
+        new-comment-data (parse-comment {:body comment-body
                                                           :created-at (utils/as-of-now)
                                                           :author {:name (jwt/get-key :name)
                                                                    :avatar-url (jwt/get-key :avatar-url)
-                                                                   :user-id (jwt/get-key :user-id)}})))]
+                                                                   :user-id (jwt/get-key :user-id)}})
+        new-comments-data (sort-comments (conj comments-data new-comment-data))]
     (assoc-in db comments-key new-comments-data)))
 
 (defmethod dispatcher/action :comment-add/finish

--- a/src/oc/web/stores/comment.cljs
+++ b/src/oc/web/stores/comment.cljs
@@ -44,11 +44,12 @@
         board-slug (router/current-board-slug)
         comments-key (dispatcher/activity-comments-key org-slug board-slug (:uuid activity-data))
         comments-data (get-in db comments-key)
-        new-comments-data (conj comments-data (parse-comment {:body comment-body
-                                                             :created-at (utils/as-of-now)
-                                                              :author {:name (jwt/get-key :name)
-                                                                       :avatar-url (jwt/get-key :avatar-url)
-                                                                       :user-id (jwt/get-key :user-id)}}))]
+        new-comments-data (sort-comments (conj comments-data
+                                          (parse-comment {:body comment-body
+                                                          :created-at (utils/as-of-now)
+                                                          :author {:name (jwt/get-key :name)
+                                                                   :avatar-url (jwt/get-key :avatar-url)
+                                                                   :user-id (jwt/get-key :user-id)}})))]
     (assoc-in db comments-key new-comments-data)))
 
 (defmethod dispatcher/action :comment-add/finish

--- a/src/oc/web/utils/comment.cljs
+++ b/src/oc/web/utils/comment.cljs
@@ -2,27 +2,8 @@
   (:require [cljsjs.medium-editor]
             [goog.object :as gobj]
             [cuerdas.core :as string]
-            [defun.core :refer (defun)]
             [oc.web.lib.jwt :as jwt]
             [oc.web.lib.utils :as utils]))
-
-(defn is-emoji
-  [body]
-  (let [plain-text (.text (js/$ body))
-        is-emoji? (js/RegExp "^([\ud800-\udbff])([\udc00-\udfff])" "g")
-        is-text-message? (js/RegExp "[a-zA-Z0-9\\s!?@#\\$%\\^&(())_=\\-<>,\\.\\*;':\"]" "g")]
-    (and ;; emojis can have up to 11 codepoints
-         (<= (count plain-text) 11)
-         (.match plain-text is-emoji?)
-         (not (.match plain-text is-text-message?)))))
-
-(defun sort-comments
-  ([comments :guard nil?]
-   [])
-  ([comments :guard map?]
-   (sort-comments (vals comments)))
-  ([comments :guard sequential?]
-   (vec (reverse (sort-by :created-at comments)))))
 
 (defn setup-medium-editor [comment-node]
   (let [config {:toolbar false

--- a/src/oc/web/utils/comment.cljs
+++ b/src/oc/web/utils/comment.cljs
@@ -6,6 +6,16 @@
             [oc.web.lib.jwt :as jwt]
             [oc.web.lib.utils :as utils]))
 
+(defn is-emoji
+  [body]
+  (let [plain-text (.text (js/$ body))
+        is-emoji? (js/RegExp "^([\ud800-\udbff])([\udc00-\udfff])" "g")
+        is-text-message? (js/RegExp "[a-zA-Z0-9\\s!?@#\\$%\\^&(())_=\\-<>,\\.\\*;':\"]" "g")]
+    (and ;; emojis can have up to 11 codepoints
+         (<= (count plain-text) 11)
+         (.match plain-text is-emoji?)
+         (not (.match plain-text is-text-message?)))))
+
 (defun sort-comments
   ([comments :guard nil?]
    [])


### PR DESCRIPTION
Card: 
Item:
> We no longer have the special treatment for a comment that is only emoji working (should be shown bigger with no agree action)

We use `oc.web.utils.comment/is-emoji` function to check if it's an emoji comment but it's not perfect. It doesn't recognise all the emojis but at least it's safe in the sense that it should not show normal comments as emoji comments.

To test:
- go to stream view
- add a normal comment
- [x] do you see it? Good
- [x] can you agree to it? Good
- [x] font size of the body is 14px? Good
- now add a single emoji comment
- [x] do you see it? Good
- [x] can you NOT react to it? Good
- [x] font size of the emoji is 50px? Good
- retry with some of the most common emoijs

NB: it should also recognise up to 3 emojis (maybe more) since some emojis are composed with up to 11 code points so it's hard to distinguish them with a simple reg exp.