### PR TITLE
Comment edit delete

### DIFF
--- a/resources/public/img/ML/horizontal_ellipsis.svg
+++ b/resources/public/img/ML/horizontal_ellipsis.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20px" height="4px" viewBox="0 0 20 4" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 49.3 (51167) - http://www.bohemiancoding.com/sketch -->
+    <title>Combined Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Redlines" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Comment-box-states" transform="translate(-758.000000, -495.000000)" fill="#C4C6C9">
+            <g id="Group-2" transform="translate(129.000000, 470.000000)">
+                <path d="M639,21 C637.895431,21 637,20.1045695 637,19 C637,17.8954305 637.895431,17 639,17 C640.104569,17 641,17.8954305 641,19 C641,20.1045695 640.104569,21 639,21 Z M639,29 C637.895431,29 637,28.1045695 637,27 C637,25.8954305 637.895431,25 639,25 C640.104569,25 641,25.8954305 641,27 C641,28.1045695 640.104569,29 639,29 Z M639,37 C637.895431,37 637,36.1045695 637,35 C637,33.8954305 637.895431,33 639,33 C640.104569,33 641,33.8954305 641,35 C641,36.1045695 640.104569,37 639,37 Z" id="Combined-Shape" transform="translate(639.000000, 27.000000) rotate(90.000000) translate(-639.000000, -27.000000) "></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources/public/img/ML/horizontal_ellipsis_ui_grey.svg
+++ b/resources/public/img/ML/horizontal_ellipsis_ui_grey.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20px" height="4px" viewBox="0 0 20 4" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 49.3 (51167) - http://www.bohemiancoding.com/sketch -->
+    <title>Combined Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Redlines" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Comment-box-states" transform="translate(-758.000000, -495.000000)" fill="#898D93">
+            <g id="Group-2" transform="translate(129.000000, 470.000000)">
+                <path d="M639,21 C637.895431,21 637,20.1045695 637,19 C637,17.8954305 637.895431,17 639,17 C640.104569,17 641,17.8954305 641,19 C641,20.1045695 640.104569,21 639,21 Z M639,29 C637.895431,29 637,28.1045695 637,27 C637,25.8954305 637.895431,25 639,25 C640.104569,25 641,25.8954305 641,27 C641,28.1045695 640.104569,29 639,29 Z M639,37 C637.895431,37 637,36.1045695 637,35 C637,33.8954305 637.895431,33 639,33 C640.104569,33 641,33.8954305 641,35 C641,36.1045695 640.104569,37 639,37 Z" id="Combined-Shape" transform="translate(639.000000, 27.000000) rotate(90.000000) translate(-639.000000, -27.000000) "></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/scss/partials/_stream_comments.scss
+++ b/scss/partials/_stream_comments.scss
@@ -132,6 +132,7 @@ div.stream-comments {
       }
 
       div.stream-comment-footer {
+        height: 25px;
 
         div.stream-comment-reaction {
           padding-top: 8px;
@@ -183,6 +184,86 @@ div.stream-comments {
             float: left;
             margin-left: 6px;
             margin-top: 2px;
+          }
+        }
+
+        div.stream-comment-more-menu-container {
+          float: right;
+          position: relative;
+
+          button.comment-more-menu {
+            width: 24px;
+            height: 26px;
+            padding: 2px 10px;
+            display: block;
+            background-image: cdnUrl("/img/ML/vertical_ellipsis.svg");
+            background-position: center;
+            background-size: 4px 20px;
+            background-repeat: no-repeat;
+            opacity: 0.8;
+
+            &:hover {
+              opacity: 1;
+            }
+
+            &:hover, &.active {
+              background-image: cdnUrl("/img/ML/vertical_ellipsis_deep_navy.svg");
+            }
+          }
+
+          div.stream-comment-more-menu {
+            position: absolute;
+            bottom: 24px;
+            left: calc(100% - 136px);
+            background-color: white;
+            width: 136px;
+            background-color: white;
+            border: 1px solid $deep_tan;
+            box-shadow: 0 2px 4px 1px rgba(0,0,0,0.10);
+            outline: none;
+            z-index: 110;
+            border-radius: 5px;
+            margin: 0;
+            padding: 24px;
+
+            div.stream-comment-more-menu-item {
+              height: 18px;
+              @include avenir_H();
+              font-size: 14px;
+              color: $deep_navy;
+              cursor: pointer;
+              padding-left: 32px;
+              position: relative;
+              margin-top: 16px;
+
+              &:before {
+                content: "";
+                position: absolute;
+                top: 0px;
+                left: 0px;
+                width: 18px;
+                height: 18px;
+                background-repeat: no-repeat;
+                background-size: 18px 18px;
+                background-position: center;
+              }
+
+              &:first-child {
+                margin-top: 0px;
+              }
+
+              &.edit {
+                &:before {
+                  background-image: cdnUrl("/img/ML/more_menu_edit.svg");
+                }
+              }
+
+              &.delete {
+                &:before {
+                  background-image: cdnUrl("/img/ML/more_menu_delete.svg");
+                } 
+              }
+            }
           }
         }
       }

