### PR TITLE
REFACTOR: Change service messages refactor.

### DIFF
--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -21,7 +21,6 @@
   (timbre/info "Full event: " (pr-str payload))
   db)
 
-
 (defn- org-change [db org-uuid change-at]
   (timbre/debug "Org change:" org-uuid "at:" change-at)
   (utils/after 1000 (fn [] (oa/get-org)))
@@ -47,19 +46,3 @@
   (if (fn? value-fn)
     (update-in db path value-fn)
     db))
-
-(defmethod dispatcher/action :container/status
-  [db [_ status-data]]
-  (timbre/debug "Change status received:" status-data)
-  (let [org-data (dispatcher/org-data db)
-        old-status-data (dispatcher/change-data db)
-        status-by-uuid (group-by :container-id status-data)
-        clean-status-data (zipmap (keys status-by-uuid) (->> status-by-uuid
-                                                          vals
-                                                          ; remove the sequence of 1 from group-by
-                                                          (map first)
-                                                          ; dup seen-at as nav-at
-                                                          (map #(assoc % :nav-at (:seen-at %)))))
-        new-status-data (merge old-status-data clean-status-data)]
-    (timbre/debug "Change status data:" new-status-data)
-    (assoc-in db (dispatcher/change-data-key (:slug org-data)) new-status-data)))

--- a/src/oc/web/actions.cljs
+++ b/src/oc/web/actions.cljs
@@ -1,9 +1,6 @@
 (ns oc.web.actions
   (:require [taoensso.timbre :as timbre]
-            [oc.web.dispatcher :as dispatcher]
-            [oc.web.actions.org :as oa]
-            [oc.web.lib.jwt :as jwt]
-            [oc.web.lib.utils :as utils]))
+            [oc.web.dispatcher :as dispatcher]))
 
 ;; ---- Generic Actions Dispatch
 ;; This is a small generic abstraction to handle "actions".
@@ -20,24 +17,6 @@
   (timbre/warn "No handler defined for" (str (first payload)))
   (timbre/info "Full event: " (pr-str payload))
   db)
-
-(defn- org-change [db org-uuid change-at]
-  (timbre/debug "Org change:" org-uuid "at:" change-at)
-  (utils/after 1000 (fn [] (oa/get-org)))
-  db)
-
-(defmethod dispatcher/action :container/change
-  [db [_ {container-uuid :container-id change-at :change-at user-id :user-id}]]
-  (timbre/debug "Container change:" container-uuid "at:" change-at "by:" user-id)
-  (if (not= (jwt/user-id) user-id) ; no need to respond to our own events
-    (if (= container-uuid (:uuid (dispatcher/org-data)))
-      (org-change db container-uuid change-at)
-      db)
-    db))
-
-;; This should be turned into a proper form library
-;; Lomakeets FormState ideas seem like a good start:
-;; https://github.com/metosin/lomakkeet/blob/master/src/cljs/lomakkeet/core.cljs
 
 (defmethod dispatcher/action :input [db [_ path value]]
   (assoc-in db path value))

--- a/src/oc/web/actions/comment.cljs
+++ b/src/oc/web/actions/comment.cljs
@@ -6,6 +6,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.json :refer (json->cljs)]
+            [oc.web.lib.ws-interaction-client :as ws-ic]
             [oc.web.actions.activity :as activity-actions]))
 
 (defn add-comment-focus [activity-uuid]
@@ -90,11 +91,10 @@
       (activity-actions/get-entry entry-data)))
   (dis/dispatch! [:ws-interaction/comment-add interaction-data]))
 
