### PR TITLE
Fix mobile comments

### DIFF
--- a/scss/partials/_add_comment.scss
+++ b/scss/partials/_add_comment.scss
@@ -32,6 +32,7 @@ div.add-comment-box-container {
 
           @include tablet() {
             height: auto;
+            width: auto;
           }
         }
       }

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -169,7 +169,6 @@ div.stream-item {
 
         @include mobile() {
           background-color: transparent;
-          margin-top: 24px;
         }
 
         div.stream-comments-title {


### PR DESCRIPTION
Card: https://trello.com/c/Isza2z8Z

After the last stream view refresh we lost the comments on mobile. If you click the comments summary it does nothing.
To fix it i completely removed the comments summary (ie: You and Sean commented) since the new comments are already short enough: it shows only up to 3 comments with a show more button and comments longer then 4 lines are truncated.

To test:
- compose a post
- add a short comment
- add a very long comment (at least 10 lines to make sure)
- check the post on the mobile stream view
- [x] do you see the comments? Good
- [x] do you see the long comment truncated? Good
- add another comment
- and one more (long)
- [x] do you see 3 comments with a button to show all? Good
- [x] can you show all comments and hide them? Good
- [x] can you expand the truncated comments? Good