--- a/scss/partials/_stream_comments.scss
+++ b/scss/partials/_stream_comments.scss
@@ -95,6 +95,86 @@ div.stream-comments {
             opacity: 0.5;
           }
         }
+
+        div.stream-comment-more-menu-container {
+          float: right;
+          position: relative;
+
+          button.comment-more-menu {
+            width: 24px;
+            height: 26px;
+            padding: 2px 2px 16px 2px;
+            display: block;
+            background-image: cdnUrl("/img/ML/horizontal_ellipsis.svg");
+            background-position: 50% 4px;
+            background-size: 20px 4px;
+            background-repeat: no-repeat;
+            opacity: 0.8;
+
+            &:hover {
+              opacity: 1;
+            }
+
+            &:hover, &.active {
+              background-image: cdnUrl("/img/ML/horizontal_ellipsis_ui_grey.svg");
+            }
+          }
+
+          div.stream-comment-more-menu {
+            position: absolute;
+            top: -8px;
+            left: calc(100% - 164px);
+            background-color: white;
+            width: 136px;
+            background-color: white;
+            border: 1px solid $deep_tan;
+            box-shadow: 0 2px 4px 1px rgba(0,0,0,0.10);
+            outline: none;
+            z-index: 110;
+            border-radius: 5px;
+            margin: 0;
+            padding: 24px;
+
+            div.stream-comment-more-menu-item {
+              height: 18px;
+              @include avenir_H();
+              font-size: 14px;
+              color: $deep_navy;
+              cursor: pointer;
+              padding-left: 32px;
+              position: relative;
+              margin-top: 16px;
+
+              &:before {
+                content: "";
+                position: absolute;
+                top: 0px;
+                left: 0px;
+                width: 18px;
+                height: 18px;
+                background-repeat: no-repeat;
+                background-size: 18px 18px;
+                background-position: center;
+              }
+
+              &:first-child {
+                margin-top: 0px;
+              }
+
+              &.edit {
+                &:before {
+                  background-image: cdnUrl("/img/ML/more_menu_edit.svg");
+                }
+              }
+
+              &.delete {
+                &:before {
+                  background-image: cdnUrl("/img/ML/more_menu_delete.svg");
+                }
+              }
+            }
+          }
+        }
       }
 
       div.stream-comment-content {
@@ -107,6 +187,14 @@ div.stream-comments {
           color: $deep_navy;
           white-space: pre-wrap;
           word-wrap: break-word;
+
+          &.medium-editor-element {
+            // editing comment
+            border-radius: 4px;
+            border: 1px solid $ui_grey;
+            outline: none;
+            padding: 4px;
+          }
 
           * {
             white-space: pre-wrap;
@@ -186,85 +274,14 @@ div.stream-comments {
             margin-top: 2px;
           }
         }
+      }
 
-        div.stream-comment-more-menu-container {
+      div.save-cancel-edit-buttons {
+        float: right;
+        padding-top: 8px;
+
+        button {
           float: right;
-          position: relative;
-
-          button.comment-more-menu {
-            width: 24px;
-            height: 26px;
-            padding: 2px 10px;
-            display: block;
-            background-image: cdnUrl("/img/ML/vertical_ellipsis.svg");
-            background-position: center;
-            background-size: 4px 20px;
-            background-repeat: no-repeat;
-            opacity: 0.8;
-
-            &:hover {
-              opacity: 1;
-            }
-
-            &:hover, &.active {
-              background-image: cdnUrl("/img/ML/vertical_ellipsis_deep_navy.svg");
-            }
-          }
-
-          div.stream-comment-more-menu {
-            position: absolute;
-            bottom: 24px;
-            left: calc(100% - 136px);
-            background-color: white;
-            width: 136px;
-            background-color: white;
-            border: 1px solid $deep_tan;
-            box-shadow: 0 2px 4px 1px rgba(0,0,0,0.10);
-            outline: none;
-            z-index: 110;
-            border-radius: 5px;
-            margin: 0;
-            padding: 24px;
-
-            div.stream-comment-more-menu-item {
-              height: 18px;
-              @include avenir_H();
-              font-size: 14px;
-              color: $deep_navy;
-              cursor: pointer;
-              padding-left: 32px;
-              position: relative;
-              margin-top: 16px;
-
-              &:before {
-                content: "";
-                position: absolute;
-                top: 0px;
-                left: 0px;
-                width: 18px;
-                height: 18px;
-                background-repeat: no-repeat;
-                background-size: 18px 18px;
-                background-position: center;
-              }
-
-              &:first-child {
-                margin-top: 0px;
-              }
-
-              &.edit {
-                &:before {
-                  background-image: cdnUrl("/img/ML/more_menu_edit.svg");
-                }
-              }
-
-              &.delete {
-                &:before {
-                  background-image: cdnUrl("/img/ML/more_menu_delete.svg");
-                } 
-              }
-            }
-          }
         }
       }
     }

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -4,8 +4,55 @@
             [goog.events.EventType :as EventType]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.lib.utils :as utils]
