### PR TITLE
Your digest

### DIFF
--- a/resources/public/js/static-js.js
+++ b/resources/public/js/static-js.js
@@ -97,13 +97,13 @@ document.addEventListener("DOMContentLoaded", function(_) {
     $("section.keep-aligned").css({"display": "none"});
     // Remove login button from the site mobile menu
     $("button#site-mobile-menu-login").css({"display": "none"});
-    // Change Get started button to Your boards on site mobile menu
+    // Change Get started button to Your digest on site mobile menu
     var siteMobileMenuGetStarted = $("button#site-mobile-menu-getstarted");
-    siteMobileMenuGetStarted.text( "Your Boards" );
-    siteMobileMenuGetStarted.addClass("your-boards");
-    // Top right corner became Your Boards
+    siteMobileMenuGetStarted.text( "Your digest" );
+    siteMobileMenuGetStarted.addClass("your-digest");
+    // Top right corner became Your digest
     var signupButton = $("#site-header-signup-item");
-    signupButton.addClass("your-boards");
+    signupButton.addClass("your-digest");
 
     var decoded_jwt = OCStaticGetDecodedJWT(jwt),
         your_board_url = OCStaticGetYourBoardsUrl(decoded_jwt);

--- a/scss/partials/_home_page.scss
+++ b/scss/partials/_home_page.scss
@@ -19,7 +19,7 @@ button.get-started-button {
     margin: 16px auto;
     padding: 0px 32px;
 
-    &.your-boards {
+    &.your-digest {
       text-align: center;
 
       &:after {

--- a/scss/partials/_site_header.scss
+++ b/scss/partials/_site_header.scss
@@ -114,7 +114,7 @@ nav.site-navbar {
         }
       }
 
-      a.mobile-your-boards {
+      a.mobile-your-digest {
         margin-top: 6px;
 
         img.user-avatar {
@@ -138,7 +138,7 @@ nav.site-navbar {
         margin-top: 0px;
         opacity: 0.8;
 
-        &:not(.your-boards).slack-get-started {
+        &:not(.your-digest).slack-get-started {
           height: 42px;
           background-color: transparent;
           @include avenir_H();
@@ -170,7 +170,7 @@ nav.site-navbar {
           }
         }
 
-        &.your-boards {
+        &.your-digest {
           height: unset;
           border: none;
           border-radius: none;

--- a/src/oc/web/components/ui/site_footer.cljs
+++ b/src/oc/web/components/ui/site_footer.cljs
@@ -21,8 +21,8 @@
         [:img {:src (utils/cdn "/img/ML/home_page_medium.svg")}]]]
     [:div.copyright "© Copyright 2017. All rights reserved"]])
 
-(defn navigate-to-your-boards [your-boards-url]
-  (router/redirect! your-boards-url))
+(defn navigate-to-your-digest [your-digest-url]
+  (router/redirect! your-digest-url))
 
 (rum/defcs site-footer  < (rum/local nil ::expanded)
   [s]

--- a/src/oc/web/components/ui/site_header.cljs
+++ b/src/oc/web/components/ui/site_header.cljs
@@ -29,7 +29,7 @@
   [auth-settings use-slack-signup-button]
   ; <!-- Nav Bar -->
   (let [logged-in (jwt/jwt)
-        your-boards (when logged-in (utils/your-boards-url))
+        your-digest (when logged-in (utils/your-digest-url))
         slack-auth-link (utils/link-for (:links auth-settings) "authenticate" "GET"
                          {:auth-source "slack"})]
     [:nav.site-navbar
@@ -40,25 +40,25 @@
         [:div.site-navbar-right.big-web-only
           (when-not logged-in
             [:a.login
-              {:href (utils/your-boards-url)
-               :class (when logged-in "your-boards")
+              {:href (utils/your-digest-url)
+               :class (when logged-in "your-digest")
                :on-click (fn [e]
                            (.preventDefault e)
                            (if logged-in
-                             (nav! (utils/your-boards-url) e)
+                             (nav! (utils/your-digest-url) e)
                              (nav! oc-urls/login e))
                            (user/show-login :login-with-slack))}
                 "Log in"])
           [:a.start
             {:href (if logged-in
-                    your-boards
+                    your-digest
                     oc-urls/sign-up)
-             :class (utils/class-set {:your-boards logged-in
+             :class (utils/class-set {:your-digest logged-in
                                       :slack-get-started use-slack-signup-button})
              :on-click (fn [e]
                          (.preventDefault e)
                          (if logged-in
-                          (nav! your-boards e)
+                          (nav! your-digest e)
                           (if use-slack-signup-button
                             (user-actions/login-with-slack slack-auth-link)
                             (nav! oc-urls/sign-up e))))}
@@ -72,9 +72,9 @@
                 "Start"))]]
         [:div.site-navbar-right.mobile-only
           (if logged-in
-            [:a.mobile-your-boards
-              {:href your-boards
-               :on-click (partial nav! your-boards)}
+            [:a.mobile-your-digest
+              {:href your-digest
+               :on-click (partial nav! your-digest)}
               [:span.go-to-digest
                 "Go to digest"]]
             [:a.start
@@ -82,7 +82,7 @@
                :on-click (fn [e]
                            (.preventDefault e)
                            (if logged-in
-                             (nav! your-boards e)
+                             (nav! your-digest e)
                              (if use-slack-signup-button
                                (user-actions/login-with-slack slack-auth-link)
                                (nav! oc-urls/sign-up e))))

--- a/src/oc/web/components/ui/site_mobile_menu.cljs
+++ b/src/oc/web/components/ui/site_mobile_menu.cljs
@@ -87,15 +87,15 @@
              :on-touch-start identity}
             "Log In"])
         [:button.mlb-reset.get-started-button
-          {:class (when (jwt/jwt) "your-boards")
+          {:class (when (jwt/jwt) "your-digest")
            :on-touch-start identity
            :on-click (fn [e]
                       (site-menu-toggle)
                       (if (jwt/jwt)
-                        (router/redirect! (utils/your-boards-url))
+                        (router/redirect! (utils/your-digest-url))
                         (if (utils/in? (:route @router/path) "login")
                           (user/show-login :signup-with-slack)
                           (router/nav! oc-urls/sign-up))))}
           (if (jwt/jwt)
-            "Your Boards"
+            "Your digest"
             "Get started for free")]]]))

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -575,7 +575,7 @@
         _ (.detach $container)]
     cleaned-html))
 
-(defn your-boards-url []
+(defn your-digest-url []
   (if-let [org-slug (cook/get-cookie (router/last-org-cookie))]
     (if-let [board-slug "all-posts"]
       ;; Repalce all-posts above with the following to go back to the last visited board


### PR DESCRIPTION
Card: https://trello.com/c/edD7WE0z
Item:
> If you open up the browser and you're still logged in, click on navigation and it still says "Your Boards". Change to "Your digest"

To test:
- login
- navigate to / from mobile
- click on the ham menu
- [x] do you see Your digest at the bottom? Good
- navigate to your digest
- open the nav menu
- [x] do you not see the word board in the menu? Good