### PR TITLE
Sort sections by name in the section picker.

### DIFF
--- a/src/oc/web/components/ui/sections_picker.cljs
+++ b/src/oc/web/components/ui/sections_picker.cljs
@@ -24,7 +24,7 @@
         [:div.sections-picker-group-header
           (get-section-name group)])
       (when (pos? (count group))
-        (for [b group
+        (for [b (sort-by :name group)
               :let [active (= (:slug b) active-slug)]]
           [:div.sections-picker-section.group
             {:key (str "sections-picker-" (:uuid b))


### PR DESCRIPTION
Card: https://trello.com/c/FkueqOrT
Item:
> sections list grouped by access type should be in alpha order in the section picker

To test:
- use an org with a bunch of sections of different types
- Compose
- click on the section name
- [x] the sections are grouped by access type and sorted by name? Good