+            [oc.web.utils.comment :as cu]
             [oc.web.actions.comment :as comment-actions]
             [oc.web.components.ui.alert-modal :as alert-modal]))
+
+(defn stop-editing [s]
+  (let [medium-editor @(::medium-editor s)]
+    (.destroy medium-editor)
+    (when @(::esc-key-listener s)
+      (events/unlistenByKey @(::esc-key-listener s))
+      (reset! (::esc-key-listener s) nil))
+    (reset! (::medium-editor s) nil)
+    (reset! (::editing? s) false)))
+
+(defn cancel-edit
+  [e s c]
+  (.stopPropagation e)
+  (let [comment-field (rum/ref-node s (str "comment-body-" (:uuid c)))]
+    (set! (.-innerHTML comment-field) (:body c))
+    (stop-editing s)))
+
+(defn edit-finished
+  [e s c]
+  (let [activity-data (first (:rum/args s))
+        new-comment (rum/ref-node s (str "comment-body-" (:uuid c)))
+        comment-text (cu/add-comment-content new-comment)]
+    (if (pos? (count comment-text))
+      (do
+        (stop-editing s)
+        (set! (.-innerHTML new-comment) comment-text)
+        (comment-actions/save-comment activity-data c comment-text))
+      (cancel-edit e s c))))
+
+(defn start-editing [s comment-data]
+  (let [comment-node (rum/ref-node s (str "comment-body-" (:uuid comment-data)))
+        medium-editor (cu/setup-medium-editor comment-node)]
+    (reset! (::esc-key-listener s)
+     (events/listen
+      js/window
+      EventType/KEYDOWN
+      (fn [e]
+        (when (and (= "Enter" (.-key e))
+                   (not (.-shiftKey e)))
+          (edit-finished e s comment-data)
+          (.preventDefault e))
+        (when (= "Escape" (.-key e))
+          (cancel-edit e s comment-data)))))
+    (reset! (::medium-editor s) medium-editor)
+    (reset! (::editing? s) (:uuid comment-data))
+    (utils/after 600 #(utils/to-end-of-content-editable (rum/ref-node s (str "comment-body-" (:uuid comment-data)))))))
 
 (defn delete-clicked [e activity-data comment-data]
   (let [alert-data {:icon "/img/ML/trash.svg"
@@ -31,6 +78,9 @@
                              (rum/local false ::last-focused-state)
                              (rum/local false ::showing-menu)
                              (rum/local nil ::click-listener)
+                             (rum/local false ::editing?)
+                             (rum/local false ::medium-editor)
+                             (rum/local nil ::esc-key-listener)
                              {:will-mount (fn [s]
                                (reset! (::click-listener s)
                                  (events/listen js/window EventType/CLICK
@@ -66,7 +116,9 @@
         [:div.stream-comments-title
           (str (count comments-data) " Comment" (when (> (count comments-data) 1) "s"))])
       (if (pos? (count comments-data))
-        (for [comment-data comments-data]
+        (for [comment-data comments-data
+              :let [is-editing? (= @(::editing? s) (:uuid comment-data))
+                    reaction-data (first (:reactions comment-data))]]
           [:div.stream-comment
             {:key (str "stream-comment-" (:created-at comment-data))}
             [:div.stream-comment-header.group.fs-hide
@@ -76,48 +128,63 @@
                 [:div.stream-comment-author-name
                   (:name (:author comment-data))]
                 [:div.stream-comment-author-timestamp
-                  (utils/time-since (:created-at comment-data))]]]
+                  (utils/time-since (:created-at comment-data))]]
+              (when (or (:can-edit comment-data)
+                        (:can-delete comment-data))
+                (let [showing-more-menu (= @(::showing-menu s) (:uuid comment-data))]
+                  [:div.stream-comment-more-menu-container
+                    {:ref (str "comment-more-menu-" (:uuid comment-data))}
+                    [:button.comment-more-menu.mlb-reset
+                      {:class (when showing-more-menu "active")
+                       :on-click (fn [e]
+                                  (utils/event-stop e)
+                                  (reset! (::showing-menu s) (:uuid comment-data)))}]
+                    (when showing-more-menu
+                      [:div.stream-comment-more-menu
+                        (when (:can-edit comment-data)
+                          [:div.stream-comment-more-menu-item.edit
+                            {:on-click #(do
+                                          (reset! (::showing-menu s) false)
+                                          (start-editing s comment-data))}
+                            "Edit"])
+                        (when (:can-delete comment-data)
+                          [:div.stream-comment-more-menu-item.delete
+                            {:on-click #(do
+                                         (reset! (::showing-menu s) false)
+                                         (delete-clicked % activity-data comment-data))}
+                            "Delete"])])]))]
             [:div.stream-comment-content
               [:div.stream-comment-body.fs-hide
                 {:dangerouslySetInnerHTML (utils/emojify (:body comment-data))
+                 :ref (str "comment-body-" (:uuid comment-data))
                  :class (utils/class-set {:emoji-comment (:is-emoji comment-data)})}]]
-            (when (or (not (:is-emoji comment-data))
-                      (:can-edit comment-data)
-                      (:can-delete comment-data))
+            (when (or is-editing?
+                      (and (not is-editing?)
+                           (not (:is-emoji comment-data))
+                           (or (:can-react comment-data)
+                               (pos? (:count reaction-data)))))
               [:div.stream-comment-footer.group
-                (let [reaction-data (first (:reactions comment-data))
-                      can-react? (utils/link-for (:links reaction-data) "react"  ["PUT" "DELETE"])]
-                  (when (or can-react?
-                            (pos? (:count reaction-data)))
-                    [:div.stream-comment-reaction
-                      {:class (utils/class-set {:reacted (:reacted reaction-data)
-                                                :can-react can-react?})}
-                        (when (or (pos? (:count reaction-data))
-                                  can-react?)
-                          [:div.stream-comment-reaction-icon
-                            {:on-click #(comment-actions/comment-reaction-toggle activity-data comment-data
-                              reaction-data (not (:reacted reaction-data)))}])
-                        (when (pos? (:count reaction-data))
-                          [:div.stream-comment-reaction-count
-                            (:count reaction-data)])]))
-                (when (or (:can-edit comment-data)
-                          (:can-delete comment-data))
-                  (let [showing-more-menu (= @(::showing-menu s) (:uuid comment-data))]
-                    [:div.stream-comment-more-menu-container
-                      {:ref (str "comment-more-menu-" (:uuid comment-data))}
-                      [:button.comment-more-menu.mlb-reset
-                        {:class (when showing-more-menu "active")
-                         :on-click (fn [e]
-                                    (utils/event-stop e)
-                                    (reset! (::showing-menu s) (:uuid comment-data)))}]
-                      (when showing-more-menu
-                        [:div.stream-comment-more-menu
-                          (when (:can-edit comment-data)
-                            [:div.stream-comment-more-menu-item.edit
-                              {:on-click #()}
-                              "Edit"])
-                          (when (:can-delete comment-data)
-                            [:div.stream-comment-more-menu-item.delete
-                              {:on-click #(delete-clicked % activity-data comment-data)}
-                              "Delete"])])]))])])
+                (when (and (not is-editing?)
+                           (not (:is-emoji comment-data))
+                           (or (:can-react comment-data)
+                               (pos? (:count reaction-data))))
+                  [:div.stream-comment-reaction
+                    {:class (utils/class-set {:reacted (:reacted reaction-data)
+                                              :can-react (:can-react comment-data)})}
+                      (when (or (pos? (:count reaction-data))
+                                (:can-react comment-data))
+                        [:div.stream-comment-reaction-icon
+                          {:on-click #(comment-actions/comment-reaction-toggle activity-data comment-data
+                            reaction-data (not (:reacted reaction-data)))}])
+                      (when (pos? (:count reaction-data))
+                        [:div.stream-comment-reaction-count
+                          (:count reaction-data)])])
+                  (when is-editing?
+                    [:div.save-cancel-edit-buttons
+                      [:button.mlb-reset.mlb-link-green
+                        {:on-click #(edit-finished % s comment-data)}
+                        "Save"]
+                      [:button.mlb-reset.mlb-link-black
+                        {:on-click #(cancel-edit % s comment-data)}
+                        "Cancel"]])])])
         [:div.stream-comments-empty])]])

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -129,7 +129,8 @@
                   (:name (:author comment-data))]
                 [:div.stream-comment-author-timestamp
                   (utils/time-since (:created-at comment-data))]]
