### PR TITLE
Fix onboard drop off

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -120,7 +120,7 @@
           (org-created org-data))))
     (when (= status 409)
       ;; Redirect to the already available org
-      (router/nav! (oc-urls/org (:slug (first (:orgs @dis/app-state))))))))
+      (router/nav! (oc-urls/org (:slug (first (dis/orgs-data))))))))
 
 (defn org-create [org-data]
   (when-not (empty? (:name org-data))

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -8,6 +8,7 @@
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
             [oc.web.local_settings :as ls]
+            [oc.web.stores.user :as user-store]
             [oc.web.actions.org :as org-actions]
             [oc.web.lib.json :refer (json->cljs)]
             [oc.web.actions.team :as team-actions]
@@ -56,10 +57,10 @@
     ; Delay to let the last api request set the app-state data
     (when (jwt/jwt)
       (utils/after 100
-        #(when (and (contains? @dis/app-state :orgs)
-                    (contains? @dis/app-state (first dis/auth-settings-key))
-                    (contains? (get-in @dis/app-state dis/auth-settings-key) :status))
-            (check-user-walls (dis/auth-settings) (:orgs @dis/app-state))))))
+        #(when (and (user-store/orgs?)
+                    (user-store/auth-settings?)
+                    (user-store/auth-settings-status?))
+            (check-user-walls (dis/auth-settings) (dis/orgs-data))))))
   ([auth-settings orgs]
     (let [status-response (set (map keyword (:status auth-settings)))
           has-orgs (pos? (count orgs))]

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -66,7 +66,8 @@
       (cond
         (status-response :password-required)
         (router/nav! oc-urls/confirm-invitation-password)
-        (status-response :name-required)
+        (or (status-response :name-required)
+            (:new-slack-user @dis/app-state))
         (if has-orgs
           (router/nav! oc-urls/confirm-invitation-profile)
           (router/nav! oc-urls/sign-up-profile))

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -57,7 +57,8 @@
     (when (jwt/jwt)
       (utils/after 100
         #(when (and (contains? @dis/app-state :orgs)
-                    (contains? @dis/app-state (first dis/auth-settings-key)))
+                    (contains? @dis/app-state (first dis/auth-settings-key))
+                    (contains? (get-in @dis/app-state dis/auth-settings-key) :status))
             (check-user-walls (dis/auth-settings) (:orgs @dis/app-state))))))
   ([auth-settings orgs]
     (let [status-response (set (map keyword (:status auth-settings)))
@@ -67,7 +68,7 @@
         (router/nav! oc-urls/confirm-invitation-password)
         (status-response :name-required)
         (if has-orgs
-          (router/nav! oc-urls/confirm-invitation-profile) 
+          (router/nav! oc-urls/confirm-invitation-profile)
           (router/nav! oc-urls/sign-up-profile))
         :else
         (when-not has-orgs

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -252,8 +252,7 @@
        (fn [success body]
          (entry-point-get-finished success body
            (fn [orgs collection]
-             (if (zero? (count orgs))
-               (router/nav! oc-urls/sign-up-team)
+             (when (pos? (count orgs))
                (router/nav! (oc-urls/org (:slug (utils/get-default-org orgs))))))))))
     :else ;; Valid signup let's collect user data
     (do

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -393,19 +393,6 @@
          (fn [{:keys [status body success]}]
            (cb status body success))))))
 
-(defn collect-name-password [firstname lastname pswd cb]
-  (let [update-link (utils/link-for (:links (:current-user-data @dispatcher/app-state)) "partial-update" "PATCH")]
-    (when (and (or firstname lastname) pswd update-link)
-      (auth-http (method-for-link update-link) (relative-href update-link)
-        {:json-params {
-          :first-name firstname
-          :last-name lastname
-          :password pswd
-         }
-         :headers (headers-for-link update-link)}
-        (fn [{:keys [status body success]}]
-          (cb status body success))))))
-
 (defn add-email-domain [domain callback]
   (when domain
     (let [team-data (dispatcher/team-data)

--- a/src/oc/web/components/ui/login_overlay.cljs
+++ b/src/oc/web/components/ui/login_overlay.cljs
@@ -232,88 +232,6 @@
                    :on-touch-start identity}
                   "Cancel"]])]]]]))
 
