### PR TITLE
Fix compose button

### DIFF
--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -412,23 +412,29 @@ div.dashboard-layout {
               display: none;
             }
 
-            &:hover, &:active, &:focus, &.active {
-              background-color: $carrot_orange;
-              color: white;
-              opacity: 1;
-
-              div.add-to-board-pencil {
-                background-image: cdnUrl("/img/ML/add_to_board_pencil_white.svg");
-              }
-
-              label.add-to-board-label {
-                color: white;
-              }
+            &.disabled {
+              opacity: 0.4;
             }
 
-            &:active, &:focus {
-              background-color: #ED4F3B;
-              opacity: 1;
+            &:not(.disabled) {
+              &:hover, &:active, &:focus, &.active {
+                background-color: $carrot_orange;
+                color: white;
+                opacity: 1;
+
+                div.add-to-board-pencil {
+                  background-image: cdnUrl("/img/ML/add_to_board_pencil_white.svg");
+                }
+
+                label.add-to-board-label {
+                  color: white;
+                }
+              }
+
+              &:active, &:focus {
+                background-color: #ED4F3B;
+                opacity: 1;
+              }
             }
 
             div.add-to-board-pencil {

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -170,7 +170,13 @@
         drafts-link (utils/link-for (:links drafts-board) "self")
         show-drafts (pos? (:count drafts-link))
         mobile-navigation-sidebar (drv/react s :mobile-navigation-sidebar)
-        all-posts-key (str "all-posts-stream-" (clojure.string/join "-" (keys (:fixed-items all-posts-data))))]
+        all-posts-key (str "all-posts-stream-" (clojure.string/join "-" (keys (:fixed-items all-posts-data))))
+        show-compose-button (or (and (or is-all-posts
+                                         is-drafts-board)
+                                     (pos? (count all-boards)))
+                                (and (not is-all-posts)
+                                     (not is-drafts-board)
+                                     (utils/link-for (:links board-data) "create")))]
       ;; Entries list
       [:div.dashboard-layout.group
         ;; Show create new section for desktop
@@ -237,10 +243,7 @@
                        :title "Visible to the world, including search engines"}
                       "Public"])]
                 ;; Add entry button
-                (when (and (not (:read-only org-data))
-                           (or (utils/link-for (:links board-data) "create")
-                               is-drafts-board
-                               is-all-posts))
+                (when show-compose-button
                   [:div.new-post-top-dropdown-container.group
                     [:button.mlb-reset.mlb-default.add-to-board-top-button.group
                       {:on-click compose-fn}
@@ -311,10 +314,7 @@
                   :else
                   (section-stream)))
               ;; Add entry floating button
-              (when (and (not (:read-only org-data))
-                         (or (utils/link-for (:links board-data) "create")
-                             is-drafts-board
-                             is-all-posts))
+              (when show-compose-button
                 (let [opacity (if (responsive/is-tablet-or-mobile?)
                                 1
                                 (calc-opacity (document-scroll-top)))]


### PR DESCRIPTION
Card: https://trello.com/c/NFLQYd64

Show the compose button for all users that are part of the team. If the user has no write privileges on the current section show it disabled with a tooltip.

To test:
- signup to a brand new org
- [x] can see the Compose buttons? Good
- [x] can you click it and add? Good
- [x] can you NOT see a tooltip when you hover? Good
- create a public section
- add a few post
- navigate to the public section from incognito (anonymous user)
- [x] can you NOT see the compose button? Good
- go back to the logged in user
- invite a contributor
- [x] can you see the compose button with the contributor? Good
- [x] can you click it and add posts? Good
- invite a viewer
- [x] can you see the compose button with the viewer? Good
- [x] is it disabled and has no hover state? Good
- [x] do you see a tooltip when you hover it? Good
- with the first user create a private section
- add the viewer user as contributor to the private section
- visit the private section with the viewer
- [x] can you see the compose button? Good
- [x] can you click it?
- [x] do you NOT see a tooltip when you hover? Good
- now go in device mode with the viewer
- [x] do you NOT see the compose button? Good