### PR TITLE
Fix empty invite row

### DIFF
--- a/src/oc/web/actions/team.cljs
+++ b/src/oc/web/actions/team.cljs
@@ -224,7 +224,8 @@
 (defn invite-users [inviting-users]
   (let [org-data (dis/org-data)
         team-data (dis/team-data (:team-id org-data))
-        checked-users (for [user inviting-users]
+        filter-empty (filterv #(seq (:user %)) inviting-users)
+        checked-users (for [user filter-empty]
                         (let [valid? (valid-inviting-user? user)
                               intive-duplicated? (duplicated-email-addresses user inviting-users)
                               team-duplicated? (duplicated-team-user user (:users team-data))]
@@ -238,7 +239,7 @@
                             :else
                             (dissoc user :error))))
         cleaned-inviting-users (filterv #(not (:error %)) checked-users)]
-    (when (= (count cleaned-inviting-users) (count inviting-users))
+    (when (<= (count cleaned-inviting-users) (count filter-empty))
       (doseq [user cleaned-inviting-users]
         (invite-user org-data team-data user)))
     (dis/dispatch! [:invite-users (vec checked-users)])))


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby

Item:
> Add a 2nd row to invite users, fill in only 1 row, errors out because of the blank row, should just ignore it

To test:
- click user menu
- click Invite People
- add an email invite with valid email
- add an empty row
- add an email invite with valid email
- add an empty row
- add an email invite with a not valid email
- click invite
- [x] do you see only the not valid row left in the invite? Good
- [x] do you not see the empty rows? Good