### PR TITLE
Fix duplicate tooltips

### DIFF
--- a/src/oc/web/components/activity_card.cljs
+++ b/src/oc/web/components/activity_card.cljs
@@ -75,7 +75,7 @@
                  :data-toggle (when-not is-mobile? "tooltip")
                  :data-placement "top"
                  :data-delay "{\"show\":\"1000\", \"hide\":\"0\"}"
-                 :title (utils/activity-date-tooltip activity-data)}
+                 :data-title (utils/activity-date-tooltip activity-data)}
                 (utils/time-since t)])]]
         ; Card labels
         [:div.activity-card-head-right

--- a/src/oc/web/components/drafts_layout.cljs
+++ b/src/oc/web/components/drafts_layout.cljs
@@ -53,7 +53,7 @@
                    :data-toggle "tooltip"
                    :data-placement "top"
                    :data-delay "{\"show\":\"1000\", \"hide\":\"0\"}"
-                   :title (utils/activity-date-tooltip draft)}
+                   :data-title (utils/activity-date-tooltip draft)}
                   (utils/time-since t)])]]]
         [:div.draft-card-content.group
           [:div.draft-card-title

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -325,7 +325,7 @@
               {:date-time (:published-at activity-data)
                :data-toggle "tooltip"
                :data-placement "top"
-               :title (utils/activity-date-tooltip activity-data)}
+               :data-title (utils/activity-date-tooltip activity-data)}
               (utils/time-since (:published-at activity-data))]]]
         [:div.fullscreen-post-header-right
           (if editing

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -35,7 +35,7 @@
            :data-toggle "tooltip"
            :data-placement "top"
            :data-delay "{\"show\":\"1000\", \"hide\":\"0\"}"
-           :title (utils/activity-date-tooltip result)}
+           :data-title (utils/activity-date-tooltip result)}
           (utils/time-since t)])]
       ]]))
 

--- a/src/oc/web/components/stream_view_item.cljs
+++ b/src/oc/web/components/stream_view_item.cljs
@@ -80,7 +80,7 @@
                  :data-toggle (when-not is-mobile? "tooltip")
                  :data-placement "top"
                  :data-delay "{\"show\":\"1000\", \"hide\":\"0\"}"
-                 :title (utils/activity-date-tooltip activity-data)}
+                 :data-title (utils/activity-date-tooltip activity-data)}
                 (utils/time-since t)])]]
         (more-menu activity-data)]
       [:div.stream-view-item-body.group


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby

Item:
> Duplicate tooltips when hovering date and have conflicting info (the grey text one seems accurate): http://take.ms/Ro82q

To avoid the browser showing 2 times the tooltip (one with bootstrap style and the other with the native tooltip style) i switched to use data-title as attribute, bootstrap read it just like the usual `title`.
Since the browser reads only the `title` attribute it shouldn't be possible to see both tooltips together.

Assigning this to you @belucid because i think  you found it and are able to repeat test steps