-;; Pass in the subscriber until we sort out the namespaces in actions.cljs
-(defn subscribe [subscriber]
-  (subscriber :interaction-comment/add
-              #(ws-comment-add (:data %)))
-  (subscriber :interaction-comment/update
-              #(ws-comment-update (:data %)))
-  (subscriber :interaction-comment/delete
-              #(ws-comment-delete (:data %))))
+(defn subscribe []
+  (ws-ic/subscribe :interaction-comment/add
+                   #(ws-comment-add (:data %)))
+  (ws-ic/subscribe :interaction-comment/update
+                   #(ws-comment-update (:data %)))
+  (ws-ic/subscribe :interaction-comment/delete
+                   #(ws-comment-delete (:data %))))

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -65,19 +65,12 @@
   ;; Change service connection
   (when (jwt/jwt) ; only for logged in users
     (when-let [ws-link (utils/link-for (:links org-data) "changes")]
-      (ws-cc/reconnect ws-link (jwt/get-key :user-id) (:slug org-data) (conj (map :uuid (:boards org-data)) (:uuid org-data)))
-      (sa/wc-subscribe ws-cc/subscribe)
-      (ws-cc/subscribe :container/change #(dis/dispatch! [:container/change (:data %)]))
-      (ws-cc/subscribe :container/status #(dis/dispatch! [:container/status (:data %)]))))
+      (ws-cc/reconnect ws-link (jwt/get-key :user-id) (:slug org-data) (conj (map :uuid (:boards org-data)) (:uuid org-data)))))
 
   ;; Interaction service connection
   (when (jwt/jwt) ; only for logged in users
     (when-let [ws-link (utils/link-for (:links org-data) "interactions")]
-      (ws-ic/reconnect ws-link (jwt/get-key :user-id))
-      (ra/subscribe ws-ic/subscribe)
-      (ca/subscribe ws-ic/subscribe)
-      (sa/wi-subscribe ws-ic/subscribe)))
-  
+      (ws-ic/reconnect ws-link (jwt/get-key :user-id))))  
   (dis/dispatch! [:org-loaded org-data saved?]))
 
 (defn get-org-cb [{:keys [status body success]}]
@@ -134,3 +127,15 @@
 
 (defn org-edit-save [org-data]
   (api/patch-org org-data org-edit-save-cb))
+
+(defn org-change [data]
+  (let [change-data (:data data)
+        container-id (:container-id change-data)
+        user-id (:user-id change-data)]
+    (when (not= (jwt/user-id) user-id) ; no need to respond to our own events
+      (when (= container-id (:uuid (dis/org-data)))
+        (utils/after 1000 (fn [] (get-org)))))))
+
+;; subscribe to websocket events
+(defn subscribe []
+  (ws-cc/subscribe :container/change org-change))

--- a/src/oc/web/actions/reaction.cljs
+++ b/src/oc/web/actions/reaction.cljs
@@ -7,6 +7,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.json :refer (json->cljs)]
+            [oc.web.lib.ws-interaction-client :as ws-ic]
             [oc.web.actions.activity :as activity-actions]))
 
 (defn react-from-picker [activity-data emoji]
@@ -78,8 +79,8 @@
       (refresh-if-needed org-slug board-slug interaction-data)))
   (dis/dispatch! [:ws-interaction/reaction-delete interaction-data]))
 
-(defn subscribe [subscriber]
-  (subscriber :interaction-reaction/add
-              #(ws-interaction-reaction-add (:data %)))
-  (subscriber :interaction-reaction/delete
-              #(ws-interaction-reaction-delete (:data %))))
+(defn subscribe []
+  (ws-ic/subscribe :interaction-reaction/add
+                   #(ws-interaction-reaction-add (:data %)))
+  (ws-ic/subscribe :interaction-reaction/delete
+                   #(ws-interaction-reaction-delete (:data %))))

--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -154,9 +154,13 @@
       (let [board-data (dispatcher/board-data)]
         (section-get (utils/link-for (:links (dispatcher/board-data)) ["item" "self"] "GET"))))))
 
-(defn wc-subscribe
-  [subscriber]
-  (subscriber :container/change
+
+(defn ws-change-subscribe []
+  (ws-cc/subscribe :container/status
+    (fn [data]
+      (dispatcher/dispatch! [:container/status (:data data)])))
+
+  (ws-cc/subscribe :container/change
     (fn [data]
       (let [change-data (:data data)
             container-id (:container-id change-data)]
@@ -164,7 +168,6 @@
         (when (not= container-id (:uuid (dispatcher/org-data)))
           (section-change container-id (:change-at change-data)))))))
 
-(defn wi-subscribe
-  [subscriber]
-  (subscriber :interaction-comment/add
-              #(ws-comment-add (:data %))))
+(defn ws-interaction-subscribe []
+  (ws-ic/subscribe :interaction-comment/add
+                   #(ws-comment-add (:data %))))

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -26,25 +26,6 @@
   (router/nav! url)
   (close-navigation-sidebar))
 
-(defn new?
-  "
-  A board is new if:
-    user is part of the team (we don't track new for non-team members accessing public boards)
-     -and-
-    change-at is newer than seen at
-      -or-
-    we have a change-at and no seen at
-  "
-  [change-data board]
-  (let [changes (get change-data (:uuid board))
-        change-at (:change-at changes)
-        nav-at (:nav-at changes)
-        in-team? (jwt/user-is-part-of-the-team (:team-id (dis/org-data)))
-        new? (and in-team?
-                  (or (and change-at nav-at (> change-at nav-at))
-                      (and change-at (not nav-at))))]
-    new?))
-
 (def sidebar-top-margin 122)
 (def footer-button-height 31)
 
@@ -191,7 +172,7 @@
                                             :private-board (= (:access board) "private")
                                             :team-board (= (:access board) "team")})}
                   [:div.internal
-                    {:class (utils/class-set {:new (new? change-data board)
+                    {:class (utils/class-set {:new (:new board)
                                               :has-icon (#{"public" "private"} (:access board))})
                      :key (str "board-list-" (name (:slug board)) "-internal")
                      :dangerouslySetInnerHTML (utils/emojify (or (:name board) (:slug board)))}]]])])]

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -21,8 +21,10 @@
             ;; Pull in the needed file for the ws interaction events
             [oc.web.lib.ws-interaction-client]
             [oc.web.actions.team]
-            [oc.web.actions.comment]
-            [oc.web.actions.reaction]
+            [oc.web.actions.org :as oa]
+            [oc.web.actions.comment :as ca]
+            [oc.web.actions.reaction :as ra]
+            [oc.web.actions.section :as sa]
             [oc.web.actions.user :as user-actions]
             [oc.web.actions.error-banner :as error-banner-actions]
             [oc.web.api :as api]
@@ -566,6 +568,14 @@
 
   ;; Persist JWT in App State
   (user-actions/dispatch-jwt)
+
+  ;; Subscribe to websocket client events
+  (sa/ws-change-subscribe)
+  (sa/ws-interaction-subscribe)
+  (oa/subscribe)
+  (ra/subscribe)
+  (ca/subscribe)
+
   ;; on any click remove all the shown tooltips to make sure they don't get stuck
   (.click (js/$ js/window) #(utils/remove-tooltips))
   ; mount the error banner

--- a/src/oc/web/stores/org.cljs
+++ b/src/oc/web/stores/org.cljs
@@ -1,11 +1,23 @@
 (ns oc.web.stores.org
   (:require [oc.web.lib.utils :as utils]
+            [taoensso.timbre :as timbre]
             [oc.web.dispatcher :as dispatcher]))
+
+(defn read-only-org
+  [org-data]
+  (let [links (:links org-data)
+        read-only (utils/readonly-org? links)]
+    (assoc org-data :read-only read-only)))
+
+(defn fix-org
+  "Fix org data coming from the API."
+  [org-data]
+  (read-only-org org-data))
 
 (defmethod dispatcher/action :org-loaded
   [db [_ org-data saved?]]  
   (-> db
-    (assoc-in (dispatcher/org-data-key (:slug org-data)) (utils/fix-org org-data))
+    (assoc-in (dispatcher/org-data-key (:slug org-data)) (fix-org org-data))
     (assoc :org-editing (-> org-data
                             (assoc :saved saved?)
                             (dissoc :has-changes)))))

--- a/src/oc/web/stores/reaction.cljs
+++ b/src/oc/web/stores/reaction.cljs
@@ -232,7 +232,7 @@
 (defmethod reducer :section
   [db [_ board-data]]
   (let [org (router/current-org-slug)
-        fixed-board-data (utils/fix-board board-data)]
+        fixed-board-data (utils/fix-board board-data (dispatcher/change-data db))]
     (swap! reactions-atom index-posts org (vals (:fixed-items fixed-board-data))))
   db)
 

--- a/src/oc/web/stores/section.cljs
+++ b/src/oc/web/stores/section.cljs
@@ -52,10 +52,6 @@
         new? (and in-team?
                   (or (and change-at nav-at (> change-at nav-at))
                       (and change-at (not nav-at))))]
-    (timbre/debug "in-team? " in-team?)
-    (timbre/debug "change-at " change-at)
-    (timbre/debug "nav-at " nav-at)
-    (timbre/debug (and change-at nav-at (> change-at nav-at)))
     new?))
 
 (defn add-new-to-sections
@@ -63,8 +59,6 @@
   (let [section-data (:boards org-data)
         new-section-data (for [section section-data]
                            (assoc section :new (new? change-data section)))]
-    (timbre/debug change-data)
-    (timbre/debug new-section-data)
     (assoc org-data :boards new-section-data)))
 
 (defn fix-org-section-data

--- a/src/oc/web/stores/section.cljs
+++ b/src/oc/web/stores/section.cljs
@@ -71,11 +71,13 @@
   [db org-data changes]
   (let [sections (:boards org-data)
         org-slug (:slug org-data)]
-    (reduce #(let [board-key (dispatcher/board-data-key org-slug (:slug %2))
-                   board-data (utils/fix-board
-                               (dispatcher/board-data db org-slug (:slug %2))
-                               changes)]
-               (assoc-in %1 board-key board-data))
+    (reduce #(if (dispatcher/board-data db org-slug (:slug %2))
+               (let [board-key (dispatcher/board-data-key org-slug (:slug %2))
+                     board-data (utils/fix-board
+                                 (dispatcher/board-data db org-slug (:slug %2))
+                                 changes)]
+                 (assoc-in %1 board-key board-data))
+               %1)
             db sections)))
 
 (defn- update-change-data [db section-uuid property timestamp]

--- a/src/oc/web/stores/section.cljs
+++ b/src/oc/web/stores/section.cljs
@@ -1,14 +1,27 @@
 (ns oc.web.stores.section
   (:require [taoensso.timbre :as timbre]
+            [cljs-flux.dispatcher :as flux]
             [oc.web.lib.jwt :as jwt]
             [oc.web.router :as router]
             [oc.web.dispatcher :as dispatcher]
             [oc.lib.time :as oc-time]
             [oc.web.lib.utils :as utils]))
 
+;; Reducers used to watch for org/section dispatch data
+(defmulti reducer (fn [db [action-type & _]]
+                    (when-not (some #{action-type} [:update :input])
+                      (timbre/debug "Dispatching section reducer:" action-type))
+                    action-type))
+
+(def sections-dispatch
+  (flux/register
+   dispatcher/actions
+   (fn [payload]
+     (swap! dispatcher/app-state reducer payload))))
+
 (defmethod dispatcher/action :section
   [db [_ section-data]]
-  (let [fixed-section-data (utils/fix-board section-data)
+  (let [fixed-section-data (utils/fix-board section-data (dispatcher/change-data db))
         db-loading (if (:is-loaded section-data)
                      (dissoc db :loading)
                      db)
@@ -22,13 +35,66 @@
                   with-current-edit)]
     next-db))
 
+(defn new?
+  "
+  A board is new if:
+    user is part of the team (we don't track new for non-team members accessing public boards)
+     -and-
+    change-at is newer than seen at
+      -or-
+    we have a change-at and no seen at
+  "
+  [change-data board]
+  (let [changes (get change-data (:uuid board))
+        change-at (:change-at changes)
+        nav-at (:nav-at changes)
+        in-team? (jwt/user-is-part-of-the-team (:team-id (dispatcher/org-data)))
+        new? (and in-team?
+                  (or (and change-at nav-at (> change-at nav-at))
+                      (and change-at (not nav-at))))]
+    (timbre/debug "in-team? " in-team?)
+    (timbre/debug "change-at " change-at)
+    (timbre/debug "nav-at " nav-at)
+    (timbre/debug (and change-at nav-at (> change-at nav-at)))
+    new?))
+
+(defn add-new-to-sections
+  [org-data change-data]
+  (let [section-data (:boards org-data)
+        new-section-data (for [section section-data]
+                           (assoc section :new (new? change-data section)))]
+    (timbre/debug change-data)
+    (timbre/debug new-section-data)
+    (assoc org-data :boards new-section-data)))
+
+(defn fix-org-section-data
+  [db org-data changes]
+  (assoc-in db
+            (dispatcher/org-data-key (:slug org-data))
+            (add-new-to-sections org-data changes)))
+
+(defn fix-sections
+  [db org-data changes]
+  (let [sections (:boards org-data)
+        org-slug (:slug org-data)]
+    (reduce #(let [board-key (dispatcher/board-data-key org-slug (:slug %2))
+                   board-data (utils/fix-board
+                               (dispatcher/board-data db org-slug (:slug %2))
+                               changes)]
+               (assoc-in %1 board-key board-data))
+            db sections)))
+
 (defn- update-change-data [db section-uuid property timestamp]
-  (let [change-data-key (dispatcher/change-data-key (router/current-org-slug))
+  (let [org-data (dispatcher/org-data db)
+        change-data-key (dispatcher/change-data-key (router/current-org-slug))
         change-data (get-in db change-data-key)
         change-map (or (get change-data section-uuid) {})
         new-change-map (assoc change-map property timestamp)
         new-change-data (assoc change-data section-uuid new-change-map)]
-    (assoc-in db change-data-key new-change-data)))
+    (-> db
+      (fix-org-section-data org-data new-change-data)
+      (fix-sections org-data new-change-data)
+      (assoc-in change-data-key new-change-data))))
 
 (defmethod dispatcher/action :section-change
   [db [_ section-uuid change-at]]
@@ -65,7 +131,7 @@
   (let [org-slug (router/current-org-slug)
         section-slug (:slug section-data)
         board-key (dispatcher/board-data-key org-slug section-slug)
-        fixed-section-data (utils/fix-board section-data)]
+        fixed-section-data (utils/fix-board section-data (dispatcher/change-data db))]
     (-> db
         (assoc-in board-key fixed-section-data)
         (dissoc :section-editing))))


### PR DESCRIPTION
Review after https://github.com/open-company/open-company-web/pull/435

This change moved the web socket, API handlers to the actions and stores that deal with the changed data.

It is the final step in https://trello.com/c/nOF8CduC/1102-step-1-clean-up-actions-in-web-app

To test:

- Open a section as user A.
- Open a different section as user B.
- Add a new entry as user B.
- [x] In user A's list of sections there should be a darker highlight indicating a new entry in that section.
- Add a new section as user B.
- [x] User A should see the new section with the font a darker grey.

- React to the new post as user B
- [x] user A should see the new reaction

- Comment on post as user B
- [x] user A should see the new comment

- React to this comment as user B
- [x] user A should see the new reaction.

