### PR TITLE
Fix drafts layout and truncation.

### DIFF
--- a/scss/partials/_drafts_layout.scss
+++ b/scss/partials/_drafts_layout.scss
@@ -136,11 +136,23 @@ div.drafts-layout {
             @include activity-body();
             display: block;
             line-height: 24px;
-            height: #{24*3}px;
+            height: #{24*2}px;
             overflow: hidden;
 
             &.has-body {
-              height: #{24*3}px;
+              height: #{24 * 2}px;
+            }
+
+            & > *:not(:last-child) {
+              margin: 24px 0px;
+            }
+
+            & > *:last-child {
+              margin: 24px 0px 0px;
+            }
+
+            & > *:first-child {
+              margin-top: 0px;
             }
 
             &.has-media-preview {
@@ -218,7 +230,6 @@ div.drafts-layout {
           padding: 16px;
           margin: 24px;
           height: 46px;
-          width: 382px;
           background-color: #D4F7E5;
           border-radius: 4px;
           cursor: pointer;

--- a/src/oc/web/utils/activity.cljs
+++ b/src/oc/web/utils/activity.cljs
@@ -81,11 +81,6 @@
                                   (* 24 6)
                                   :else
                                   (* 24 3))]
-           (js/console.log "   el-h" el-h)
-           (js/console.log "   container-max-height" container-max-height)
-           (js/console.log "   prev-height" prev-height)
-           (js/console.log "   actual-height" actual-height)
-           (js/console.log "   truncate-height" truncate-height)
            (swap! partial-heights #(vec (conj % el-h)))
            (when (>= actual-height container-max-height)
              (reset! found true)

--- a/src/oc/web/utils/activity.cljs
+++ b/src/oc/web/utils/activity.cljs
@@ -39,6 +39,7 @@
 
 (def default-body-height 72)
 (def default-all-posts-body-height 144)
+(def default-draft-body-height 48)
 
 (defn truncate-body
   "Given a body element truncate the body. It iterate on the elements
@@ -48,6 +49,7 @@
   [body-el]
   (reset-truncate-body body-el)
   (let [is-ap (= (router/current-board-slug) "all-posts")
+        is-drafts (= (router/current-board-slug) utils/default-drafts-board-slug)
         $body-els (js/$ ">*" body-el)
         partial-heights (atom [])
         found (atom false)]
@@ -56,9 +58,10 @@
        (this-as this
          (let [$this (js/$ this)
                el-h (.outerHeight $this true) ;; Include margins in height calculation
-               container-max-height (if is-ap
-                                     default-all-posts-body-height
-                                     default-body-height)
+               container-max-height (cond
+                                     is-ap default-all-posts-body-height
+                                     is-drafts default-draft-body-height
+                                     :else default-body-height)
                prev-height (apply + @partial-heights)
                actual-height (+ prev-height el-h)
                truncate-height  (cond
@@ -75,7 +78,14 @@
                                   (< (- container-max-height prev-height) (* 24 5))
                                   (* 24 5)
                                   (< (- container-max-height prev-height) (* 24 6))
-                                  (* 24 6))]
+                                  (* 24 6)
+                                  :else
+                                  (* 24 3))]
+           (js/console.log "   el-h" el-h)
+           (js/console.log "   container-max-height" container-max-height)
+           (js/console.log "   prev-height" prev-height)
+           (js/console.log "   actual-height" actual-height)
+           (js/console.log "   truncate-height" truncate-height)
            (swap! partial-heights #(vec (conj % el-h)))
            (when (>= actual-height container-max-height)
              (reset! found true)


### PR DESCRIPTION
Some general fixes for drafts.

To test:
- Compose
- add a long single paragraph body (at least 4 lines)
- save as draft
- refresh drafts (due to a known bug, will fix in a different PR)
- [x] do you see 2 lines of body with ... truncation at the end? Good
- [x] do you see the same margin on left and right of the green bar (footer)? Good