### PR TITLE
If at least one of the teams has Slack enabled let the user select it.

### DIFF
--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -1,6 +1,7 @@
 (ns oc.web.components.user-profile
   (:require [rum.core :as rum]
             [org.martinklepsch.derivatives :as drv]
+            [oc.web.lib.jwt :as jwt]
             [oc.web.urls :as oc-urls]
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]

--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -317,7 +317,11 @@
                       [:li
                         {:on-click #(change! s :digest-medium "email")}
                         "Email"]
-                      (when (some jwt/team-has-bot? (jwt/get-key :teams))
+                      ;; Show Slack digest option if
+                      (when (and ;; at least one team has a Slack bot
+                                 (some jwt/team-has-bot? (jwt/get-key :teams))
+                                 ;; the user is also a Slack user
+                                 (seq (jwt/get-key :slack-id)))
                         [:li
                           {:on-click #(change! s :digest-medium "slack")}
                           "Slack"])]]]])]]]

--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -321,9 +321,10 @@
                       [:li
                         {:on-click #(change! s :digest-medium "email")}
                         "Email"]
-                      [:li
-                        {:on-click #(change! s :digest-medium "slack")}
-                        "Slack"]]]]])]]]
+                      (when (some jwt/team-has-bot? (jwt/get-key :teams))
+                        [:li
+                          {:on-click #(change! s :digest-medium "slack")}
+                          "Slack"])]]]])]]]
             ;; Eventually we want them to be able specify day and time of digest, but not yet
             ; [:div.user-profile-field.digest-frequency-field.digest-day
             ;   [:select


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby

Item:
> Can pick digest type as Slack in User Profile even though there's no bot to send the Slack digest

Assigning this to you @belucid because i think you found the bug.

I changed it so now it checks if at least one of the teams the user is associated to has a slack bot. If so i guess the backend will use the available bot for that team and email digest for the other. Makes sense?
Do you think this should be associated with a backend PR?