### PR TITLE
Fix user roles chevron click

### DIFF
--- a/scss/partials/_user_type_dropdown.scss
+++ b/scss/partials/_user_type_dropdown.scss
@@ -2,8 +2,9 @@ div.dropdown{
   position: relative;
 
   button.user-type-btn {
-    margin-right: 10px;
     position: relative;
+    cursor: pointer;
+    padding-right: 25px;
 
     &:after {
       color: $oc_gray_7;
@@ -12,7 +13,7 @@ div.dropdown{
       content: "\F35D";
       position: absolute;
       top: -4px;
-      right: -15px;
+      right: 0px;
     }
   }
 


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby

Item:
> Manage Members roles dropdown, if you click the disclosure arrow, it doesn't work, you have to click the role name.

To test:
- open FireFox (the issue was here)
- click on user menu (top right corner)
- click on Team Management
- click on the chevron beside one of the users
- [x] does the roles dropdown appear? Good
- [x] repeat for all the users you have to make sure