### PR TITLE
BUG: grid more menu is hidden

### DIFF
--- a/scss/partials/_activity_card.scss
+++ b/scss/partials/_activity_card.scss
@@ -134,7 +134,6 @@ div.activity-card {
 
     div.activity-card-head-right {
       white-space: nowrap;
-      overflow: hidden;
       max-width: #{$right_max_width}px;
 
       div.new-tag {


### PR DESCRIPTION
Card: https://trello.com/c/FkueqOrT
Item:
> Vertical ellipsis on grid view is broken

To test:
- go to AP
- switch to grid view
- click on the vertical ellipses of some posts
- [x] can you see the menus? Good
- [x] also check that a short section name label and a long section name label are visible as expected (second should be truncated with ellipses)