### PR TITLE
Update textcomplete to version 1.8.4

### DIFF
--- a/site/oc/core.clj
+++ b/site/oc/core.clj
@@ -63,7 +63,7 @@
       :type "text/javascript"
       :integrity "sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
       :crossorigin "anonymous"}]
-    ;; jQuery textcomplete needed by Emoji One autocomplete
+    ;; JWT library to decode/encode JWT
     [:script {:src "/lib/jwt_decode/jwt-decode.min.js" :type "text/javascript"}]])
 
 (defn mobile-menu

--- a/site/oc/pages.clj
+++ b/site/oc/pages.clj
@@ -861,7 +861,7 @@
           [:script {:type "text/javascript" :src "/lib/rangy/rangy-selectionsaverestore.js"}]
           ;; jQuery textcomplete needed by Emoji One autocomplete
           [:script
-            {:src "//cdnjs.cloudflare.com/ajax/libs/jquery.textcomplete/1.7.3/jquery.textcomplete.min.js"
+            {:src "//cdnjs.cloudflare.com/ajax/libs/jquery.textcomplete/1.8.4/jquery.textcomplete.min.js"
              :type "text/javascript"}]
           ;; WURFL used for mobile/tablet detection
           [:script {:type "text/javascript" :src "//wurfl.io/wurfl.js"}]
@@ -940,7 +940,7 @@
           [:script {:src (cdn "/js/static-js.js")}]
           ;; jQuery textcomplete needed by Emoji One autocomplete
           [:script
-            {:src "//cdnjs.cloudflare.com/ajax/libs/jquery.textcomplete/1.7.3/jquery.textcomplete.min.js"
+            {:src "//cdnjs.cloudflare.com/ajax/libs/jquery.textcomplete/1.8.4/jquery.textcomplete.min.js"
              :type "text/javascript"}]
           ;; WURFL used for mobile/tablet detection
           [:script {:type "text/javascript" :src "//wurfl.io/wurfl.js"}]


### PR DESCRIPTION
Sentry: https://sentry.io/opencompany/oc-beta-web/issues/517578176/

Most probably the sentry is caused by a race condition btw the user selecting an emoji from the textcomplete window and the field losing focus.
I couldn't not reproduce it but if we are lucky this issue (that is a [known issue](https://stackoverflow.com/questions/22935320/uncaught-indexsizeerror-failed-to-execute-getrangeat-on-selection-0-is-not) of Chrome and Safari) has been addressed.

To test:
- compose
- try to add an emoji using the autocomplete in the headline
- [ ] did it work? Good
- try to add an emoji using the autocomplete in the body
- [ ] did it work? Good