### PR TITLE
Slack users skip the invite step of the onboard.

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -94,9 +94,15 @@
 
 ;; Org create
 
+(defn- org-created [org-data]
+  (let [auth-source (jwt/get-key :auth-source)]
+    (if (= auth-source "email")
+      (router/nav! (oc-urls/sign-up-invite (:slug org-data)))
+      (org-redirect org-data))))
+
 (defn team-patch-cb [org-data {:keys [success body status]}]
   (when success
-    (router/nav! (oc-urls/sign-up-invite (:slug org-data)))))
+    (org-created org-data)))
 
 (defn org-create-cb [{:keys [success status body]}]
   (when-let [org-data (when success (json->cljs body))]
@@ -110,7 +116,7 @@
         ; for it and patch it back
         (api/patch-team (:team-id org-data) {:name (:name org-data)} org-data (partial team-patch-cb org-data))
         ; if not redirect the user to the invite page
-        (router/nav! (oc-urls/sign-up-invite (:slug org-data)))))))
+        (org-created org-data)))))
 
 (defn org-create [org-data]
   (when-not (empty? (:name org-data))


### PR DESCRIPTION
Card: https://trello.com/c/sHcrtwdI

Item:
> Don't show invite colleagues in NUX when onboarding via Slack

To test:
- sign up with Slack
- setup profile
- setup org
- [x] did you land on org AP right after the org setup? Good
- [x] no invite users via email step? Good
- sign up with email
- setup profile
- setup org
- [x] are you now seeing the email invite step of the onboard? Good
- skip it or invite someone
- [x] did you land on the org AP after? Good