### PR TITLE
Fix Compose button tooltip

### DIFF
--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -156,7 +156,7 @@
     (nil? update-link)))
 
 (defn readonly-board? [links]
-  (let [new-link (link-for links "new")
+  (let [new-link (link-for links "create")
         update-link (link-for links "partial-update")
         delete-link (link-for links "delete")]
     (and (nil? new-link)


### PR DESCRIPTION
Card: https://trello.com/c/sHcrtwdI

Item:
> View only user tooltip shows even if admin/contributor - only after first login, then goes away on refresh

To test:
- setup an org with an admin, a contributor and a viewer
- login with the admin (it's important to perform the following checks upon login, not after)
- [x] do you have the Compose button *enabled*? Good
- [x] do you NOT see a tooltip when you hover the button? Good
- refresh
- [x] confirm the above? Good
- login with the contributor (it's important to perform the following checks upon login, not after)
- [x] do you have the Compose button *enabled*? Good
- [x] do you NOT see a tooltip when you hover the button? Good
- refresh
- [x] confirm the above? Good
- login with the viewer (it's important to perform the following checks upon login, not after)
- [x] do you have the Compose button *disabled*? Good
- [x] do you see a tooltip when you hover the button? Good
- refresh
- [x] confirm the above? Good