### PR TITLE
Fix user avatar default.

### DIFF
--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -154,7 +154,7 @@
                                   (rum/local nil ::temp-user-avatar)
                                   {:will-mount (fn [s]
                                     (user-actions/user-profile-reset)
-                                    (let [avatar-with-cdn (:avatar-url @(drv/get-ref s :edit-user-profile))]
+                                    (let [avatar-with-cdn (:avatar-url (:user-data @(drv/get-ref s :edit-user-profile)))]
                                       (reset! (::temp-user-avatar s) avatar-with-cdn))
                                     s)
                                    :did-mount (fn [s]
@@ -525,7 +525,7 @@
                                     (rum/local nil ::temp-user-avatar)
                                     {:will-mount (fn [s]
                                       (user-actions/user-profile-reset)
-                                      (let [avatar-with-cdn (:avatar-url @(drv/get-ref s :edit-user-profile))]
+                                      (let [avatar-with-cdn (:avatar-url (:user-data @(drv/get-ref s :edit-user-profile)))]
                                         (reset! (::temp-user-avatar s) avatar-with-cdn))
                                       s)
                                      :did-mount (fn [s]


### PR DESCRIPTION
Card: https://trello.com/c/XXAcNuw6

Test:
- go to signup
- fill in email password
- on profile step add first and last name
- now click on the user avatar and dismiss the FS picker
- [x] is the continue button at the bottom still enabled? Good
- [x] is the avatar still of the color it was initially, not red? Good (if it was red initially no need to check this)
- now upload an avatar to FS
- click again on the new uploaded avatar
- [x] is the continue button at the bottom still enabled? Good
- [x] did the avatar go back to the initial happy face color? Good