### PR TITLE
Settings refresh data

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -74,7 +74,8 @@
       (ws-ic/reconnect ws-link (jwt/get-key :user-id))
       (ra/subscribe ws-ic/subscribe)
       (ca/subscribe ws-ic/subscribe)))
-  (dis/dispatch! [:org-loaded org-data saved?]))
+  (dis/dispatch! [:org-loaded org-data saved?])
+  (dis/dispatch! [:org-edit-setup org-data]))
 
 (defn get-org-cb [{:keys [status body success]}]
   (let [org-data (json->cljs body)]

--- a/src/oc/web/actions/team.cljs
+++ b/src/oc/web/actions/team.cljs
@@ -39,6 +39,13 @@
           (dis/dispatch! [:team-loaded team-data])
           (enumerate-channels team-data))))))
 
+(defn force-team-refresh [team-id]
+  (when-let [team-data (dis/team-data team-id)]
+    (when-let [team-link (utils/link-for (:links team-data) "item")]
+      (team-get team-link))
+    (when-let [roster-link (utils/link-for (:links team-data) "roster")]
+      (roster-get roster-link))))
+
 (defn read-teams [teams]
   (doseq [team teams
           :let [team-link (utils/link-for (:links team) "item")

--- a/src/oc/web/components/org_settings.cljs
+++ b/src/oc/web/components/org_settings.cljs
@@ -6,6 +6,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.image-upload :as iu]
+            [oc.web.actions.org :as org-actions]
             [oc.web.actions.team :as team-actions]
             [oc.web.mixins.ui :refer (no-scroll-mixin)]
             [oc.web.components.ui.loading :refer (loading)]
@@ -81,9 +82,11 @@
     ;; Mixins
     no-scroll-mixin
 
-    {:before-render (fn [s]
-                      (team-actions/teams-get-if-needed)
-                      s)}
+    {:will-mount (fn [s]
+                   (let [org-data @(drv/get-ref s :org-data)]
+                     (org-actions/get-org org-data)
+                     (team-actions/force-team-refresh (:team-id org-data)))
+                   s)}
   [s]
   (let [settings-tab (drv/react s :org-settings)
         org-data (drv/react s :org-data)


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby

Item:
> Refresh the current team data when the settings panel is being open

To test:
- open 2 session of the same user
- with session 1 change the org name and the logo
- now open Team Settings with session 2
- [x] do you see the updated name and logo? Good
- close settings on both
- now with session 1 invite a new user
- with session 2 open the Team Management
- [x] do you see the last invited user? Good