-              (when (or (:can-edit comment-data)
+              (when (or (and (:can-edit comment-data)
+                             (not (:is-emoji comment-data)))
                         (:can-delete comment-data))
                 (let [showing-more-menu (= @(::showing-menu s) (:uuid comment-data))]
                   [:div.stream-comment-more-menu-container
@@ -141,7 +142,8 @@
                                   (reset! (::showing-menu s) (:uuid comment-data)))}]
                     (when showing-more-menu
                       [:div.stream-comment-more-menu
-                        (when (:can-edit comment-data)
+                        (when (and (:can-edit comment-data)
+                                   (not (:is-emoji comment-data)))
                           [:div.stream-comment-more-menu-item.edit
                             {:on-click #(do
                                           (reset! (::showing-menu s) false)

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -1,8 +1,25 @@
 (ns oc.web.components.stream-comments
   (:require [rum.core :as rum]
+            [goog.events :as events]
+            [goog.events.EventType :as EventType]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.lib.utils :as utils]
-            [oc.web.actions.comment :as comment-actions]))
+            [oc.web.actions.comment :as comment-actions]
+            [oc.web.components.ui.alert-modal :as alert-modal]))
+
+(defn delete-clicked [e activity-data comment-data]
+  (let [alert-data {:icon "/img/ML/trash.svg"
+                    :action "delete-comment"
+                    :message (str "Delete this comment?")
+                    :link-button-title "No"
+                    :link-button-cb #(alert-modal/hide-alert)
+                    :solid-button-style :red
+                    :solid-button-title "Yes"
+                    :solid-button-cb (fn []
+                                       (comment-actions/delete-comment activity-data comment-data)
+                                       (alert-modal/hide-alert))
+                    }]
+    (alert-modal/show-alert alert-data)))
 
 (defn scroll-to-bottom [s]
   (let [scrolling-node (rum/ref-node s "stream-comments-inner")]
@@ -12,7 +29,17 @@
                              (drv/drv :add-comment-focus)
                              (rum/local false ::bottom-gradient)
                              (rum/local false ::last-focused-state)
-                             {:after-render (fn [s]
+                             (rum/local false ::showing-menu)
+                             (rum/local nil ::click-listener)
+                             {:will-mount (fn [s]
+                               (reset! (::click-listener s)
+                                 (events/listen js/window EventType/CLICK
+                                  #(when (and @(::showing-menu s)
+                                              (not (utils/event-inside? %
+                                                    (rum/ref-node s (str "comment-more-menu-" @(::showing-menu s))))))
+                                     (reset! (::showing-menu s) false))))
+                               s)
+                              :after-render (fn [s]
                                (let [scrolling-node (rum/ref-node s "stream-comments-inner")
                                      scrolls (> (.-scrollHeight scrolling-node) (.-clientHeight scrolling-node))]
                                  (compare-and-set! (::bottom-gradient s) (not scrolls) scrolls))
@@ -24,6 +51,11 @@
                                     (reset! (::last-focused-state s) is-self-focused?)
                                     (when is-self-focused?
                                       (scroll-to-bottom s))))
+                               s)
+                              :will-unmount (fn [s]
+                               (when @(::click-listener s)
+                                 (events/unlistenByKey @(::click-listener s))
+                                 (reset! (::click-listener s) nil))
                                s)}
   [s activity-data comments-data]
   [:div.stream-comments
@@ -49,7 +81,9 @@
               [:div.stream-comment-body
                 {:dangerouslySetInnerHTML (utils/emojify (:body comment-data))
                  :class (utils/class-set {:emoji-comment (:is-emoji comment-data)})}]]
-            (when-not (:is-emoji comment-data)
+            (when (or (not (:is-emoji comment-data))
+                      (:can-edit comment-data)
+                      (:can-delete comment-data))
               [:div.stream-comment-footer.group
                 (let [reaction-data (first (:reactions comment-data))
                       can-react? (utils/link-for (:links reaction-data) "react"  ["PUT" "DELETE"])]
@@ -65,5 +99,25 @@
                               reaction-data (not (:reacted reaction-data)))}])
                         (when (pos? (:count reaction-data))
                           [:div.stream-comment-reaction-count
-                            (:count reaction-data)])]))])])
+                            (:count reaction-data)])]))
+                (when (or (:can-edit comment-data)
+                          (:can-delete comment-data))
+                  (let [showing-more-menu (= @(::showing-menu s) (:uuid comment-data))]
+                    [:div.stream-comment-more-menu-container
+                      {:ref (str "comment-more-menu-" (:uuid comment-data))}
+                      [:button.comment-more-menu.mlb-reset
+                        {:class (when showing-more-menu "active")
+                         :on-click (fn [e]
+                                    (utils/event-stop e)
+                                    (reset! (::showing-menu s) (:uuid comment-data)))}]
+                      (when showing-more-menu
+                        [:div.stream-comment-more-menu
+                          (when (:can-edit comment-data)
+                            [:div.stream-comment-more-menu-item.edit
+                              {:on-click #()}
+                              "Edit"])
+                          (when (:can-delete comment-data)
+                            [:div.stream-comment-more-menu-item.delete
+                              {:on-click #(delete-clicked % activity-data comment-data)}
+                              "Delete"])])]))])])
         [:div.stream-comments-empty])]])

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -97,7 +97,6 @@
    :ap-initial-at       [[:base] (fn [base] (:ap-initial-at base))]
    :add-comment-focus   [[:base] (fn [base] (:add-comment-focus base))]
    :comment-add-finish  [[:base] (fn [base] (:comment-add-finish base))]
