### PR TITLE
Fix sticky post body

### DIFF
--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -37,6 +37,11 @@
 
 ;; Local cache for outstanding edits
 
+(defn remove-autosave [s]
+  (when @(::autosave-timer s)
+    (.clearInterval js/window @(::autosave-timer s))
+    (reset! (::autosave-timer s) nil)))
+
 (defn autosave [s]
   (let [entry-editing @(drv/get-ref s :entry-editing)
         body-el (sel1 [:div.rich-body-editor])
@@ -60,6 +65,7 @@
 (defn cancel-clicked [s]
   (let [entry-editing @(drv/get-ref s :entry-editing)
         clean-fn (fn [dismiss-modal?]
+                    (remove-autosave s)
                     (activity-actions/entry-clear-local-cache (:uuid entry-editing) :entry-editing)
                     (when dismiss-modal?
                       (alert-modal/hide-alert))
@@ -253,9 +259,7 @@
                           (when @(::window-click-listener s)
                             (events/unlistenByKey @(::window-click-listener s))
                             (reset! (::window-click-listener s) nil))
-                          (when @(::autosave-timer s)
-                            (.clearInterval js/window @(::autosave-timer s))
-                            (reset! (::autosave-timer s) nil))
+                          (remove-autosave s)
                           (set! (.-onbeforeunload js/window) nil)
                           s)}
   [s]
@@ -305,6 +309,7 @@
                                 (let [_ (dis/dispatch! [:input [:entry-editing :headline] fixed-headline])
                                       updated-entry-editing @(drv/get-ref s :entry-editing)
                                       section-editing @(drv/get-ref s :section-editing)]
+                                  (remove-autosave s)
                                   (if published?
                                     (do
                                       (reset! (::saving s) true)
@@ -346,6 +351,7 @@
                             "disabled")
                    :on-click (fn [_]
                               (when-not disabled?
+                                (remove-autosave s)
                                 (clean-body)
                                 (reset! (::saving s) true)
                                 (activity-actions/entry-save @(drv/get-ref s :entry-editing))))}

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -28,6 +28,11 @@
 
 ;; Unsaved edits handling
 
+(defn remove-autosave [s]
+  (when @(::autosave-timer s)
+    (.clearInterval js/window @(::autosave-timer s))
+    (reset! (::autosave-timer s) nil)))
+
 (defn autosave [s]
   (when s
     (when-let [body-el (sel1 [:div.rich-body-editor])]
@@ -106,8 +111,7 @@
 (defn- real-start-editing [state & [focus]]
   (activity-actions/activity-modal-edit (:activity-data @(drv/get-ref state :fullscreen-post-data)) true)
   (utils/after 100 #(setup-headline state))
-  (when @(::autosave-timer state)
-    (.clearInterval js/window @(::autosave-timer state)))
+  (remove-autosave state)
   (reset! (::autosave-timer state) (utils/every 5000 #(autosave state)))
   (.click (js/$ "div.rich-body-editor a") #(.stopPropagation %))
   (when (and focus
@@ -127,8 +131,7 @@
   (save-on-exit? state)
   (toggle-save-on-exit state false)
   (reset! (::edited-data-loaded state) false)
-  (.clearInterval js/window @(::autosave-timer state))
-  (reset! (::autosave-timer state) nil)
+  (remove-autosave state)
   (activity-actions/activity-modal-edit (:activity-data @(drv/get-ref state :fullscreen-post-data)) false)
   (when @(::headline-input-listener state)
     (events/unlistenByKey @(::headline-input-listener state))
@@ -155,9 +158,9 @@
         dismiss-fn (fn [dismiss-alert?]
                      (when dismiss-alert?
                        (alert-modal/hide-alert))
+                     (stop-editing state)
                      (activity-actions/entry-clear-local-cache (:uuid (:modal-editing-data modal-data))
                       :modal-editing-data)
-                     (stop-editing state)
                      (when dismiss-modal?
                        (close-clicked state)))]
   (if @(::uploading-media state)


### PR DESCRIPTION
BUG: sometimes when clicking Compose button you see that it's populated with the body of the last post you wrote or edited.

Problem: the bug is caused by a race condition btw the view dismiss and the autosave interval we used to avoid losing the user entered text.

Reproduce: it's very hard to reproduce, i was able to do it by checking the indexedDB from the devtools. Since we save the body every 5 seconds, follow these steps:
- click Compose
- type something in the headline
- type something in the body
- looking at indexedDB in dev tools you will be able to see when the autosave take place
- when autosave happens count 4 seconds
- hit Post
with this steps i was able to get the sticky cache every now and then.

Solution: repeat the steps above with the current branch. The problem is that we are removing the interval used to autosave when the entry-edit view is dismissed, meaning that there is a fraction on time btw the save (that removes the last cache) and the view dismiss where, if the autosave happens to fall in this time, you will find the post body when you get back to composing.

