### PR TITLE
Add comments on public section

### DIFF
--- a/scss/partials/_fullscreen_post.scss
+++ b/scss/partials/_fullscreen_post.scss
@@ -211,7 +211,7 @@ div.fullscreen-post-container {
     }
   }
 
-  &.editing {
+  &.editing, &.no-comments {
     div.fullscreen-post {
       div.fullscreen-post-left-column {
         left: 170px;

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -297,13 +297,16 @@
         editing (:modal-editing modal-data)
         activity-editing (:modal-editing-data modal-data)
         activity-attachments (if editing (:attachments activity-editing) (:attachments activity-data))
-        show-sections-picker (and editing (:show-sections-picker modal-data))]
+        show-sections-picker (and editing (:show-sections-picker modal-data))
+        comments-link (utils/link-for (:links activity-data) "comments")
+        add-comment-link (utils/link-for (:links activity-data) "create" "POST")]
     [:div.fullscreen-post-container.group
       {:class (utils/class-set {:will-appear (or @(::dismiss s)
                                                  (and @(::animate s)
                                                       (not @(:first-render-done s))))
                                 :appear (and (not @(::dismiss s)) @(:first-render-done s))
-                                :editing editing})}
+                                :editing editing
+                                :no-comments (not comments-link)})}
       [:div.fullscreen-post-header
         [:button.mlb-reset.mobile-modal-close-bt
           {:on-click #(if editing
@@ -425,14 +428,16 @@
                       [:div.fullscreen-post-box-footer-legend-image])]]
                 (reactions activity-data))]]]
         ;; Right column
-        (let [activity-comments (-> modal-data
-                                    :comments-data
-                                    (get (:uuid activity-data))
-                                    :sorted-comments)
-              comments-data (or activity-comments (:comments activity-data))]
-          [:div.fullscreen-post-right-column.group
-            {:class (utils/class-set {:add-comment-focused (:add-comment-focus modal-data)
-                                      :no-comments (zero? (count comments-data))})
-             :style {:right (when-not is-mobile? (str (/ (- (.-clientWidth (.-body js/document)) 1060) 2) "px"))}}
-            (add-comment activity-data)
-            (stream-comments activity-data comments-data)])]]))
+        (when comments-link
+          (let [activity-comments (-> modal-data
+                                      :comments-data
+                                      (get (:uuid activity-data))
+                                      :sorted-comments)
+                comments-data (or activity-comments (:comments activity-data))]
+            [:div.fullscreen-post-right-column.group
+              {:class (utils/class-set {:add-comment-focused (:add-comment-focus modal-data)
+                                        :no-comments (zero? (count comments-data))})
+               :style {:right (when-not is-mobile? (str (/ (- (.-clientWidth (.-body js/document)) 1060) 2) "px"))}}
+              (when add-comment-link
+                (add-comment activity-data))
+              (stream-comments activity-data comments-data)]))]]))

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -297,16 +297,14 @@
         editing (:modal-editing modal-data)
         activity-editing (:modal-editing-data modal-data)
         activity-attachments (if editing (:attachments activity-editing) (:attachments activity-data))
-        show-sections-picker (and editing (:show-sections-picker modal-data))
-        comments-link (utils/link-for (:links activity-data) "comments")
-        add-comment-link (utils/link-for (:links activity-data) "create" "POST")]
+        show-sections-picker (and editing (:show-sections-picker modal-data))]
     [:div.fullscreen-post-container.group
       {:class (utils/class-set {:will-appear (or @(::dismiss s)
                                                  (and @(::animate s)
                                                       (not @(:first-render-done s))))
                                 :appear (and (not @(::dismiss s)) @(:first-render-done s))
                                 :editing editing
-                                :no-comments (not comments-link)})}
+                                :no-comments (not (:has-comments activity-data))})}
       [:div.fullscreen-post-header
         [:button.mlb-reset.mobile-modal-close-bt
           {:on-click #(if editing
@@ -428,7 +426,7 @@
                       [:div.fullscreen-post-box-footer-legend-image])]]
                 (reactions activity-data))]]]
         ;; Right column
-        (when comments-link
+        (when (:has-comments activity-data)
           (let [activity-comments (-> modal-data
                                       :comments-data
                                       (get (:uuid activity-data))
@@ -438,6 +436,6 @@
               {:class (utils/class-set {:add-comment-focused (:add-comment-focus modal-data)
                                         :no-comments (zero? (count comments-data))})
                :style {:right (when-not is-mobile? (str (/ (- (.-clientWidth (.-body js/document)) 1060) 2) "px"))}}
-              (when add-comment-link
+              (when (:can-comment activity-data)
                 (add-comment activity-data))
               (stream-comments activity-data comments-data)]))]]))

--- a/src/oc/web/components/stream_view_item.cljs
+++ b/src/oc/web/components/stream_view_item.cljs
@@ -64,9 +64,7 @@
                               (get (:uuid activity-data))
                               :sorted-comments)
                           (:comments activity-data))
