### PR TITLE
Fix empty section name

### DIFF
--- a/scss/partials/_section_editor.scss
+++ b/scss/partials/_section_editor.scss
@@ -75,6 +75,13 @@ div.section-editor {
       margin-top: 64px;
     }
 
+    div.section-editor-error-label {
+      margin-top: 8px;
+      @include avenir_M();
+      font-size: 13px;
+      color: $carrot_orange;
+    }
+
     div.section-editor-add-label {
       margin-top: 24px;
       @include avenir_H();
@@ -482,6 +489,10 @@ div.section-editor {
         color: $carrot_green;
         @include avenir_H();
         font-size: 15px;
+
+        &.disabled {
+          opacity: 0.5;
+        }
       }
     }
   }

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -195,9 +195,9 @@
           [:div.section-add
             {:class (when show-drafts "has-drafts")}
            (section-editor nil (fn [board-data note]
-                                  (dis/dispatch! [:input [:show-section-add] false])
                                   (when board-data
-                                    (section-actions/section-save board-data note))))])
+                                    (section-actions/section-save board-data note
+                                     #(dis/dispatch! [:input [:show-section-add] false])))))])
         [:div.dashboard-layout-container.group
           (when-not is-mobile?
             (navigation-sidebar))
@@ -233,9 +233,9 @@
                                  (not (responsive/is-tablet-or-mobile?)))
                         (section-editor board-data
                          (fn [section-data note]
-                           (dis/dispatch! [:input [:show-section-editor] false])
                            (when section-data
-                             (section-actions/section-save section-data note)))))])
+                             (section-actions/section-save section-data note
+                               #(dis/dispatch! [:input [:show-section-editor] false]))))))])
                   (when (= (:access board-data) "private")
                     [:div.private-board
                       {:data-toggle "tooltip"

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -134,11 +134,17 @@
           ;; Mobile create a new section
           (and is-mobile?
                show-section-editor)
-          (section-editor board-data (fn [sec-data note] (section-actions/section-save sec-data note)))
+          (section-editor board-data
+           (fn [sec-data note]
+            (when sec-data
+              (section-actions/section-save sec-data note #(dis/dispatch! [:input [:show-section-editor] false])))))
           ;; Mobile edit current section data
           (and is-mobile?
                show-section-add)
-          (section-editor nil (fn [_ _] (dis/dispatch! [:input [:show-section-add] false])))
+          (section-editor nil
+           (fn [sec-data note]
+            (when sec-data
+              (section-actions/section-save sec-data note #(dis/dispatch! [:input [:show-section-add] false])))))
           ;; Mobile sections picker
           (and is-mobile?
                show-sections-picker)

--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -18,8 +18,6 @@
 
 ;; Private section users search helpers
 
-(def min-section-name-length 3)
-
 (defn filter-user-by-query
   "Given a user and a query string, return true if first-name, last-name or email contains it."
   [user query]
@@ -392,19 +390,14 @@
               "Delete section"])
           [:button.mlb-reset.create-bt
             {:on-click (fn [_]
-                        (if (< (count @(::section-name s)) min-section-name-length)
-                          (dis/dispatch! [:section-edit/error (str "Name must be at least " min-section-name-length " characters.")])
-                          (let [section-node (rum/ref-node s "section-name")
-                                inner-html (.-innerHTML section-node)
-                                section-name (utils/strip-HTML-tags inner-html)
-                                personal-note-node (rum/ref-node s "personal-note")
-                                personal-note (when personal-note-node (.-innerText personal-note-node))
-                                next-section-editing (merge section-editing {:slug utils/default-section-slug
-                                                                             :name section-name})]
-                            (dis/dispatch! [:input [:section-editing] next-section-editing])
-                            (when (fn? on-change)
-                              (on-change next-section-editing personal-note)))))
-             :class (when (< (count @(::section-name s)) min-section-name-length) "disabled")}
+                        (let [section-node (rum/ref-node s "section-name")
+                              section-name (.-innerText section-node)
+                              personal-note-node (rum/ref-node s "personal-note")
+                              personal-note (when personal-note-node (.-innerText personal-note-node))
+                              success-cb #(when (fn? on-change)
+                                            (on-change % personal-note))]
+                          (section-actions/section-save-create section-editing section-name success-cb)))
+             :class (when (< (count @(::section-name s)) section-actions/min-section-name-length) "disabled")}
             (if @(::editing-existing-section s)
               "Save"
               "Create")]]]]))


### PR DESCRIPTION
Card: Can try to create empty section https://sentry.io/opencompany/oc-beta-web/issues/453626704/

Item:
> Can try to create empty section https://sentry.io/opencompany/oc-beta-web/issues/453626704/

To test:
- click + in the navigation
- click Create w/o adding a name
- [x] do you see an error? Good
- type one letter in the section
- [x] did the error go away? Good
- add another char and then 2 or more spaces
- [ ] do you see the error again? Good
- remove all the spaces and add a section name longer then 3 chars
- click Create
- [x] did it work? Good
- click section settings
- delete part of the section name so it's 2 characters long
- click Save
- [x] do you see the same error as before? Good
- change the section name to another longer then 3 chars
- click Save
- [x] did it work? Good