### PR TITLE
Mobile navigation header

### DIFF
--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -118,9 +118,9 @@ nav.oc-navbar {
             display: inline;
 
             &.close-bt {
-              @include image-2x("/img/ML/mobile_modal_close");
-              background-size: 14px 14px;
-              background-position: 5px 5px;
+              background-image: cdnUrl("/img/ML/black_close.svg");
+              background-size: 15px 15px;
+              background-position: center;
             }
           }
         }

--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -116,6 +116,12 @@ nav.oc-navbar {
             background-size: 18px 14px;
             background-position: 3px 5px;
             display: inline;
+
+            &.close-bt {
+              @include image-2x("/img/ML/mobile_modal_close");
+              background-size: 14px 14px;
+              background-position: 5px 5px;
+            }
           }
         }
       }

--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -135,14 +135,15 @@ div.left-navigation-sidebar {
   @include no-user-select();
 
   @include mobile() {
-    position: unset;
-    top: unset;
-    left: unset;
+    position: absolute;
+    margin-top: 65px;
+    top: 0px;
+    left: 0px;
     width: 100%;
     min-height: 100vh;
     display: none;
     z-index: 10000;
-    background-color: white;
+    background-color: transparent;
     max-height: unset;
     height: unset;
     overflow-y: unset;
@@ -153,46 +154,13 @@ div.left-navigation-sidebar {
     }
   }
 
-  div.left-navigation-sidebar-mobile-header {
-    display: none;
-
-    @include mobile() {
-      display: block;
-      height: 64px;
-      box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.1);
-    }
-
-    button.close-mobile-menu {
-      width: 32px;
-      height: 32px;
-      background-image: cdnUrl("/img/ML/black_close.svg");
-      background-size: 15px;
-      background-position: center;
-      background-repeat: no-repeat;
-      float: left;
-      margin: 16px;
-    }
-
-    div.mobile-header-title {
-      @include avenir_H();
-      font-size: 18px;
-      color: $deep_navy;
-      width: 250px;
-      position: relative;
-      left: 50%;
-      margin-top: 21px;
-      margin-left: -125px;
-      text-align: center;
-      position: absolute;
-    }
-  }
-
   div.left-navigation-sidebar-content {
     padding-bottom: 32px;
 
     @include mobile() {
       position: relative;
       padding-bottom: 0px;
+      background-color: white;
     }
   }
 

--- a/src/oc/web/actions/search.cljs
+++ b/src/oc/web/actions/search.cljs
@@ -31,3 +31,6 @@
 (defn result-clicked [url]
   (dispatcher/dispatch! [:search-result-clicked])
   (utils/after 10 (router/nav! url)))
+
+(defn focus []
+  (dispatcher/dispatch! [:search-focus]))

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -129,11 +129,6 @@
       {:class (when mobile-navigation-sidebar "show-mobile-boards-menu")}
       [:div.left-navigation-sidebar-content
         {:ref "left-navigation-sidebar-content"}
-        [:div.left-navigation-sidebar-mobile-header.group
-          [:button.mlb-reset.close-mobile-menu
-            {:on-click #(close-navigation-sidebar)}]
-          [:div.mobile-header-title
-            "Digest navigation"]]
         ;; All posts
         (when show-all-posts
           [:a.all-posts.hover-item.group

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -194,12 +194,12 @@
                            should-show-onboard-overlay?
                            is-sharing-activity
                            show-section-add
-                           show-section-editor
-                           mobile-navigation-sidebar))
+                           show-section-editor))
           [:div.page
             (navbar)
             [:div.org-dashboard-container
               [:div.org-dashboard-inner
                (when-not (and is-mobile?
-                              (and search-active? search-results?))
+                              (and search-active? search-results?)
+                              mobile-navigation-sidebar)
                  (dashboard-layout))]]])])))

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -152,7 +152,6 @@
                         (when (and (responsive/is-mobile-size?) (zero? (count search-query)))
                           (set! (.-placeholder search-input) "Search"))
                         (search/query search-query))
-           :on-change #(search/query (.-value (.-target %)))
-           }]
+           :on-change #(search/query (.-value (.-target %)))}]
        [:div.triangle {:class (when-not search-active? "inactive")}]
        (when-not (responsive/is-mobile-size?)(search-results-view))])))

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -148,6 +148,7 @@
            :on-focus #(let [search-input (.-target %)
                             search-query (.-value search-input)]
                         (reset! (::search-clicked? s) true)
+                        (search/focus)
                         (when (and (responsive/is-mobile-size?) (zero? (count search-query)))
                           (set! (.-placeholder search-input) "Search"))
                         (search/query search-query))

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -74,5 +74,4 @@
                 (login-button)))]]]
       (when (responsive/is-mobile-size?)
         ;; Render the menu here only on mobile so it can expand the navbar
-        (menu/menu))
-      ]))
+        (menu/menu))]))

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -50,7 +50,8 @@
         [:div.oc-navbar-header-container.group
           [:div.navbar-left
             [:button.mlb-reset.mobile-navigation-sidebar-ham-bt
-              {:on-click #(do
+              {:class (when mobile-navigation-sidebar "close-bt")
+               :on-click #(do
                             (menu/mobile-menu-close)
                             (dis/dispatch! [:input [:mobile-navigation-sidebar] (not mobile-navigation-sidebar)]))}]
            (search-box)]

--- a/src/oc/web/components/ui/orgs_dropdown.cljs
+++ b/src/oc/web/components/ui/orgs_dropdown.cljs
@@ -51,6 +51,7 @@
                                   :show-dropdown-caret orgs-dropdown-visible})
          :on-click (fn [e]
                      (utils/event-stop e)
+                     (dis/dispatch! [:input [:mobile-navigation-sidebar] false])
                      (when should-show-dropdown?
                        (dis/dispatch! [:input [:orgs-dropdown-visible] (not orgs-dropdown-visible)])))}
         (org-avatar org-data (not should-show-dropdown?))]

--- a/src/oc/web/stores/search.cljs
+++ b/src/oc/web/stores/search.cljs
@@ -65,3 +65,7 @@
   [db [_]]
   (reset! savedsearch @lastsearch)
   db)
+
+(defmethod dispatcher/action :search-focus
+  [db [_]]
+  (dissoc db :mobile-navigation-sidebar))


### PR DESCRIPTION
Card: https://trello.com/c/edD7WE0z

Item:
> Keep header in mobile navigation https://invis.io/MWGB5FQ6HVD

To test:
- visit dashboard on mobile
- click on the ham menu
- [x] do you still see the navbar at the top? Good
- click on the X to the left of the navbar
- [x] did it close? Good
- click on the ham menu again
- click on the search icon
- [x] did the navigation menu close? Good
- click on the ham menu again
- click on the org avatar
- [x] did the navigation menu close and the orgs dropdown appear (only if you have more then one org)? Good
- click on the ham menu again
- click on the user menu
- [x] did the navigation menu close and the user menu appear? Good
