### PR TITLE
Clean underline text on body paste

### DIFF
--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -326,7 +326,7 @@
                              :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure"]
                              :unwrapTags (clj->js (remove nil? ["div" "span" "label" "font" "h1"
                                                    (when-not show-subtitle "h2") "h3" "h4" "h5"
-                                                   "h6" "strong" "section" "time" "em" "main"]))}
+                                                   "h6" "strong" "section" "time" "em" "main" "u"]))}
                  :placeholder #js {:text "What would you like to share?"
                                    :hideOnClick true}
                  :keyboardCommands #js {:commands #js [


### PR DESCRIPTION
Card: https://trello.com/c/BomxTrBK

To test:
- create a file with HTML extension
- use the content at the bottom of this PR description for the file
- open it in the browser
- copy it
- paste it in our body
- [x] do you not see any underline? Good

Before the last paragraph was keeping the underline formatting since we didn't clean U tags.

```
<html>
  <head>
    <style type="text/css">
      span.und {
        text-decoration: underline;
      }
    </style>
  </head>
  <body>
    <div>
      <p>Hello this is some text with some <span class="und">underlined text</span> in it and <a href="https://google.it">a link</a>.</p>
      <p>Some more text with <span style="text-decoration: underline;">underline set as inline style</span>.</p>
      <p>Some more text withe <u>underline with u tag</u></p>
    </div>
  </body>
</html>
```