### PR TITLE
Fix ap comment

### DIFF
--- a/src/oc/web/components/all_posts.cljs
+++ b/src/oc/web/components/all_posts.cljs
@@ -92,8 +92,7 @@
   ;; Save the last scrollTop value
   (reset! last-scroll (.-scrollTop (.-body js/document))))
 
-(rum/defcs all-posts  < rum/static
-                        rum/reactive
+(rum/defcs all-posts  < rum/reactive
                         ;; Derivatives
                         (drv/drv :all-posts)
                         (drv/drv :ap-initial-at)

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -178,7 +178,6 @@
         drafts-link (utils/link-for (:links drafts-board) "self")
         show-drafts (pos? (:count drafts-link))
         mobile-navigation-sidebar (drv/react s :mobile-navigation-sidebar)
-        all-posts-key (str "all-posts-stream-" (clojure.string/join "-" (keys (:fixed-items all-posts-data))))
         can-compose (or (and (or is-all-posts
                                  is-drafts-board)
                              (pos? (count all-boards)))
@@ -315,7 +314,7 @@
                 ;; All Posts
                 (and is-all-posts
                      (= @(::board-switch s) :stream))
-                (rum/with-key (all-posts) all-posts-key)
+                (all-posts)
                 ;; Empty board
                 empty-board?
                 (empty-board)


### PR DESCRIPTION
Card: https://trello.com/c/sHcrtwdI

Item:
> Add post from AP then focus on the add comment, the field doesn't expand and the Post button is not shown, works on single board

Right now if you focus the add comment box right after adding a new post the box is focused but the add comment is not expanded. The problem is the key used to render the `all-posts` component that take into consideration the list of posts only.

To test:
- go to AP
- add a new post
- click on the add comment box
- [x] did the comment box get focus? Good
- [x] do you see the Post button, even if it's disabled? Good
- write a comment and post it
- [x] did the comment post? Good