### PR TITLE
Create section copy

### DIFF
--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -110,7 +110,7 @@
                                 (events/unlistenByKey @(::click-listener s))
                                 (reset! (::click-listener s) nil))
                               s)}
-  [s initial-section-data on-change]
+  [s initial-section-data on-change from-section-picker]
   (let [org-data (drv/react s :org-data)
         section-editing (drv/react s :section-editing)
         section-data (if (seq (:slug section-editing)) (drv/react s :board-data) section-editing)
@@ -400,4 +400,6 @@
              :class (when (< (count @(::section-name s)) section-actions/min-section-name-length) "disabled")}
             (if @(::editing-existing-section s)
               "Save"
-              "Create")]]]]))
+              (if from-section-picker
+                "Done"
+                "Create"))]]]]))

--- a/src/oc/web/components/ui/sections_picker.cljs
+++ b/src/oc/web/components/ui/sections_picker.cljs
@@ -84,7 +84,8 @@
       (if @(::show-add-section s)
         (section-editor nil (fn [sec-data note]
                               (reset! (::show-add-section s) false)
-                              (on-change sec-data note)))
+                              (on-change sec-data note))
+         true)
         [:div.sections-picker.group
           {:class (when should-show-headers? "show-headers")}
           [:div.sections-picker-header


### PR DESCRIPTION
Card: https://trello.com/c/h4qL6IxA

From call discussion: Create as copy of the section editor button is misleading when adding a section from post editing since it doesn't create the section right away but it waits for the post to be posted/saved.
So change the button copy to Done only when showing the section editor from within the section picker (used only when adding/editing a post).

To test:
- go to AP
- click + to add a section
- [x] the copy of the button at the bottom is Create? Good
- nav to a single section
- click the section settings button
- [x] the copy of the button at the bottom is Save? Good
- click Compose
- click on the section name
- click Add a new section
- [x] the copy of the button at the bottom is Done? Good