### PR TITLE
Truncated comment fix

### DIFF
--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -138,10 +138,10 @@
                   [:div.stream-comment-body.fs-hide
                     {:dangerouslySetInnerHTML (utils/emojify (:body comment-data))
                      :ref (str "comment-body-" (:uuid comment-data))
-                     :on-click #(let [elem (.-target %)
-                                      $body (.closest (js/$ elem) ".stream-comment-body")]
-                                  (.restore (.data $body "dotdotdot"))
-                                  (reset! (::expanded-comments s) (vec (set (conj @(::expanded-comments s) (:uuid comment-data))))))
+                     :on-click #(when-let [$body (.closest (js/$ (.-target %)) ".stream-comment-body.ddd-truncated")]
+                                  (when (> (.-length $body) 0)
+                                    (.restore (.data $body "dotdotdot"))
+                                    (reset! (::expanded-comments s) (vec (set (conj @(::expanded-comments s) (:uuid comment-data)))))))
                      :class (utils/class-set {:emoji-comment (:is-emoji comment-data)
                                               :expanded (utils/in? @(::expanded-comments s) (:uuid comment-data))})}]]
                 (when (or is-editing?


### PR DESCRIPTION
Sentry: https://sentry.io/opencompany/oc-beta-web/issues/560865789/

When clicking a not truncated comment (in stream view or fullscreen page) we get an error because right now we try to restore a not truncated comment.
I added a new selector to the comment element to that is the class added by dotdotdot when it truncates the text.
Before restoring the text it checks if jquery is returning at least an element with the new selector, if 0 are returned it means the comment was not truncated, so no need to restore.

Issue repeat:
- get a post with at least one long comment and one short comment in the last 3
- go to stream view
- click on the long comment (that is truncated)
- [x] did it expand? Good
- click on the short comment
- [x] did it error? Good (not really)
- go to fullscreen view
- click on both comments
- [x] 2 errors? Good (not really too)

To test the fix:
- go to stream view
- click on long truncated comment
- [x] did it expand? Good
- click on short comment
- [x] no error? Good
- go to fullscreen view
- click on both comments
- [x] no errors? Good