### PR TITLE
Fix activity url

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -57,11 +57,10 @@
            (not (utils/in? (:route @router/path) "secure-activity")))
       ;; Redirect to the first board if at least one is present
       (let [board-to (utils/get-default-board org-data)]
-        (utils/after 10
-          #(router/nav!
-             (if board-to
-               (oc-urls/board (:slug org-data) (:slug board-to))
-               (oc-urls/all-posts (:slug org-data))))))))
+        (router/nav!
+          (if board-to
+            (oc-urls/board (:slug org-data) (:slug board-to))
+            (oc-urls/all-posts (:slug org-data)))))))
   ;; Change service connection
   (when (jwt/jwt) ; only for logged in users
     (when-let [ws-link (utils/link-for (:links org-data) "changes")]

--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -42,7 +42,7 @@
   (let [is-currently-shown (is-currently-shown? section)]
     (when is-currently-shown
       (when (and (router/current-activity-id)
-                 (not (contains? (:entries section) (router/current-activity-id))))
+                 (not (some #(when (= (router/current-activity-id) (:uuid %)) %) (:entries section))))
         (router/nav! (oc-urls/board (router/current-org-slug) (:slug section))))
       ;; Tell the container service that we are seeing this board,
       ;; and update change-data to reflect that we are seeing this board


### PR DESCRIPTION
Bug: when visiting a fullscreen post url i'm redirected to the board and i need to click again on the post (in grid view) to go back to it.

To confirm the bug:
- go to beta
- switch to grid view
- click on a post
- refresh the page
- [x] are you redirected to the board url? Good, well not really

To test the fix:
- locally go to digest
- switch to grid view
- click on a post
- refresh the page
- [x] are you still looking at the fullscreen post page? Good
- go back to digest
- click on the menu of the post
- share url
- paste the url in the broser
- [x] are you redirected to the fullscreen post url and not to the board? Good