### PR TITLE
Preload sections fix

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -68,6 +68,7 @@
   ;; Check the loaded org
   (let [ap-initial-at (:ap-initial-at @dis/app-state)
         boards (:boards org-data)]
+    (sa/load-other-sections (:boards org-data))
     (cond
       ;; If it's all posts page, loads all posts for the current org
       (or (= (router/current-board-slug) "all-posts")
@@ -75,9 +76,7 @@
       (if (utils/link-for (:links org-data) "activity")
         ;; Load all posts only if not coming from a digest url
         ;; in that case do not load since we already have the results we need
-        (do
-           (aa/all-posts-get org-data ap-initial-at)
-           (sa/load-other-sections (:boards org-data)))
+        (aa/all-posts-get org-data ap-initial-at)
         (router/redirect-404!))
       ; If there is a board slug let's load the board data
       (router/current-board-slug)


### PR DESCRIPTION
Card: https://trello.com/c/ha8ZFQCt

Bug: create a draft, switch to draft board, refresh. Notice that the compose button is disabled. The problem is that the drafts board is readonly (you can't create post directly inside it). The problem is that we don't preload the sections when you load the app from a section instead of AP.

This should fix the above scenario by making sure the sections are all loaded when the org data are loaded.

To test:
- go to the drafts board
- refresh the app
- [x] can you click the compose button? Good
- click it
- click on the board name
- [x] do you see all the sections you can add a post to? Good
- repeat the above from a normal section (not drafts)
- repeat the above from AP