### PR TITLE
Always dismiss the invite settings panel on cancel and also reset the…

### DIFF
--- a/src/oc/web/components/ui/org_settings_invite_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_invite_panel.cljs
@@ -228,15 +228,14 @@
               send-cta
               (str send-cta " " valid-users-count " Invite" (when needs-plural "s"))))]
         [:button.mlb-reset.mlb-link-black.cancel-btn
-          {:on-click #(if (has-dirty-data? s)
-                        (do
-                          (reset! (::rand s) (int (rand 10000)))
-                          (dis/dispatch!
-                           [:input
-                            [:invite-users]
-                            (vec
-                             (repeat
-                              default-row-num
-                              (assoc default-user-row :type @(::inviting-from s))))]))
-                        (dismiss-settings-cb))}
+          {:on-click #(do
+                       (reset! (::rand s) (int (rand 10000)))
+                       (dis/dispatch!
+                        [:input
+                         [:invite-users]
+                         (vec
+                          (repeat
+                           default-row-num
+                           (assoc default-user-row :type @(::inviting-from s))))])
+                       (dismiss-settings-cb))}
           "Cancel"]]]))


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby

Item:
> Add a 2nd row to invite users, cancel out... come back in, you still have 2 rows, should have only 1

To test:
- click the user menu
- click on Invite People
- add some rows
- add some email addresses in it
- click cancel
- [ ] does the panel dismiss? Good
- enter again the invite people panel
- [ ] did it reset to one row? Good