### PR TITLE
Use our own chevron for the select

### DIFF
--- a/scss/partials/_activity_share.scss
+++ b/scss/partials/_activity_share.scss
@@ -329,6 +329,25 @@ div.activity-share-modal-container {
         font-size: 15px;
         color: $deep_navy;
         margin-top: 8px;
+        padding: 0px 12px;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        -o-appearance: none;
+        display: block;
+        position: relative;
+      }
+
+      div.chevron {
+        width: 8px;
+        height: 5px;
+        background-image: cdnUrl("/img/ML/section_access_chevron.svg");
+        background-size: 8px 5px;
+        background-position: center;
+        background-repeat: no-repeat;
+        pointer-events: none;
+        float: right;
+        margin-top: -22px;
+        margin-right: 12px;
       }
 
       div.url-audience-description {

--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -259,7 +259,8 @@
                       "Logged in team only"]
                     [:option
                       {:value :all}
-                      "Public read only"]]]]
+                      "Public read only"]]
+                  [:div.chevron]]]
               (when (not= @(::url-audience s) :team)
                 [:div.url-audience-description
                   (str "Sharing this URL will allow non-registered users to access post content. "


### PR DESCRIPTION
To test:
- share on desktop
- switch to URL
- [ ] do you see the chevron besides the "Who can view this post" select? Good
- [ ] do you on mobile? Good