-(rum/defcs collect-name-password < rum/reactive
-                                   dont-scroll
-                                   no-scroll-mixin
-                                   (drv/drv :auth-settings)
-                                   {:will-mount (fn [s]
-                                    (dis/dispatch! [:input [:collect-name-pswd] {:firstname "" :lastname "" :pswd ""}])
-                                    s)
-                                   :did-mount (fn [s]
-                                     ; initialise the keys to string to avoid jumps in UI focus
-                                     (utils/after 500
-                                      #(dis/dispatch!
-                                        [:input
-                                         [:collect-name-pswd]
-                                         {:firstname (or
-                                                      (:first-name (:current-user-data @dis/app-state))
-                                                      "")
-                                          :lastname (or
-                                                     (:last-name (:current-user-data @dis/app-state))
-                                                     "")
-                                          :pswd (or (:pswd (:collect-name-pswd @dis/app-state)) "")}]))
-                                     (utils/after 100 #(.focus (sel1 [:input.firstname])))
-                                     s)}
-  [state]
-  (let [auth-settings (drv/react state :auth-settings)]
-    [:div.login-overlay-container.group
-      {:on-click #(utils/event-stop %)}
-      [:div.login-overlay.collect-name-pswd.group
-        [:div.login-overlay-cta.pl2.pr2.group
-          [:div.sign-in-cta "Provide Your Name and a Password"
-            (when-not auth-settings
-              (small-loading))]]
-        [:div.pt2.pl3.pr3.pb2.group
-          (when-not (nil? (:collect-name-pswd-error (rum/react dis/app-state)))
-            [:span.small-caps.red
-              "System troubles logging in."
-              [:br]
-              "Please try again, then "
-              [:a.underline.red {:href oc-urls/contact-mail-to} "contact support"]
-              "."])
-          [:form.sign-in-form
-            [:div.sign-in-label-container
-              [:label.sign-in-label {:for "collect-name-pswd-firstname"} "Your Name"]]
-            [:div.sign-in-field-container.group
-              [:input.sign-in-field.firstname.half.left
-                {:value (:firstname (:collect-name-pswd (rum/react dis/app-state)))
-                 :id "collect-name-pswd-firstname"
-                 :on-change #(dis/dispatch! [:input [:collect-name-pswd :firstname] (.. % -target -value)])
-                 :placeholder "First name"
-                 :type "text"
-                 :tabIndex 1
-                 :name "firstname"}]
-              [:input.sign-in-field.lastname.half.right
-                {:value (:lastname (:collect-name-pswd (rum/react dis/app-state)))
-                 :id "collect-name-pswd-lastname"
-                 :on-change #(dis/dispatch! [:input [:collect-name-pswd :lastname] (.. % -target -value)])
-                 :placeholder "Last name"
-                 :type "text"
-                 :tabIndex 2
-                 :name "lastname"}]]
-            [:div.sign-in-label-container
-              [:label.sign-in-label {:for "signup-pswd"} "Password"]]
-            [:div.sign-in-field-container
-              [:input.sign-in-field.pswd
-                {:value (:pswd (:collect-name-pswd (rum/react dis/app-state)))
-                 :id "collect-name-pswd-pswd"
-                 :on-change #(dis/dispatch! [:input [:collect-name-pswd :pswd] (.. % -target -value)])
-                 :pattern ".{8,}"
-                 :placeholder "Minimum 8 characters"
-                 :type "password"
-                 :tabIndex 4
-                 :name "pswd"}]]
-            [:button.mlb-reset.mlb-default.continue
-              {:disabled (or (and (s/blank? (:firstname (:collect-name-pswd (rum/react dis/app-state))))
-                                  (s/blank? (:lastname (:collect-name-pswd (rum/react dis/app-state)))))
-                             (< (count (:pswd (:collect-name-pswd (rum/react dis/app-state)))) 8))
-               :on-touch-start identity
-               :on-click #(do
-                            (utils/event-stop %)
-                            (user-actions/name-password-collect
-                              (:collect-name-pswd @dis/app-state)))}
-              "Let Me In"]]]]]))
-
 (rum/defcs collect-password < rum/reactive
                               dont-scroll
                               no-scroll-mixin
@@ -387,9 +305,6 @@
     ; password reset
     (= (drv/react s user-store/show-login-overlay-key) :password-reset)
     (password-reset)
-    ; form to collect name and password
-    (= (drv/react s user-store/show-login-overlay-key) :collect-name-password)
-    (collect-name-password)
     ; form to insert a new password
     (= (drv/react s user-store/show-login-overlay-key) :collect-password)
     (collect-password)

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -462,19 +462,61 @@
               {:on-click #(org-actions/org-redirect org-data)}
               "Skip for now"]]]]]))
 
