### PR TITLE
Fix add bot

### DIFF
--- a/resources/public/lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js
@@ -1,6 +1,6 @@
 function log(){
-  var args = Array.prototype.slice.call(arguments);
-  console.debug("XXX MediaPicker", args);
+  // var args = Array.prototype.slice.call(arguments);
+  // console.debug("XXX MediaPicker", args);
 }
 
 function PlaceCaretAtEnd(el) {

--- a/scss/partials/_stream_view_item.scss
+++ b/scss/partials/_stream_view_item.scss
@@ -213,7 +213,6 @@ div.stream-view-item {
       flex-grow: 0;
       flex-shrink: 0;
       width: 387px;
-      min-height: 300px;
       position: relative;
       padding: 32px 20px 40px 32px;
       background-color: #FDFCFB;

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -147,8 +147,8 @@
 (defn bot-auth [org-data team-data user-data]
   (let [current (router/get-token)
         auth-link (utils/link-for (:links team-data) "bot")
-        fixed-auth-url (utils/slack-link-with-state (:href auth-link) (:user-id user-data) (:id team-data)
-                        (router/get-token))]
+        fixed-auth-url (utils/slack-link-with-state (:href auth-link) (:user-id user-data) (:team-id team-data)
+                        current)]
     (router/redirect! fixed-auth-url)))
 
 (defn auth-with-token-failed [error]


### PR DESCRIPTION
Fix this https://sentry.io/opencompany/oc-beta-web/issues/544509150/?referrer=slack

BUG: if you try to add a bot to a Slack org from our settings page it's broken because it's using a null team-id.

Broken flow:
- signup with email
- make sure you have a slack team that don't have our bot installed (I user OC Test org 2 on localhost, shouldn't have the bot right now)
- add the slack team above to the new org
- on the second step deny bot permissions (click Proceed on the first scree, cancel on the second)
- you should see now the settings panel with the slack org added and a button to add the bot
- click the add bot button
- error in console and no redirect

To test:
- repeat the flow above
- [x] are you redirected to the Slack page with the bot permissions? Good
- [x] could you grant bot permission clicking on the Add bot button? Good