### PR TITLE
Fix create section

### DIFF
--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -385,7 +385,8 @@
             {:on-click #(let [section-node (rum/ref-node s "section-name")
                               inner-html (.-innerHTML section-node)
                               section-name (utils/strip-HTML-tags inner-html)
-                              personal-note (.-innerText (rum/ref-node s "personal-note"))
+                              personal-note-node (rum/ref-node s "personal-note")
+                              personal-note (when personal-note-node (.-innerText personal-note-node))
                               next-section-editing (merge section-editing {:slug utils/default-section-slug
                                                                            :name section-name})]
                           (dis/dispatch! [:input [:section-editing] next-section-editing])


### PR DESCRIPTION
Card: https://trello.com/c/Bq5R7HbE

Creating a new section from the navigation menu is currently borken.

To test:
- with an admin user
- click the plus button int he nav menu
- add a new team section with a name
- [x] can you save the new section? Good
- now create a new private section
- add a user to it and a personal note
- [x] do you see the personal note? Good
- now navigate to a section
- click section settings (besides the sec name)
- edit the name and save
- [x] no errors? Good