+(defn dots-animation [s]
+  (when-let [dots-node (rum/ref-node s :dots)]
+    (let [dots (.-innerText dots-node)
+          next-dots (case dots
+                      "." ".."
+                      ".." "..."
+                      ".")]
+      (set! (.-innerText dots-node) next-dots)
+      (utils/after 800 #(dots-animation s)))))
+
+(defn confirm-invitation-when-ready [s]
+  (let [confirm-invitation @(drv/get-ref s :confirm-invitation)]
+    (when (and (:auth-settings confirm-invitation)
+               (not @(::exchange-started s)))
+      (reset! (::exchange-started s) true)
+      (user-actions/confirm-invitation (:token confirm-invitation)))))
+
 (rum/defcs invitee-lander < rum/reactive
                             (drv/drv :confirm-invitation)
-                            (rum/local false ::password-error)
-                            {:did-mount (fn [s]
-                              (delay-focus-field-with-ref s "password")
+                            (rum/local false ::exchange-started)
+                            {:will-mount (fn [s]
+                              (confirm-invitation-when-ready s)
+                              s)
+                             :did-mount (fn [s]
+                              (dots-animation s)
+                              (confirm-invitation-when-ready s)
+                              s)
+                             :did-update (fn [s]
+                              (confirm-invitation-when-ready s)
                               s)}
   [s]
-  (let [confirm-invitation (drv/react s :confirm-invitation)
-        jwt (:jwt confirm-invitation)
-        collect-pswd (:collect-pswd confirm-invitation)
-        collect-pswd-error (:collect-pswd-error confirm-invitation)
-        invitation-confirmed (:invitation-confirmed confirm-invitation)]
+  (let [confirm-invitation (drv/react s :confirm-invitation)]
     [:div.onboard-lander.invitee-lander
+      [:div.main-cta
+        [:div.title
+          "Join your team on Carrot"]
+        (if (:invitation-error confirm-invitation)
+          [:div.subtitle
+            "An error occurred while confirming your invitation, please try again."]
+          [:div.subtitle
+            "Please wait" [:span.dots {:ref :dots} "."]])]]))
+
+(rum/defcs invitee-lander-password < rum/reactive
+                                     (drv/drv :collect-password)
+                                     (rum/local false ::password-error)
+                                     {:did-mount (fn [s]
+                                       (delay-focus-field-with-ref s "password")
+                                       s)}
+  [s]
+  (let [collect-password (drv/react s :collect-password)
+        jwt (:jwt collect-password)
+        collect-pswd (:collect-pswd collect-password)
+        collect-pswd-error (:collect-pswd-error collect-password)
+        invitation-confirmed (:invitation-confirmed collect-password)]
+    [:div.onboard-lander.invitee-lander-password
       [:div.main-cta
         [:div.title
           "Join your team on Carrot"]
@@ -633,16 +675,6 @@
       (reset! (::exchange-started s) true)
       (user-actions/auth-with-token :email-verification))))
 
-(defn dots-animation [s]
-  (when-let [dots-node (rum/ref-node s :dots)]
-    (let [dots (.-innerText dots-node)
-          next-dots (case dots
-                      "." ".."
-                      ".." "..."
-                      ".")]
-      (set! (.-innerText dots-node) next-dots)
-      (utils/after 800 #(dots-animation s)))))
-
 (rum/defcs email-verified < rum/reactive
                             (drv/drv :email-verification)
                             (drv/drv :orgs)
@@ -731,6 +763,7 @@
     :lander-team (lander-team)
     :lander-invite (lander-invite)
     :invitee-lander (invitee-lander)
+    :invitee-lander-password (invitee-lander-password)
     :invitee-lander-profile (invitee-lander-profile)
     :email-wall (email-wall)
     :email-verified (email-verified)

--- a/src/oc/web/components/ui/org_settings_main_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_main_panel.cljs
@@ -207,7 +207,7 @@
                  :value (:domain um-domain-invite)
                  :pattern "@?[a-z0-9.-]+\\.[a-z]{2,4}$"
                  :on-change #(dis/dispatch! [:input [:um-domain-invite :domain] (.. % -target -value)])
-                 :placeholder "Domain, e.g. @amc.com"}]]
+                 :placeholder "Domain, e.g. @acme.com"}]]
             [:button.mlb-reset.mlb-default.add-email-domain-bt
               {:on-click #(let [domain (:domain um-domain-invite)]
                             (if (utils/valid-domain? domain)

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -131,12 +131,7 @@
                      (nil? (dis/org-data))))
         (user-actions/entry-point-get (router/current-org-slug)))
       (when (> (- now latest-auth-settings) reload-time)
-        (user-actions/auth-settings-get
-          #(when (and (utils/in? (:route @router/path) "confirm-invitation")
-                      (contains? (:query-params @router/path) :token))
-             (utils/after 100 (fn []
-               (user-actions/confirm-invitation
-                (:token (:query-params @router/path))))))))))))
+        (user-actions/auth-settings-get))))))
 
 ;; home
 (defn home-handler [target params]
@@ -405,6 +400,12 @@
         (cook/remove-cookie! :show-login-overlay))
       (simple-handler #(onboard-wrapper :invitee-lander) "confirm-invitation" target params))
 
+    (defroute confirm-invitation-password-route urls/confirm-invitation-password {:as params}
+      (timbre/info "Routing confirm-invitation-password-route" urls/confirm-invitation-password)
+      (when-not (jwt/jwt)
+        (router/redirect! urls/home))
+      (simple-handler #(onboard-wrapper :invitee-lander-password) "confirm-invitation" target params))
+
     (defroute confirm-invitation-profile-route urls/confirm-invitation-profile {:as params}
       (timbre/info "Routing confirm-invitation-profile-route" urls/confirm-invitation-profile)
       (when-not (jwt/jwt)
@@ -525,6 +526,7 @@
                                  logout-route
                                  email-confirmation-route
                                  confirm-invitation-route
+                                 confirm-invitation-password-route
                                  confirm-invitation-profile-route
                                  password-reset-route
                                  ;  ; subscription-callback-route

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -110,6 +110,8 @@
   (check-get-params query-params)
   (when should-rewrite-url
     (rewrite-url rewrite-params))
+  (when (= (:new query-params) "true")
+    (swap! dis/app-state assoc :new-slack-user true))
   (inject-loading))
 
 (defn post-routing []

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -240,7 +240,15 @@
                               (-> navbar-data
                                 (assoc :org-data org-data)
                                 (assoc :board-data board-data))))]
-   :confirm-invitation    [[:base :jwt]
+   :confirm-invitation    [[:base :route :auth-settings :jwt]
+                            (fn [base route auth-settings jwt]
+                              {:invitation-confirmed (:email-confirmed base)
+                               :invitation-error (and (contains? base :email-confirmed)
+                                                      (not (:email-confirmed base)))
+                               :auth-settings auth-settings
+                               :token (:token (:query-params route))
+                               :jwt jwt})]
+   :collect-password      [[:base :jwt]
                             (fn [base jwt]
                               {:invitation-confirmed (:email-confirmed base)
                                :collect-pswd (:collect-pswd base)

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -13,6 +13,8 @@
 
 (def auth-settings-key [:auth-settings])
 
+(def orgs-key :orgs)
+
 (defn org-key [org-slug]
   [(keyword org-slug)])
 
@@ -79,7 +81,7 @@
 (defn drv-spec [db route-db]
   {:base                [[] db]
    :route               [[] route-db]
-   :orgs                [[:base] (fn [base] (:orgs base))]
+   :orgs                [[:base] (fn [base] (get base orgs-key))]
    :org-slug            [[:route] (fn [route] (:org route))]
    :nux                 [[:base] (fn [base] (:nux base))]
    :board-slug          [[:route] (fn [route] (:board route))]
@@ -322,6 +324,10 @@
   "Get the API entry point."
   ([] (api-entry-point @app-state))
   ([data] (get-in data api-entry-point-key)))
+
+(defn orgs-data
+  ([] (orgs-data @app-state))
+  ([data] (get data orgs-key)))
 
 (defn org-data
   "Get org data."

--- a/src/oc/web/stores/user.cljs
+++ b/src/oc/web/stores/user.cljs
@@ -151,20 +151,6 @@
   [db [_ jwt]]
   (assoc db :email-verification-success true))
 
-(defmethod dispatcher/action :name-pswd-collect
-  [db [_]]
-  (dissoc db :latest-entry-point :latest-auth-settings))
-
-(defmethod dispatcher/action :name-pswd-collect/finish
-  [db [_ status user-data]]
-  (if (and status
-           (>= status 200)
-           (<= status 299))
-    (do
-      (cook/remove-cookie! :show-login-overlay)
-      (dissoc (update-user-data db user-data) :show-login-overlay))
-    (assoc db :collect-name-password-error status)))
-
 (defmethod dispatcher/action :pswd-collect
   [db [_ password-reset?]]
   (-> db

--- a/src/oc/web/stores/user.cljs
+++ b/src/oc/web/stores/user.cljs
@@ -35,7 +35,11 @@
 
 ;; Auth Settings
 (defn auth-settings? []
-  (contains? @dispatcher/app-state :auth-settings))
+  (contains? @dispatcher/app-state (first dispatcher/auth-settings-key)))
+
+(defn auth-settings-status? []
+  (and (auth-settings?)
+       (contains? (dispatcher/auth-settings) :status)))
 
 (defmethod dispatcher/action :auth-settings
   [db [_ body]]
@@ -212,13 +216,16 @@
   [db _]
   (dissoc db :jwt :latest-entry-point :latest-auth-settings))
 
+(defn orgs? []
+  (contains? @dispatcher/app-state dispatcher/orgs-key))
+
 ;; API entry point
 (defmethod dispatcher/action :entry-point
   [db [_ orgs collection]]
   (-> db
       (assoc :latest-entry-point (.getTime (js/Date.)))
       (dissoc :loading)
-      (assoc :orgs orgs)
+      (assoc dispatcher/orgs-key orgs)
       (assoc-in dispatcher/api-entry-point-key (:links collection))
       (dissoc :slack-lander-check-team-redirect :email-lander-check-team-redirect)))
 

--- a/src/oc/web/stores/user.cljs
+++ b/src/oc/web/stores/user.cljs
@@ -179,8 +179,12 @@
 (defmethod dispatcher/action :user-profile-save
   [db [_]]
   (-> db
+      ;; Loading user data
       (assoc-in [:edit-user-profile :loading] true)
-      (dissoc :latest-entry-point :latest-auth-settings)))
+      ;; Force a refresh of entry-point and auth-settings
+      (dissoc :latest-entry-point :latest-auth-settings)
+      ;; Remove the new-slack-user flag to avoid redirecting to the profile again
+      (dissoc :new-slack-user)))
 
 (defmethod dispatcher/action :user-profile-update/failed
   [db [_]]

--- a/src/oc/web/urls.cljs
+++ b/src/oc/web/urls.cljs
@@ -63,6 +63,7 @@
 (def email-confirmation "/verify")
 
 (def confirm-invitation "/invite")
+(def confirm-invitation-password "/invite/password")
 (def confirm-invitation-profile "/invite/profile")
 
 (def password-reset "/reset")


### PR DESCRIPTION
Card: https://trello.com/c/p2grDSbd

Add a `status` key to the auth settings response when the user is logged in that contains an array of the following elements: `:password-required`, `:name-required`. It's used in conjunction with the storage entry point load to understand if the current user needs to be redirected to one of onboard/invitee flow because he dropped off.

The problem Stuart found was this: while accepting an invitation he abandoned the flow before filling in the first/last name so the post action was broken because the user had no name. Also another similar issue is this: close the window while onboarding at the profile setup step or the org setup step.
With this now you should be redirected to the onboard/invtee step that you left off.

This also should fix the issue of a user that abandon the signup/invitee flow before finishing setup his user or org.

Related orgs:
- https://github.com/open-company/open-company-storage/pull/122
- https://github.com/open-company/open-company-auth/pull/38

More accurate test steps are described here: https://beta.carrot.io/carrot/post/c5f5-4a57-83ba

To test:
- signup with email/password
- on the second step (user profile setup) open another window
- navigate to our homepage (localhost:3559 or staging.carrot.io)
- [x] are you redirected to the profile setup step? Good
- fill the user name and proceed
- on the third step (team setup) open another window
- navigate to our homepage (localhost:3559 or staging.carrot.io)
- [x] are you redirected to the team setup step? Good
- fill the team data and proceed
- invite another user from onboard
- accept the invitation in a new session
- before setting you password close the window
- open another window in the same session and go to the homepage
- [x] are you redirected to the password collect step for invitee flow? Good
- fill in your password
- before adding your name/avatar close the window and open another again at homepage
- [x] are you redirected to the user name collect step for invitee flow? Good
- now do forgot password for one the users to make sure it still works
- [x] did it work? Good
- signup with slack
- invite someone from the slack org
- accept invitation
- [x] everything fine? Good
- add an email domain you can receive emails to
- signup with an email of that domain
- [x] do you get the email wall? Good
- go to your email and click the email verification link
- [x] could you get in? Everything fine? Good
