### PR TITLE
Fix image add

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -44,6 +44,7 @@ $.dotdotdot = function(){};
 $.trigger = function(){};
 $.ajax = function(){};
 $.outerHeight = function(){};
+$.after = function(){};
 // WURFL
 var WURFL = {};
 WURFL.complete_device_name = {};

--- a/resources/public/lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js
@@ -245,12 +245,21 @@ function PlaceCaretAtEnd(el) {
           element.appendChild(p);
         // if it's a P already
         } else if (element.tagName == "P"){
-          // if it has a BR inside
-          if (element.childNodes.length == 1){
-            // remove it
-            element.removeChild(element.childNodes[0]);
+          // If the paragraph is empty
+          if (element.innerText.length === 0 || element.innerText === "\n") {
+              // if it has a BR inside
+            if (element.childNodes.length == 1){
+              // remove it
+              element.removeChild(element.childNodes[0]);
+            }
+            p = element;
+          } else {
+            // If the current P is not empty create a new paragraph, append it
+            // after the current paragraph and add the image there
+            p = this.document.createElement("p");
+            $(element).after(p);
+            element = p.parentNode;
           }
-          p = element;
         }
         var img = this.document.createElement("img");
         img.src = photoUrl;


### PR DESCRIPTION
Bug report from Sean: 
- click Compose
- enter a title
- enter some text
- hit enter to add a new paragraph
- add some text
- without entering a new paragraph click the add media button
- click on image
- pick an image
- the image replace the current paragraph text

Fix: if the cursor is inside a paragraph that is not empty (ie: has 0 length or its only char is a new line char) then create a new paragraph, add it after the current one and insert the image inside it.

To test:
- repeat the flow described above
- [ ] do you see the text above the image? Good

If you want to test a bit more add an image while your cursor is in a paragraph with some text and make sure you have another paragraph of text above and below it. The new image should be added with all the text of the caret paragraph above and the after paragraph below it.

Limitation: the text of the caret paragraph that is after the cursor is not moved to a new paragraph after the image, this is left to the user.