### PR TITLE
Drift

### DIFF
--- a/resources/pages/pricing.edn
+++ b/resources/pages/pricing.edn
@@ -1,1 +1,2 @@
-{:page :pricing}
+{:page :pricing
+ :drift true}

--- a/resources/public/js/drift.js
+++ b/resources/public/js/drift.js
@@ -1,0 +1,22 @@
+<!-- Start of Async Drift Code -->
+!function() {
+  var t;
+  if (t = window.driftt = window.drift = window.driftt || [], !t.init) return t.invoked ? void (window.console && console.error && console.error("Drift snippet included twice.")) : (t.invoked = !0, 
+  t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ], 
+  t.factory = function(e) {
+    return function() {
+      var n;
+      return n = Array.prototype.slice.call(arguments), n.unshift(e), t.push(n), t;
+    };
+  }, t.methods.forEach(function(e) {
+    t[e] = t.factory(e);
+  }), t.load = function(t) {
+    var e, n, o, i;
+    e = 3e5, i = Math.ceil(new Date() / e) * e, o = document.createElement("script"), 
+    o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + i + "/" + t + ".js", 
+    n = document.getElementsByTagName("script")[0], n.parentNode.insertBefore(o, n);
+  });
+}();
+drift.SNIPPET_VERSION = '0.3.1';
+drift.load('---DRIFT-KEY---');
+<!-- End of Async Drift Code -->

--- a/resources/public/js/drift.js
+++ b/resources/public/js/drift.js
@@ -18,5 +18,5 @@
   });
 }();
 drift.SNIPPET_VERSION = '0.3.1';
-drift.load('---DRIFT-KEY---');
+drift.load('DRIFT_KEY');
 <!-- End of Async Drift Code -->

--- a/site/oc/core.clj
+++ b/site/oc/core.clj
@@ -10,58 +10,61 @@
 (def options {:contact-email contact-email
               :contact-mail-to contact-mail-to})
 
