### PR TITLE
Add fs-hide class to the missed items.

### DIFF
--- a/src/oc/web/components/secure_activity.cljs
+++ b/src/oc/web/components/secure_activity.cljs
@@ -46,7 +46,7 @@
                                (str (- win-height default-activity-header-height) "px"))}}
         (when (drv/react s :made-with-carrot-modal)
           (made-with-carrot-modal/made-with-carrot-modal))
-        [:div.activity-header.group
+        [:div.activity-header.group.fs-hide
           (org-avatar (clojure.set/rename-keys
                        activity-data
                        {:org-logo-height :logo-height
@@ -59,9 +59,9 @@
             {:style {:min-height (when is-mobile?
                                   (str (- win-height default-activity-header-height) "px"))}}
             (when (:headline activity-data)
-              [:div.activity-title
+              [:div.activity-title.fs-hide
                 {:dangerouslySetInnerHTML (utils/emojify (:headline activity-data))}])
-            [:div.activity-author.group
+            [:div.activity-author.group.fs-hide
               [:div.activity-author-inner.group
                 (user-avatar-image activity-author)
                 [:div.posted-by
@@ -71,7 +71,7 @@
                    " "
                    (utils/activity-date (utils/js-date (:published-at activity-data)) true) ".")]]]
             (when (:body activity-data)
-              [:div.activity-body
+              [:div.activity-body.fs-hide
                 {:dangerouslySetInnerHTML (utils/emojify (:body activity-data))}])]]
         [:div.activity-content-footer
           {:on-click #(when-not is-mobile?

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -478,7 +478,7 @@
         [:div.title
           "Join your team on Carrot"]
         [:div.subtitle
-          "Signing up as " [:span.email-address (:email jwt)]]]
+          "Signing up as " [:span.email-address.fs-hide (:email jwt)]]]
       [:div.onboard-form
         [:form
           {:on-submit (fn [e]


### PR DESCRIPTION
Bug: with FullStory we are able to see the user email when onboarding through an invitation and a post full content on the secure url (for anonymous and not part of the team users).

To test:
- create a post
- visit it with anonymous browser mode
- [x] do you NOT see the post body in FullStory? Good
- invite a user through an email you can receive
- click on the email
- [x] do you NOT see the email address in FullStory on the accept invite session? Good