-        activity-attachments (:attachments activity-data)
-        comments-link (utils/link-for (:links activity-data) "comments")
-        add-comment-link (utils/link-for (:links activity-data) "create" "POST")]
+        activity-attachments (:attachments activity-data)]
     [:div.stream-view-item
       {:class (utils/class-set {(str "stream-view-item-" (:uuid activity-data)) true
                                 :expanded expanded?})}
@@ -124,19 +122,19 @@
               (when-not (zero? (count comments-data))
                 (comments-summary activity-data false))])
           (when (and is-mobile?
-                     comments-link
+                     (:has-comments activity-data)
                      @(::should-show-comments s))
             [:div.stream-mobile-comments
               {:class (when (drv/react s :add-comment-focus) "add-comment-expanded")}
-              (when add-comment-link
+              (when (:can-comment activity-data)
                 (rum/with-key (add-comment activity-data) (str "add-comment-mobile-" (:uuid activity-data))))
               (stream-comments activity-data comments-data)])]
         (when (and (not is-mobile?)
-                   comments-link)
+                   (:has-comments activity-data))
           [:div.stream-body-right
             {:class (when expanded? "expanded")}
             [:div.stream-body-comments
               {:class (when (drv/react s :add-comment-focus) "add-comment-expanded")}
-              (when add-comment-link
+              (when (:can-comment activity-data)
                 (rum/with-key (add-comment activity-data) (str "add-comment-" (:uuid activity-data))))
               (stream-comments activity-data comments-data)]])]]))

--- a/src/oc/web/components/stream_view_item.cljs
+++ b/src/oc/web/components/stream_view_item.cljs
@@ -65,7 +65,8 @@
                               :sorted-comments)
                           (:comments activity-data))
         activity-attachments (:attachments activity-data)
-        comment-link (utils/link-for (:links activity-data) "comments")]
+        comments-link (utils/link-for (:links activity-data) "comments")
+        add-comment-link (utils/link-for (:links activity-data) "create" "POST")]
     [:div.stream-view-item
       {:class (utils/class-set {(str "stream-view-item-" (:uuid activity-data)) true
                                 :expanded expanded?})}
@@ -123,17 +124,19 @@
               (when-not (zero? (count comments-data))
                 (comments-summary activity-data false))])
           (when (and is-mobile?
-                     comment-link
+                     comments-link
                      @(::should-show-comments s))
             [:div.stream-mobile-comments
               {:class (when (drv/react s :add-comment-focus) "add-comment-expanded")}
-              (rum/with-key (add-comment activity-data) (str "add-comment-mobile-" (:uuid activity-data)))
+              (when add-comment-link
+                (rum/with-key (add-comment activity-data) (str "add-comment-mobile-" (:uuid activity-data))))
               (stream-comments activity-data comments-data)])]
         (when (and (not is-mobile?)
-                   comment-link)
+                   comments-link)
           [:div.stream-body-right
             {:class (when expanded? "expanded")}
             [:div.stream-body-comments
               {:class (when (drv/react s :add-comment-focus) "add-comment-expanded")}
-              (rum/with-key (add-comment activity-data) (str "add-comment-" (:uuid activity-data)))
+              (when add-comment-link
+                (rum/with-key (add-comment activity-data) (str "add-comment-" (:uuid activity-data))))
               (stream-comments activity-data comments-data)]])]]))

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -177,12 +177,18 @@
 
 (defn fix-entry
   "Add `:read-only`, `:board-slug`, `:board-name` and `:content-type` keys to the entry map."
-  [entry-body board-data]
-  (-> entry-body
-    (assoc :content-type "entry")
-    (assoc :read-only (readonly-entry? (:links entry-body)))
-    (assoc :board-slug (or (:board-slug entry-body) (:slug board-data)))
-    (assoc :board-name (or (:board-name entry-body) (:name board-data)))))
+  [entry-data board-data]
+  (let [comments-link (link-for (:links entry-data) "comments")
+        add-comment-link (link-for (:links entry-data) "create" "POST")
+        fixed-board-slug (or (:board-slug entry-data) (:slug board-data))
+        fixed-board-name (or (:board-name entry-data) (:name board-data))]
+    (-> entry-data
+      (assoc :content-type "entry")
+      (assoc :read-only (readonly-entry? (:links entry-data)))
+      (assoc :board-slug fixed-board-slug)
+      (assoc :board-name fixed-board-name)
+      (assoc :has-comments (boolean comments-link))
+      (assoc :can-comment (boolean add-comment-link)))))
 
 (defn fix-board
   "Add `:read-only` and fix each entry of the board, then create a :fixed-entries map with the entry UUID."


### PR DESCRIPTION
BUG: the add comment is visible on a public board in fullscreen post view. If the user adds a comment it thrown an exception.

To test:
- login
- nav to a public section
- switch to stream view
- [x] do you see the comments? Good
- [x] do you see the add comment box? Good
- try to add a comment
- [x] worked? Good
- switch to grid view
- click on a post to enter fullscreen post
- [x] do you see the comments? Good
- [x] can you add a comment? Good
- open an anonymous window or a session not associated with this org
- go to the same public section as above
- switch to stream view
- [x] do you NOT see the comments? Good
- [x] do you NOT see the add comment box? Good
 - switch to grid view
- click on a post to enter fullscreen view
- [x] do you see the post centred? Good
- [x] do you NOT see comments? Good
- [x] do you NOT see the add comment box? Good