### PR TITLE
Fix dismiss invite people tooltip

### DIFF
--- a/src/oc/web/components/ui/org_settings_invite_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_invite_panel.cljs
@@ -7,6 +7,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.actions.team :as team-actions]
+            [oc.web.actions.activity :as activity-actions]
             [oc.web.components.ui.user-avatar :refer (user-avatar-image)]
             [oc.web.components.ui.user-type-dropdown :refer (user-type-dropdown)]
             [oc.web.components.ui.slack-users-dropdown :refer (slack-users-dropdown)]))
@@ -72,6 +73,7 @@
     (rum/local 0 ::sending)
     {:will-mount (fn [s]
                    (setup-initial-rows s)
+                   (activity-actions/remove-invite-people-tooltip)
                    s)
      :after-render (fn [s]
                      (doto (js/$ "[data-toggle=\"tooltip\"]")


### PR DESCRIPTION
Card: https://trello.com/c/ZKnzdbch
Item:
> In NUX, dismiss the Invite people tip if user clicks the Invite People link

To test:
- signup
- dismiss the compose tooltip
- add a post
- [x] do you see the invite people tooltip? Good
- click on the invite people button below the tooltip
- dismiss the invite people panel
- [x] do you not see the invite people tooltip anymore? Good
- repeat from step 1 but this time open the menu and click invite people here (not below the tooltip)
- [x] do you NOT see the invite people tooltip anymore when you dismiss the panel? Good