### PR TITLE
MediumEditor dnd

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -68,6 +68,9 @@ MediaPicker.addChart = function(){};
 MediaPicker.addAttachment = function(){};
 MediaPicker.saveSelection = function(){};
 MediaPicker.removeSelection = function(){};
+// MediumEditorFileDragging
+var MyFileDragging = function(){};
+MyFileDragging.insertImageFile = function(){};
 // Debug app state
 var OCWebPrintAppState = function(){};
 var OCWebPrintOrgData = function(){};

--- a/resources/public/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js
@@ -89,22 +89,19 @@ var MyFileDragging = MediumEditor.Extension.extend({
     },
 
     insertImageFile: function (file, imageURL, thumbnailURL) {
-        if (typeof FileReader !== 'function') {
-            return;
-        }
         var addImageElement = this.document.createElement('img');
-        addImageElement.src = imageURL;
-        addImageElement.className = "carrot-no-preview";
-        addImageElement.dataset.mediaType = "image";
-        addImageElement.onLoad = function(){
+        var that = this;
+        addImageElement.onload = function(){
             addImageElement.width = this.width;
             addImageElement.height = this.height;
+            addImageElement.className = "carrot-no-preview";
+            addImageElement.dataset.mediaType = "image";
+            if (thumbnailURL) {
+                addImageElement.dataset.thumbnail = photoThumbnail;
+            }
+            MediumEditor.util.insertHTMLCommand(that.document, addImageElement.outerHTML);
         };
-
-        if (thumbnailURL) {
-            addImageElement.dataset.thumbnail = photoThumbnail;
-        }
-        MediumEditor.util.insertHTMLCommand(this.document, addImageElement.outerHTML);
+        addImageElement.src = imageURL;
     }
 });
 

--- a/resources/public/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js
@@ -1,0 +1,113 @@
+(function (root, factory) {
+    'use strict';
+    if (typeof module === 'object') {
+        module.exports = factory;
+    } else if (typeof define === 'function' && define.amd) {
+        define(factory);
+    } else {
+        root.MyFileDragging = factory;
+    }
+}(this, function (MediumEditor) {
+
+var CLASS_DRAG_OVER = 'medium-editor-dragover';
+
+function clearClassNames(element) {
+    var editable = MediumEditor.util.getContainerEditorElement(element),
+        existing = Array.prototype.slice.call(editable.parentElement.querySelectorAll('.' + CLASS_DRAG_OVER));
+
+    existing.forEach(function (el) {
+        el.classList.remove(CLASS_DRAG_OVER);
+    });
+}
+
+var MyFileDragging = MediumEditor.Extension.extend({
+    name: 'myFileDragging',
+
+    allowedTypes: ['.*'],
+
+    options: undefined,
+
+    constructor: function (options) {
+      if (options) {
+        this.options = options;
+      }
+
+      MediumEditor.Extension.call(this, this.options);
+    },
+
+    init: function () {
+        MediumEditor.Extension.prototype.init.apply(this, arguments);
+
+        this.subscribe('editableDrag', this.handleDrag.bind(this));
+        this.subscribe('editableDrop', this.handleDrop.bind(this));
+    },
+
+    handleDrag: function (event) {
+        event.preventDefault();
+        if (this.options.uploadHandler) {
+            event.dataTransfer.dropEffect = 'copy';
+
+            var target = event.target.classList ? event.target : event.target.parentElement;
+
+            // Ensure the class gets removed from anything that had it before
+            clearClassNames(target);
+
+            if (event.type === 'dragover') {
+                target.classList.add(CLASS_DRAG_OVER);
+            }
+        }
+    },
+
+    handleDrop: function (event) {
+        // Prevent file from opening in the current window
+        event.preventDefault();
+        if (this.options.uploadHandler) {
+            event.stopPropagation();
+            // Select the dropping target, and set the selection to the end of the target
+            // https://github.com/yabwe/medium-editor/issues/980
+            this.base.selectElement(event.target);
+            var selection = this.base.exportSelection();
+            selection.start = selection.end;
+            this.base.importSelection(selection);
+            // IE9 does not support the File API, so prevent file from opening in the window
+            // but also don't try to actually get the file
+            if (event.dataTransfer.files) {
+                Array.prototype.slice.call(event.dataTransfer.files).forEach(function (file) {
+                    this.options.uploadHandler(this, file);
+                }, this);
+            }
+
+            // Make sure we remove our class from everything
+            clearClassNames(event.target);
+        }
+    },
+
+    isAllowedFile: function (file) {
+        return this.allowedTypes.some(function (fileType) {
+            return !!file.type.match(fileType);
+        });
+    },
+
+    insertImageFile: function (file, imageURL, thumbnailURL) {
+        if (typeof FileReader !== 'function') {
+            return;
+        }
+        var addImageElement = this.document.createElement('img');
+        addImageElement.src = imageURL;
+        addImageElement.className = "carrot-no-preview";
+        addImageElement.dataset.mediaType = "image";
+        addImageElement.onLoad = function(){
+            addImageElement.width = this.width;
+            addImageElement.height = this.height;
+        };
+
+        if (thumbnailURL) {
+            addImageElement.dataset.thumbnail = photoThumbnail;
+        }
+        MediumEditor.util.insertHTMLCommand(this.document, addImageElement.outerHTML);
+    }
+});
+
+return MyFileDragging;
+
+}(typeof require === 'function' ? require('medium-editor') : MediumEditor)));

