### PR TITLE
Fix duplicated slack user upon invitation

### DIFF
--- a/src/oc/web/components/ui/org_settings_invite_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_invite_panel.cljs
@@ -143,19 +143,19 @@
                       [:div
                         {:class (when (:error user-data) "error")}
                         (rum/with-key
-                          (slack-users-dropdown {:on-change #(dis/dispatch!
-                                                              [:input
-                                                               [:invite-users i]
-                                                               (merge user-data {:user % :error nil :temp-user nil})])
-                                                 :on-intermediate-change
-                                                  #(dis/dispatch!
-                                                    [:input
-                                                     [:invite-users]
-                                                     (assoc
-                                                      invite-users
-                                                      i
+                         (slack-users-dropdown
+                          {:on-change #(dis/dispatch! [:input [:invite-users i]
+                                        (merge user-data {:user % :error nil :temp-user nil})])
+                           :filter-fn (fn [user]
+                                        (let [check-fn #(or
+                                                         (not (:user %))
+                                                         (not= (:slack-org-id (:user %)) (:slack-org-id user))
+                                                         (not= (:slack-id (:user %)) (:slack-id user)))]
+                                          (every? check-fn invite-users)))
+                           :on-intermediate-change #(dis/dispatch! [:input [:invite-users]
+                                                     (assoc invite-users i
                                                       (merge user-data {:user nil :error nil :temp-user %}))])
-                                                 :initial-value (utils/name-or-email (:user user-data))})
+                            :initial-value (utils/name-or-email (:user user-data))})
                           (str "slack-users-dropdown-" (count uninvited-users) "-row-" i))]
                       [:input.org-settings-field.email-field
                         {:type "text"

--- a/src/oc/web/components/ui/slack_users_dropdown.cljs
+++ b/src/oc/web/components/ui/slack_users_dropdown.cljs
@@ -20,17 +20,43 @@
   (let [look-for (string/lower s)]
     (filterv #(check-user % look-for) users)))
 
+(defn- setup-sorted-users
+  "Read the roster users, group them by slack org and sort by slack org and name/email.
+   Save the result in the local component state to be used during render."
+  [s]
+  (let [roster-data @(drv/get-ref s :team-roster)
+        all-users (filterv #(= (:status %) "uninvited") (:users roster-data))
+        team-roster (vals (group-by :slack-org-id all-users))
+        sorted-team-roster (vec
+                            (map
+                             (fn [team]
+                              (vec (sort-by #(str (:first-name %) " " (:last-name %)) team))) team-roster))
+        all-sorted-users (vec (apply concat sorted-team-roster))]
+    (when (not= @(::all-sorted-users s) all-sorted-users)
+      (reset! (::all-sorted-users s) all-sorted-users))))
+
+(defn- get-filtered-sorted-users
+  "Filter ::all-sorted-users on the fly with the passed filter-fn if present."
+  [s]
+  (let [filter-fn (:filter-fn (first (:rum/args s)))
+        all-sorted-users @(::all-sorted-users s)]
+    (if (fn? filter-fn)
+      (filter filter-fn all-sorted-users)
+      all-sorted-users)))
+
 (rum/defcs slack-users-dropdown   <  (rum/local nil ::show-users-dropdown)
                                      (rum/local nil ::field-value)
                                      (rum/local nil ::window-click)
                                      (rum/local "" ::slack-user)
                                      (rum/local false ::typing)
+                                     (rum/local [] ::all-sorted-users)
                                      rum/reactive
                                      (drv/drv :team-data)
                                      (drv/drv :team-roster)
                                      {:will-mount (fn [s]
                                        (let [initial-value (:initial-value (first (:rum/args s)))]
                                          (reset! (::slack-user s) (or initial-value "")))
+                                       (setup-sorted-users s)
                                        (reset! (::window-click s)
                                         (events/listen js/window EventType/CLICK
                                           #(when (and @(::show-users-dropdown s)
@@ -47,26 +73,23 @@
                                                (when (fn? on-blur)
                                                  (on-blur))))))
                                        s)
+                                      :will-update (fn [s]
+                                       (setup-sorted-users s)
+                                       s)
                                       :before-render (fn [s]
                                        (team-actions/teams-get-if-needed)
                                        s)
                                       :will-unmount (fn [s]
                                        (events/unlistenByKey @(::window-click s))
                                        s)}
-  [s {:keys [disabled initial-value on-change on-intermediate-change on-focus on-blur] :as data}]
-  (let [roster-data (drv/react s :team-roster)
-        all-users (filterv #(= (:status %) "uninvited") (:users roster-data))
-        team-roster (vals (group-by :slack-org-id all-users))
-        sorted-team-roster (vec
-                            (map
-                             (fn [team]
-                              (vec (sort-by #(str (:first-name %) " " (:last-name %)) team))) team-roster))
-        all-sorted-users (vec (apply concat sorted-team-roster))
+  [s {:keys [disabled initial-value on-change on-intermediate-change on-focus on-blur filter-fn] :as data}]
+  (let [_ (drv/react s :team-roster) ;; Make sure the component is re-render when roster changes
+        all-sorted-users (get-filtered-sorted-users s)
         slack-orgs (:slack-orgs (drv/react s :team-data))
         slack-orgs-map (zipmap (map :slack-org-id slack-orgs) (map :name slack-orgs))]
     [:div.slack-users-dropdown
       {:class (if disabled "disabled" "")
-       :key (str "slack-users-dropdown-" (count all-users))}
+       :key (str "slack-users-dropdown-" (count all-sorted-users))}
       [:input.slack-users-dropdown
         {:value @(::slack-user s)
          :on-focus (fn []
@@ -81,7 +104,7 @@
                          (on-intermediate-change (.. % -target -value)))
                        (reset! (::slack-user s) (.. % -target -value)))
          :disabled disabled
-         :placeholder (if (pos? (count all-users)) "Select User..." "No more members to add")}]
+         :placeholder (if (pos? (count all-sorted-users)) "Select User..." "No more members to add")}]
       (when-not disabled
         [:i.fa
           {:class (utils/class-set {:fa-angle-down (not @(::show-users-dropdown s))


### PR DESCRIPTION
Card: https://trello.com/c/sHcrtwdI

Item:
> Can invite the same slack user twice in the same batch ending with 2 different users for the same slack one

Right now we have hole in the UI that make it possible to create 2 users for the same slack user. The flow is this:
- go to invite users
- select Slack
- select a user
- add another invite row
- invite the same user
- click invite
- check the REPL and you'll find 2 users with the same slack-org-id and slack-id

With this fix the UI don't let you pick the same Slack users twice, even in the same batch.

To test:
- repeat the flow above
- [x] can you NOT select the same user twice? Good
- after inviting a Slack user
- [x] can you NOT select him again? Good

NB: this doesn't fix the backend problem of creating 2 users for the same slack user. We should fix also it because 2 users inviting the same Slack user at the same team (or even to different teams) will end up creating 2 different users. Having 2 users for the same slack user will lead to unclear situation and probably bugs. We need to prevent this.

Assigning to @belucid since he already has some background on this because of our debug of yesterday (2nd of may).