### PR TITLE
Add more tags to unwrap when pasting in.

### DIFF
--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -323,7 +323,7 @@
                  :paste #js {:forcePlainText false
                              :cleanPastedHTML true
                              :cleanAttrs #js ["class" "style" "alt" "dir" "size" "face" "color" "itemprop" "name" "id"]
-                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input"]
+                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input" "textarea" "abbr"]
                              :unwrapTags (clj->js (remove nil? ["div" "span" "label" "font" "h1"
                                                    (when-not show-subtitle "h2") "h3" "h4" "h5"
                                                    "h6" "strong" "section" "time" "em" "main" "u" "form" "header" "footer"

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -323,10 +323,11 @@
                  :paste #js {:forcePlainText false
                              :cleanPastedHTML true
                              :cleanAttrs #js ["class" "style" "alt" "dir" "size" "face" "color" "itemprop" "name" "id"]
-                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure"]
+                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input"]
                              :unwrapTags (clj->js (remove nil? ["div" "span" "label" "font" "h1"
                                                    (when-not show-subtitle "h2") "h3" "h4" "h5"
-                                                   "h6" "strong" "section" "time" "em" "main" "u"]))}
+                                                   "h6" "strong" "section" "time" "em" "main" "u" "form" "header" "footer"
+                                                   "details" "summary" "nav"]))}
                  :placeholder #js {:text "What would you like to share?"
                                    :hideOnClick true}
                  :keyboardCommands #js {:commands #js [

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -323,11 +323,11 @@
                  :paste #js {:forcePlainText false
                              :cleanPastedHTML true
                              :cleanAttrs #js ["class" "style" "alt" "dir" "size" "face" "color" "itemprop" "name" "id"]
-                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input" "textarea" "abbr"]
+                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input" "textarea"]
                              :unwrapTags (clj->js (remove nil? ["div" "span" "label" "font" "h1"
                                                    (when-not show-subtitle "h2") "h3" "h4" "h5"
                                                    "h6" "strong" "section" "time" "em" "main" "u" "form" "header" "footer"
-                                                   "details" "summary" "nav"]))}
+                                                   "details" "summary" "nav" "abbr"]))}
                  :placeholder #js {:text "What would you like to share?"
                                    :hideOnClick true}
                  :keyboardCommands #js {:commands #js [


### PR DESCRIPTION
No related card.

Trying to debug this https://sentry.io/opencompany/oc-beta-web/issues/514098229/ i tried copying and pasting a github page our medium editor. I found out that we keep a lot of tags that we don't need.

Also i'm waiting a reply on this issue https://github.com/yabwe/medium-editor/issues/1444 to know what's the best way to clean data attributes from the pasted code.

To test:
- select all the text of this page
- copy it
- paste it in our body field
- [ ] do you NOT see unwanted tags: section, footer, header, figure etc...? Good