### PR TITLE
Fix user profile timezone

### DIFF
--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -118,6 +118,14 @@
       :else
       (user-actions/user-profile-save current-user-data edit-user-profile))))
 
+(defn- setup-timezone [s]
+  (when (and (not (utils/is-test-env?))
+             (empty? (:timezone (:user-data @(drv/get-ref s :edit-user-profile)))))
+    (dis/dispatch!
+      [:input
+       [:edit-user-profile :timezone]
+       (.. js/moment -tz guess)])))
+
 (rum/defcs user-profile < rum/reactive
                           ;; Derivatives
                           (drv/drv :orgs)
@@ -133,17 +141,13 @@
                           (rum/local false ::current-password-error)
                           {:will-mount (fn [s]
                             (dis/dispatch! [:user-profile-reset])
+                            (setup-timezone s)
                             s)
                            :after-render (fn [s]
                               (when-not (utils/is-test-env?)
                                 (doto (js/$ "[data-toggle=\"tooltip\"]")
                                   (.tooltip "fixTitle")
-                                  (.tooltip "hide"))
-                                (when (empty? (:timezone (:user-data @(drv/get-ref s :edit-user-profile))))
-                                  (dis/dispatch!
-                                    [:input
-                                     [:edit-user-profile :timezone]
-                                     (.. js/moment -tz guess)])))
+                                  (.tooltip "hide")))
                               s)
                            :did-remount (fn [old-state new-state]
                             (let [user-data (:user-data @(drv/get-ref new-state :edit-user-profile))]


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby

Item:
> Brand new user, go to user profile, click dropdown and change digest type from Email to Slack, at the same time, you'll see Time Zone changes from US/Eastern to America/New York. Why does this happen?

To test:
- go to /profile
- [ ] do you see the timezone? Good
- [ ] is it the same of your browser timezone? Good
- switch from slack to email or the opposite
- [ ] do you NOT see the timezone change? Good