### PR TITLE
Paste long html

### DIFF
--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -287,9 +287,11 @@
                               :targetCheckboxText "Open in new window"}
                  :paste #js {:forcePlainText false
                              :cleanPastedHTML true
-                             :cleanAttrs #js ["class" "style" "alt" "dir" "size" "face" "color" "itemprop"]
-                             :cleanTags #js ["meta" "video" "audio" "img"]
-                             :unwrapTags (clj->js (remove nil? ["div" "span" "label" "font" "h1" (when-not show-subtitle "h2") "h3" "h4" "h5" "h6" "strong"]))}
+                             :cleanAttrs #js ["class" "style" "alt" "dir" "size" "face" "color" "itemprop" "name" "id"]
+                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure"]
+                             :unwrapTags (clj->js (remove nil? ["div" "span" "label" "font" "h1"
+                                                   (when-not show-subtitle "h2") "h3" "h4" "h5"
+                                                   "h6" "strong" "section" "time" "em" "main"]))}
                  :placeholder #js {:text "What would you like to share?"
                                    :hideOnClick true}
                  :keyboardCommands #js {:commands #js [

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -288,8 +288,8 @@
                  :paste #js {:forcePlainText false
                              :cleanPastedHTML true
                              :cleanAttrs #js ["class" "style" "alt" "dir" "size" "face" "color" "itemprop"]
-                             :cleanTags #js ["meta" "video" "audio"]
-                             :unwrapTags #js ["div" "span" "label" "font" "h1" "h3" "h4" "h5" "h6" "strong"]}
+                             :cleanTags #js ["meta" "video" "audio" "img"]
+                             :unwrapTags (clj->js (remove nil? ["div" "span" "label" "font" "h1" (when-not show-subtitle "h2") "h3" "h4" "h5" "h6" "strong"]))}
                  :placeholder #js {:text "What would you like to share?"
                                    :hideOnClick true}
                  :keyboardCommands #js {:commands #js [
@@ -320,9 +320,7 @@
                 "editableInput"
                 (fn [event editable]
                   (body-on-change s)))
-    (reset! (::editor s) body-editor)
-    ; (js/recursiveAttachPasteListener body-el #(body-on-change s))
-    ))
+    (reset! (::editor s) body-editor)))
 
 (defn toggle-menu-cb [s show?]
   (when-let [editable @(::editor s)]


### PR DESCRIPTION
Sentry: https://sentry.io/opencompany/oc-beta-web/issues/514098229/?referrer=slack

BUG: paste in the body some random article copied from the web with images. You'll see there are a lot of unformatted things and the images are kept with their own original source.
This lead to 2 main problems: images not under our control can change, be slow, disappear; images with inline base64 data can break our body limit.
To avoid this we decided to remove images from paste actions for now, we will handle them later making sure the source is under our control.

To test:
- compose
- paste an article from Medium.com
- [x] looking good? Good
- [x] no images? Good
- compose
- paste an article from CNN.com
- [x] looking good? Good
- [x] no images? Good
- compose
- paste any article you can think of that can break our editor

Please report any unformatted thing you see with the source URL.