-(defn head []
+(defn head [drift?]
   [:head
-   [:meta {:charset "utf-8"}]
-   [:meta {:content "IE=edge", :http-equiv "X-UA-Compatible"}]
-   [:meta {:content "width=device-width, initial-scale=1", :name "viewport"}]
-   [:meta {:name "slack-app-id" :content (env :oc-slack-app-id)}]
-   ;; The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags
-   [:title "Stay aligned"]
-   ;; Bootstrap - Latest compiled and minified CSS
-   [:link
+    [:meta {:charset "utf-8"}]
+    [:meta {:content "IE=edge", :http-equiv "X-UA-Compatible"}]
+    [:meta {:content "width=device-width, initial-scale=1", :name "viewport"}]
+    [:meta {:name "slack-app-id" :content (env :oc-slack-app-id)}]
+    ;; The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags
+    [:title "Stay aligned"]
+    ;; Bootstrap - Latest compiled and minified CSS
+    [:link
     {:rel "stylesheet"
      :href "//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
      :integrity "sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
      :crossorigin "anonymous"}]
-   ;; Local css
-   [:link {:href (pages/cdn "/css/app.main.css"), :rel "stylesheet"}]
-   ;; Fallback for the CDN compacted css
-   [:link {:href (pages/cdn "/main.css") :rel "stylesheet"}]
-   ;; HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries
-   ;; WARNING: Respond.js doesn't work if you view the page via file://
-   "<!--[if lt IE 9]>
+    ;; Local css
+    [:link {:href (pages/cdn "/css/app.main.css"), :rel "stylesheet"}]
+    ;; Fallback for the CDN compacted css
+    [:link {:href (pages/cdn "/main.css") :rel "stylesheet"}]
+    ;; HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries
+    ;; WARNING: Respond.js doesn't work if you view the page via file://
+    "<!--[if lt IE 9]>
       <script src=\"//oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js\"></script>
       <script src=\"//oss.maxcdn.com/respond/1.4.2/respond.min.js\"></script>
     <![endif]-->"
-   ;; Google fonts Open Sans / Lora
-   [:link {:type "text/css", :rel "stylesheet",
+    ;; Google fonts Open Sans / Lora
+    [:link {:type "text/css", :rel "stylesheet",
            :href "https://fonts.googleapis.com/css?family=Open+Sans:400,300"}]
-   [:link {:type "text/css", :rel "stylesheet",
+    [:link {:type "text/css", :rel "stylesheet",
            :href "//fonts.googleapis.com/css?family=Lora:400,400italic,700,700italic"}]
-   ;; CarrotKit Font
-   [:link {:type "text/css" :rel "stylesheet" :href (pages/cdn "/css/fonts/CarrotKit.css")}]
-   ;; Font Awesome icon fonts //fortawesome.github.io/Font-Awesome/cheatsheet/
-   [:link {:rel "stylesheet" :href "//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css"}]
-   ;; Favicon
-   [:link {:rel "icon" :type "image/png" :href (pages/cdn "/img/carrot_logo.png") :sizes "64x64"}]
-   ;; jQuery needed by Bootstrap JavaScript
-   [:script {:src "//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js" :type "text/javascript"}]
-   ;; Static js files
-   [:script {:src (pages/cdn "/js/static-js.js")}]
-   ;; Google Analytics
-   [:script {:type "text/javascript" :src "https://www.google-analytics.com/analytics.js"}]
-   [:script {:type "text/javascript" :src "/lib/autotrack/autotrack.js"}]
-   [:script {:type "text/javascript" :src "/lib/autotrack/google-analytics.js"}]
-   (pages/google-analytics-init)
-   ;; Bootstrap JavaScript //getf.com/
-   [:script
+    ;; CarrotKit Font
+    [:link {:type "text/css" :rel "stylesheet" :href (pages/cdn "/css/fonts/CarrotKit.css")}]
+    ;; Font Awesome icon fonts //fortawesome.github.io/Font-Awesome/cheatsheet/
+    [:link {:rel "stylesheet" :href "//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css"}]
+    ;; Favicon
+    [:link {:rel "icon" :type "image/png" :href (pages/cdn "/img/carrot_logo.png") :sizes "64x64"}]
+    ;; jQuery needed by Bootstrap JavaScript
+    [:script {:src "//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js" :type "text/javascript"}]
+    ;; Static js files
+    [:script {:src (pages/cdn "/js/static-js.js")}]
+    (when drift?
+      ;; Drift
+      [:script {:src (pages/cdn "/js/drift.js")}])
+    ;; Google Analytics
+    [:script {:type "text/javascript" :src "https://www.google-analytics.com/analytics.js"}]
+    [:script {:type "text/javascript" :src "/lib/autotrack/autotrack.js"}]
+    [:script {:type "text/javascript" :src "/lib/autotrack/google-analytics.js"}]
+    (pages/google-analytics-init)
+    ;; Bootstrap JavaScript //getf.com/
+    [:script
      {:src "//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
       :type "text/javascript"
       :integrity "sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
       :crossorigin "anonymous"}]
-   ;; jQuery textcomplete needed by Emoji One autocomplete
-   [:script {:src "/lib/jwt_decode/jwt-decode.min.js" :type "text/javascript"}]])
+    ;; jQuery textcomplete needed by Emoji One autocomplete
+    [:script {:src "/lib/jwt_decode/jwt-decode.min.js" :type "text/javascript"}]])
 
 (defn mobile-menu
   "Mobile menu used to show the collapsable menu in the marketing site."
@@ -196,10 +199,10 @@
   ([content]
    (static-page content {}))
   ([content opts]
-   (let [{:keys [page title]} (-> content :entry read-edn)
+   (let [{:keys [page title drift]} (-> content :entry read-edn)
          is?    (fn [& args] ((set args) page))]
      (hp/html5 {:lang "en"}
-               (head)
+               (head drift)
                [:body
                 [:div
                  {:class "outer header"}


### PR DESCRIPTION
This PR adds Drift's JS to static pages that include the `:drift` option as truthy.

Right now, only static page w/ that is pricing.

Supporting PR: https://github.com/belucid/open-company-infrastructure/pull/60

To test:

- deploy with the Drift infra and web branches
- Nav. to /pricing
- [x] do you see an orange drift button in the bottom right corner?
- Click it
- [x] does it work?
- [ ] merge
- [ ] deploy
- [ ] rub your stomach and pat your head at the same time