### PR TITLE
Fix invite panel Slack invite

### DIFF
--- a/src/oc/web/components/ui/org_settings_invite_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_invite_panel.cljs
@@ -46,7 +46,12 @@
   (let [inviting-users-data @(drv/get-ref s :invite-data)
         invite-users (:invite-users inviting-users-data)
         cur-user-data (:current-user-data @(drv/get-ref s :invite-data))
-        invite-from (or @(::inviting-from s) (:auth-source cur-user-data))]
+        team-data (:team-data inviting-users-data)
+        invite-from-default (if (and (= (:auth-source cur-user-data) "slack")
+                                     (:can-slack-invite team-data))
+                              "slack"
+                              "email")
+        invite-from (or @(::inviting-from s) invite-from-default)]
     ;; Setup the invite from if it's not already
     (when (nil? @(::inviting-from s))
       (reset! (::inviting-from s) invite-from))


### PR DESCRIPTION
Bug: after removing the Slack app from Slack side i had auth-source Slack but no slack bot in the JWT. This meant that the invite panel was defaulted to slack invite but with Slack button disabled. Now it check if the user has auth-source slack and if there is at elast a bot in the JWT.

To test:
- with a user that initially signed up with slack
- remove the slack app from slack side
- refresh the web app
- go to invite
- [x] do you see it defaulted to email? Good
- [x] do you see the Slack disabled? Good