### PR TITLE
Mobile navigation

### DIFF
--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -301,7 +301,7 @@ div.left-navigation-sidebar {
         background-color: $oc_gray_8;
         height: 40px;
         width: 100%;
-        padding: 13px 24px;
+        padding: 13px 24px 13px 58px;
         margin-bottom: 0px;
       }
 
@@ -353,7 +353,7 @@ div.left-navigation-sidebar {
       }
 
       @include mobile() {
-        background-color: #F0EFEA;
+        display: none;
         float: right;
 
         &:hover {


### PR DESCRIPTION
Card: https://trello.com/c/edD7WE0z
Item:
> On mobile only, remove (+) button in navigation; and align SECTIONS with other words

Test:
- with an admin or contributor (of the org)
- on mobile nav to your digest
- click on the ham menu
- [x] do you NOT see the plus button to the right of the Sections word? Good
- [x] do you see Sections aligned with the other section labels? Good