### PR TITLE
Fix CDN urls

### DIFF
--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -444,8 +444,8 @@
       (not= (.indexOf cleaned-url "://docs.google.com/spreadsheets/d/") -1))))
 
 (defn cdn [img-src & [no-deploy-folder]]
-  (let [use-cdn? (empty? ls/cdn-url)
-        cdn (if use-cdn? "" (str "/" ls/cdn-url))
+  (let [use-cdn? (seq ls/cdn-url)
+        cdn (if use-cdn? ls/cdn-url "")
         deploy-key (if (empty? ls/deploy-key) "" (str "/" ls/deploy-key))
         with-deploy-folder (if no-deploy-folder
                              cdn

--- a/src/oc/web/stores/user.cljs
+++ b/src/oc/web/stores/user.cljs
@@ -5,12 +5,12 @@
             [oc.web.lib.cookies :as cook]
             [oc.web.lib.utils :as utils]))
 
-(def default-user-image "/img/ML/happy_face_red.svg")
+(def default-user-image "/img/ML/happy_face_red.png")
 (def other-user-images
- ["/img/ML/happy_face_green.svg"
-  "/img/ML/happy_face_blue.svg"
-  "/img/ML/happy_face_purple.svg"
-  "/img/ML/happy_face_yellow.svg"])
+ ["/img/ML/happy_face_green.png"
+  "/img/ML/happy_face_blue.png"
+  "/img/ML/happy_face_purple.png"
+  "/img/ML/happy_face_yellow.png"])
 
 (defn random-user-image []
   (first (shuffle (vec (conj other-user-images default-user-image)))))

--- a/src/oc/web/stores/user.cljs
+++ b/src/oc/web/stores/user.cljs
@@ -5,12 +5,12 @@
             [oc.web.lib.cookies :as cook]
             [oc.web.lib.utils :as utils]))
 
-(def default-user-image "/img/ML/happy_face_red.png")
+(def default-user-image "/img/ML/happy_face_red.svg")
 (def other-user-images
- ["/img/ML/happy_face_green.png"
-  "/img/ML/happy_face_blue.png"
-  "/img/ML/happy_face_purple.png"
-  "/img/ML/happy_face_yellow.png"])
+ ["/img/ML/happy_face_green.svg"
+  "/img/ML/happy_face_blue.svg"
+  "/img/ML/happy_face_purple.svg"
+  "/img/ML/happy_face_yellow.svg"])
 
 (defn random-user-image []
   (first (shuffle (vec (conj other-user-images default-user-image)))))


### PR DESCRIPTION
CDN urls are currently broken because of a bug in the function that creates the urls.

To test (on staging, locally it doesn't use the CDN):
- signup
- do not upload an avatar, use the default happy face
- go to your digest
- right click on your user avatar (top right corner) and inspect element
- [x] is it using an absolute CDN url? Good
- [x] is it an SVG image? Good