### PR TITLE
Preload sections on AP

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -32,7 +32,9 @@
       (if (utils/link-for (:links org-data) "activity")
         ;; Load all posts only if not coming from a digest url
         ;; in that case do not load since we already have the results we need
-        (aa/all-posts-get org-data ap-initial-at)
+        (do
+           (aa/all-posts-get org-data ap-initial-at)
+           (sa/load-other-sections (:boards org-data)))
         (router/redirect-404!))
       ; If there is a board slug let's load the board data
       (router/current-board-slug)


### PR DESCRIPTION
BUG: if you visit All posts directly (not coming from a single section) we don't preload the sections of the org so there are no sections to post to. When clicking post in the compose it won't do anything.

To test:
- go to AP
- click compose
- [x] do you see a section selected? Good
- click on the section name
- [x] do you see the complete list of sections? Good
- go to a single board (refresh, not internal nav)
- click compose
- [x] do you see the current section selected? Good
- click on the section name
- [x] do you see the complete list of sections? Good