### PR TITLE
Fix invite people tooltip appear

### DIFF
--- a/src/oc/web/actions/team.cljs
+++ b/src/oc/web/actions/team.cljs
@@ -9,7 +9,8 @@
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
             [oc.web.actions.org :as org-actions]
-            [oc.web.lib.json :refer (json->cljs)]))
+            [oc.web.lib.json :refer (json->cljs)]
+            [oc.web.actions.activity :as activity-actions]))
 
 (defn roster-get [roster-link]
   (api/get-team roster-link
@@ -102,6 +103,7 @@
   (if success
     (do
       (teams-get)
+      (activity-actions/remove-invite-people-tooltip)
       (dis/dispatch! [:invite-user/success user]))
     (dis/dispatch! [:invite-user/failed user])))
 

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -189,7 +189,7 @@
         (when show-invite-people-tooltip
           [:div.invite-people-tooltip-container.group
             [:button.mlb-reset.invite-people-tooltip-dismiss
-              {:on-click #(activity-actions/hide-invite-people-tooltip)}]
+              {:on-click #(activity-actions/remove-invite-people-tooltip)}]
             [:div.invite-people-tooltip-icon]
             [:div.invite-people-tooltip-title
               "Well done on your first post!"]


### PR DESCRIPTION
Card: https://trello.com/c/qOhybzim

Wait until there are least 2 posts before showing the invite people tooltip.

To test:
- signup
- avoid inviting people
- dismiss the add post tooltip with the X
- [x] do you NOT see the invite people tooltip appear? Good
- Compose
- publish a post
- [x] do you see the invite people tooltip? Good
- click on X to dismiss the tooltip
 - [x] did it go away? Good
- refresh
 - [x] did it NOT came back? Good
- logout
- signup
- avoid inviting people
- click compose
- dismiss w/o saving the draft or publoshing
- [x] do you NOT see the invite people tooltip appear? Good
- Compose
- publish a post
- [x] do you see the invite people tooltip? Good
- logout
- signup
- avoid inviting people
- click compose
- publish a post
- [x] do you see the invite people tooltip? Good
- go to Invite People
- invite another user to the team
- [x] do you see the invite people tooltip disappear? Good
- refresh
- [x] did it NOT come back? Good