### PR TITLE
BUG: MediumEditor and Firefox

### DIFF
--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -580,7 +580,7 @@ div.entry-edit-modal-container {
             color: $deep_navy;
             @include avenir_R();
             font-size: 16px;
-            margin: 15px 0;
+            margin: 16px 0;
             cursor: text;
             min-height: 85px;
             white-space: pre-wrap;

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -173,7 +173,7 @@
                           (let [entry-editing @(drv/get-ref s :entry-editing)
                                 initial-body (if (seq (:body entry-editing))
                                                (:body entry-editing)
-                                               utils/default-body)
+                                               "")
                                 initial-headline (utils/emojify
                                                    (if (seq (:headline entry-editing))
                                                      (:headline entry-editing)

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -533,8 +533,6 @@
         _ (.remove $hidden-div)]
     body-without-preview))
 
-(def default-body "<p><br/></p>")
-
 (defn newest-org [orgs]
   (first (sort-by :created-at orgs)))
 


### PR DESCRIPTION
Card: https://trello.com/c/XfXJYHby
Item:
> FF only, not Chrome: http://take.ms/5Yg03 sequence: my cursor is at the end of "...of content." I hit enter, and I get the new paragraph (where I typed "We're") but I also get the break above "of content".  Here's the DOM. Very strange cause there doesn't seem to be anything in the DOM to do that space above of content. The `br` is after it: http://take.ms/8E4qS

Found out that MediumEditor already handles the weird FF behaviour on initial editings and my initialization of the editor field with `<p><br/><p/>` was only causing problems, i removed it and it looks like it's working as expected.
Fix also a small inconsistency of the css that was moving the body text up and down when the second paragraph was created.