### PR TITLE
BUG: Token refresh

### DIFF
--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -136,9 +136,17 @@
         expired? (j/expired?)]
     (timbre/debug jwt expired?)
     (go
+      ;; Async refresh the JWT token if needed
+      ;; Make sure this uses this same go cycle to avoid doing an async call and breaking
+      ;; the refresh flow
       (when (and jwt expired?)
-        (jwt-refresh #(jwt-refresh-handler (:body %))
-                     #(jwt-refresh-error-hn)))
+        (if-let [refresh-url (j/get-key :refresh-url)]
+          (let [res (<! (refresh-jwt refresh-url))]
+            (timbre/debug "jwt-refresh" res)
+            (if (:success res)
+              (jwt-refresh-handler (:body res))
+              (jwt-refresh-error-hn)))
+          (jwt-refresh-error-hn)))
 
       (let [{:keys [status body] :as response} (<! (method (str endpoint path) (complete-params params)))]
         (timbre/debug "Resp:" (method-name method) (str endpoint path) status)

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -99,15 +99,19 @@
                   http/get)]
   (method refresh-url (complete-params headers))))
 
+(defn- sync-jwt-refresh
+  [success-cb error-cb]
+  (if-let [refresh-url (j/get-key :refresh-url)]
+    (let [res (<! (refresh-jwt refresh-url))]
+      (timbre/debug "jwt-refresh" res)
+      (if (:success res)
+        (success-cb (:body res))
+        (error-cb)))
+    (error-cb)))
+;; Async version of jwt-refresh
 (defn- jwt-refresh [success-cb error-cb]
   (go
-   (if-let [refresh-url (j/get-key :refresh-url)]
-     (let [res (<! (refresh-jwt refresh-url))]
-       (timbre/debug "jwt-refresh" res)
-       (if (:success res)
-         (success-cb (:body res))
-         (error-cb)))
-     (error-cb))))
+   (sync-jwt-refresh success-cb error-cb)))
 
 (defn- method-name [method]
   (cond
@@ -136,17 +140,10 @@
         expired? (j/expired?)]
     (timbre/debug jwt expired?)
     (go
-      ;; Async refresh the JWT token if needed
-      ;; Make sure this uses this same go cycle to avoid doing an async call and breaking
-      ;; the refresh flow
-      (when (and jwt expired?)
-        (if-let [refresh-url (j/get-key :refresh-url)]
-          (let [res (<! (refresh-jwt refresh-url))]
-            (timbre/debug "jwt-refresh" res)
-            (if (:success res)
-              (jwt-refresh-handler (:body res))
-              (jwt-refresh-error-hn)))
-          (jwt-refresh-error-hn)))
+     ;; sync refresh
+     (when (and jwt expired?)
+       (sync-jwt-refresh #(jwt-refresh-handler (:body %))
+                         #(jwt-refresh-error-hn)))
 
       (let [{:keys [status body] :as response} (<! (method (str endpoint path) (complete-params params)))]
         (timbre/debug "Resp:" (method-name method) (str endpoint path) status)


### PR DESCRIPTION
BUG: when the token is expired we refresh the JWT token before making any http call to our servers with a synchronous refresh call. This call was not synchronous anymore causing the forced logout every time the JWT expires.

This fix this situation putting back in place the sync call.

To test:
- open local lib repo and change `oc.lib.jwt#115` so the jwt expires in 1 min
- change lib version (add an "a" to the current version avoid future version conflicts)
- `lein install`
- stop auth service
- update lib version in project.clj with the just installed version
- `lein start`
- with web mainline go to /login
- login
- go to / and wait one minute
- click on "Go to digest"
- [x] are you redirected to /logout and then to the home (logged out)? Good
- switch to this branch
- login
- go to / and wait one minute
- go to Network tab of dev tools and clean all
- click on "Go to digest"
- [x] do you see a bunch of refresh call in the network tab first of all the other? Good
- [x] are you still logged in when the page load finishes? Good
- [x] do you not see any 401 in the network calls list? Good