--- a/script/compile_assets.sh
+++ b/script/compile_assets.sh
@@ -18,6 +18,7 @@ java -jar ~/closure_compiler/closure-compiler-v$1.jar \
 --js lib/rangy/rangy-classapplier.js \
 --js lib/MediumEditorExtensions/MediumEditorAutolist/autolist.js \
 --js lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js \
+--js lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js \
 --js lib/jwt_decode/jwt-decode.min.js \
 --output_wrapper "%output%
 //# sourceMappingURL=$3/oc_assets.js.map"

--- a/site/oc/pages.clj
+++ b/site/oc/pages.clj
@@ -888,7 +888,9 @@
           ;; MediumEditorAutolist
           [:script {:type "text/javascript" :src "/lib/MediumEditorExtensions/MediumEditorAutolist/autolist.js"}]
           ;; MediumEditorMediaPicker
-          [:script {:type "text/javascript" :src "/lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js"}]]})
+          [:script {:type "text/javascript" :src "/lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js"}]
+          ;; MediumEditorFileDragging
+          [:script {:type "text/javascript" :src "/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js"}]]})
 
 (def prod-app-shell
   {:head [:head

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -256,25 +256,26 @@
 (def default-mutli-picker-button-id "entry-edit-multi-picker-bt")
 
 (defn- file-dnd-handler [s editor-ext file]
-  (if (.match (.-type file) "image")
-    (iu/upload-file! file
-      (fn [url]
-        (.insertImageFile editor-ext url)))
-    (iu/upload-file! file
-      (fn [url]
-        (let [size (gobj/get file "size")
-              mimetype (gobj/get file "type")
-              filename (gobj/get file "name")
-              createdat (utils/js-date)
-              prefix (str "Uploaded by " (jwt/get-key :name) " on " (utils/date-string createdat [:year]) " - ")
-              subtitle (str prefix (filesize size :binary false :format "%.2f" ))
-              icon (au/icon-for-mimetype mimetype)
-              attachment-data {:file-name filename
-                               :file-type mimetype
-                               :file-size size
-                               :file-url url}
-              dispatch-input-key (:dispatch-input-key (first (:rum/args s)))]
-          (activity-actions/add-attachment dispatch-input-key attachment-data))))))
+  (when (< (gobj/get file "size") (* 5 1000 1000))
+    (if (.match (.-type file) "image")
+      (iu/upload-file! file
+        (fn [url]
+          (.insertImageFile editor-ext url)))
+      (iu/upload-file! file
+        (fn [url]
+          (let [size (gobj/get file "size")
+                mimetype (gobj/get file "type")
+                filename (gobj/get file "name")
+                createdat (utils/js-date)
+                prefix (str "Uploaded by " (jwt/get-key :name) " on " (utils/date-string createdat [:year]) " - ")
+                subtitle (str prefix (filesize size :binary false :format "%.2f" ))
+                icon (au/icon-for-mimetype mimetype)
+                attachment-data {:file-name filename
+                                 :file-type mimetype
+                                 :file-size size
+                                 :file-url url}
+                dispatch-input-key (:dispatch-input-key (first (:rum/args s)))]
+            (activity-actions/add-attachment dispatch-input-key attachment-data)))))))
 
 (defn- setup-editor [s]
   (let [options (first (:rum/args s))

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -256,7 +256,7 @@
 (def default-mutli-picker-button-id "entry-edit-multi-picker-bt")
 
 (defn- file-dnd-handler [s editor-ext file]
-  (when (< (gobj/get file "size") (* 5 1000 1000))
+  (if (< (gobj/get file "size") (* 5 1000 1000))
     (if (.match (.-type file) "image")
       (iu/upload-file! file
         (fn [url]
@@ -275,7 +275,14 @@
                                  :file-size size
                                  :file-url url}
                 dispatch-input-key (:dispatch-input-key (first (:rum/args s)))]
-            (activity-actions/add-attachment dispatch-input-key attachment-data)))))))
+            (activity-actions/add-attachment dispatch-input-key attachment-data)))))
+    (let [alert-data {:icon "/img/ML/error_icon.png"
+                    :action "dnd-file-too-big"
+                    :title "Sorry!"
+                    :message "Error, please use files smaller than 5MB."
+                    :solid-button-title "OK"
+                    :solid-button-cb #(alert-modal/hide-alert)}]
+      (alert-modal/show-alert alert-data))))
 
 (defn- setup-editor [s]
   (let [options (first (:rum/args s))

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -255,6 +255,27 @@
 
 (def default-mutli-picker-button-id "entry-edit-multi-picker-bt")
 
+(defn- file-dnd-handler [s editor-ext file]
+  (if (.match (.-type file) "image")
+    (iu/upload-file! file
+      (fn [url]
+        (.insertImageFile editor-ext url)))
+    (iu/upload-file! file
+      (fn [url]
+        (let [size (gobj/get file "size")
+              mimetype (gobj/get file "type")
+              filename (gobj/get file "name")
+              createdat (utils/js-date)
+              prefix (str "Uploaded by " (jwt/get-key :name) " on " (utils/date-string createdat [:year]) " - ")
+              subtitle (str prefix (filesize size :binary false :format "%.2f" ))
+              icon (au/icon-for-mimetype mimetype)
+              attachment-data {:file-name filename
+                               :file-type mimetype
+                               :file-size size
+                               :file-url url}
+              dispatch-input-key (:dispatch-input-key (first (:rum/args s)))]
+          (activity-actions/add-attachment dispatch-input-key attachment-data))))))
+
 (defn- setup-editor [s]
   (let [options (first (:rum/args s))
         mobile-editor (responsive/is-tablet-or-mobile?)
@@ -266,18 +287,23 @@
                            :saveSelectionClickElementId default-mutli-picker-button-id
                            :delegateMethods #js {:onPickerClick (partial on-picker-click s)
                                                  :willExpand #(reset! (::did-change s) true)}}
-        media-picker-ext (js/MediaPicker. (clj->js media-picker-opts))
+        media-picker-ext (when-not mobile-editor (js/MediaPicker. (clj->js media-picker-opts)))
+        file-dragging-ext (when-not mobile-editor (js/MyFileDragging. (clj->js {:uploadHandler (partial file-dnd-handler s)})))
         buttons (if show-subtitle
                   ["bold" "italic" "h2" "unorderedlist" "anchor"]
                   ["bold" "italic" "unorderedlist" "anchor"])
         extensions (if mobile-editor
                       #js {"autolist" (js/AutoList.)}
                       #js {"autolist" (js/AutoList.)
-                           "media-picker" media-picker-ext})
+                           "media-picker" media-picker-ext
+                           "fileDragging" false
+                           "imageDragging" false
+                           "myFileDragging" file-dragging-ext})
         options {:toolbar (if mobile-editor false #js {:buttons (clj->js buttons)})
                  :buttonLabels "fontawesome"
                  :anchorPreview (if mobile-editor false #js {:hideDelay 500, :previewValueSelector "a"})
                  :extensions extensions
+                 :targetBlank true
                  :autoLink true
                  :anchor #js {:customClassOption nil
                               :customClassOptionText "Button"

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -260,7 +260,7 @@
     (if (.match (.-type file) "image")
       (iu/upload-file! file
         (fn [url]
-          (.insertImageFile editor-ext url)))
+          (.insertImageFile editor-ext file url nil)))
       (iu/upload-file! file
         (fn [url]
           (let [size (gobj/get file "size")
@@ -305,12 +305,12 @@
                       #js {"autolist" (js/AutoList.)
                            "media-picker" media-picker-ext
                            "fileDragging" false
-                           "imageDragging" false
                            "myFileDragging" file-dragging-ext})
         options {:toolbar (if mobile-editor false #js {:buttons (clj->js buttons)})
                  :buttonLabels "fontawesome"
                  :anchorPreview (if mobile-editor false #js {:hideDelay 500, :previewValueSelector "a"})
                  :extensions extensions
+                 :imageDragging false
                  :targetBlank true
                  :autoLink true
                  :anchor #js {:customClassOption nil

--- a/src/oc/web/lib/image_upload.cljs
+++ b/src/oc/web/lib/image_upload.cljs
@@ -62,6 +62,20 @@
           (when (= (count files-uploaded)1)
             (success-cb (get files-uploaded 0))))))))
 
+(defn upload-file! [file success-cb & [error-cb]]
+  (try
+    (let [fs-client (init-filestack)]
+      (.then
+        (.upload fs-client file #js {})
+        (fn [res]
+          (let [url (gobj/get res "url")]
+            (when (fn? success-cb)
+              (success-cb url))))))
+    (catch :default e
+      (sentry/capture-error e)
+      (when (fn? error-cb)
+        (error-cb e)))))
+
 (defn thumbnail! [fs-url & [success-cb progress-cb error-cb]]
   (let [fs-client (init-filestack)
         opts (clj->js {:resize {

--- a/src/oc/web/utils/comment.cljs
+++ b/src/oc/web/utils/comment.cljs
@@ -8,9 +8,11 @@
 (defn setup-medium-editor [comment-node]
   (let [config {:toolbar false
                 :anchorPreview false
+                :imageDragging false
                 :extensions #js []
                 :autoLink true
                 :anchor false
+                :targetBlank true
                 :paste #js {:forcePlainText true}
                 :placeholder #js {:text "Share your thoughts..."
                                   :hideOnClick true}


### PR DESCRIPTION
MediumEditor natively support drag and drop but it supports only images and they are added with inline base64 source.

This breaks our backend since makes the blob too big and also lose all the other files type.

This adds an extension to handle the d&d starting from MediumEditor native dnd but it upload the file to Filestack and then add the file as attachment if it's not an image, or put it in the body HTML if it's an image.

For image it means every file that has mimetype that match "image", meaning "image/png", "image/jpg" etc...

To test:
- compose
- dnd an image in the filed
- inspect the added image
- [ ] do you see the IMG tag? Good
- [ ] does it have a src linked to cdn.filestackcontent.com? Good
- [ ] does it has class, width and height attributes set? Good
- now dnd another type of file (txt, html, csv etc..) in the body
- [ ] do you see it being added as an attachment at the bottom? Good
- [ ] does it have name and size? Good
- now try to dnd a file bigger then 5MB (if you can't you can lower the size at line 259 of oc.web.components.rich-body-editor)
- [ ] do you see an error message? Good