-   :comment-edit        [[:base] (fn [base] (:comment-edit base))]
    :show-add-post-tooltip [[:base] (fn [base] (:show-add-post-tooltip base))]
    :show-invite-people-tooltip [[:base] (fn [base] (:show-invite-people-tooltip base))]
    :email-verification  [[:base :auth-settings]
@@ -211,11 +210,11 @@
    :activity-share        [[:base] (fn [base] (:activity-share base))]
    :activity-shared-data  [[:base] (fn [base] (:activity-shared-data base))]
    :fullscreen-post-data [[:base :org-data :activity-data :activity-share
-                          :add-comment-focus :comment-edit :ap-initial-at
-                          :comments-data :show-sections-picker :section-editing]
+                           :add-comment-focus :ap-initial-at :comments-data
+                           :show-sections-picker :section-editing]
                           (fn [base org-data activity-data activity-share
-                               add-comment-focus comment-edit ap-initial-at
-                               comments-data show-sections-picker section-editing]
+                               add-comment-focus ap-initial-at comments-data
+                               show-sections-picker section-editing]
                             {:org-data org-data
                              :activity-data activity-data
                              :activity-modal-fade-in (:activity-modal-fade-in base)
@@ -225,7 +224,6 @@
                              :activity-share activity-share
                              :entry-save-on-exit (:entry-save-on-exit base)
                              :add-comment-focus add-comment-focus
-                             :comment-edit comment-edit
                              :comments-data comments-data
                              :ap-initial-at ap-initial-at
                              :show-sections-picker show-sections-picker

--- a/src/oc/web/stores/comment.cljs
+++ b/src/oc/web/stores/comment.cljs
@@ -32,11 +32,14 @@
     {})
   ([comment-map :guard map?]
     (let [edit-comment-link (utils/link-for (:links comment-map) "partial-update")
-          delete-comment-link (utils/link-for (:links comment-map) "delete")]
+          delete-comment-link (utils/link-for (:links comment-map) "delete")
+          reaction-data (first (:reactions comment-map))
+          can-react? (utils/link-for (:links reaction-data) "react"  ["PUT" "DELETE"])]
       (-> comment-map
         (assoc :is-emoji (is-emoji (:body comment-map)))
         (assoc :can-edit (boolean edit-comment-link))
-        (assoc :can-delete (boolean delete-comment-link))))))
+        (assoc :can-delete (boolean delete-comment-link))
+        (assoc :can-react can-react?)))))
 
 (defmethod dispatcher/action :add-comment-focus
   [db [_ focus-uuid]]

--- a/src/oc/web/stores/comment.cljs
+++ b/src/oc/web/stores/comment.cljs
@@ -31,7 +31,12 @@
   ([comment-map :guard nil?]
     {})
   ([comment-map :guard map?]
-    (assoc comment-map :is-emoji (is-emoji (:body comment-map)))))
+    (let [edit-comment-link (utils/link-for (:links comment-map) "partial-update")
+          delete-comment-link (utils/link-for (:links comment-map) "delete")]
+      (-> comment-map
+        (assoc :is-emoji (is-emoji (:body comment-map)))
+        (assoc :can-edit (boolean edit-comment-link))
+        (assoc :can-delete (boolean delete-comment-link))))))
 
 (defmethod dispatcher/action :add-comment-focus
   [db [_ focus-uuid]]


### PR DESCRIPTION
Card: https://trello.com/c/r53ya5tr

Add the edit/delete comment features back in place.

To test:
- go to a post with at least one comment from another user (you can use the initial org post)
- [x] can you NOT see the comment more menu on the comment from another user? Good
- add a text comment to it
- [x] can you see the more menu? Good
- [x] can you edit the comment? Good
- [x] can you delete the comment? Good
- refresh
- [x] still the same options? Good
- delete it
- [x] did it work? Good
- refresh
- [x] the comment is still gone? Good
- add another text comment
- edit it
- click Save
- [x] did it work? Good
- refresh
- [x] still looks the same? Good
- edit again
- click ESC while editing
- [x] did it cancel the edit? Good
- edit again
- click Cancel button at the bottom
- [x] did it cancel the edit? Good
- add an emoji comment (a single emoji)
- [x] can you only delete it? Good
- delete it
- [x] did it work? Good
- refresh
- [x] still gone? Good