### PR TITLE
Show an explanatory copy when public access is selected.

### DIFF
--- a/scss/partials/_section_editor.scss
+++ b/scss/partials/_section_editor.scss
@@ -222,6 +222,13 @@ div.section-editor {
       }
     }
 
+    div.sectoin-editor-access-public-description {
+      @include avenir_R();
+      font-size: 14px;
+      color: $ui_grey;
+      margin-top: 8px;
+    }
+
     div.section-editor-add-access {
       border-radius: 4px;
       border: 1px solid $carrot_light_gray_1;

--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -216,6 +216,9 @@
                             (reset! (::show-access-list s) false)
                             (dis/dispatch! [:input [:section-editing :access] "public"]))}
               public-access]])
+        (when (= (:access section-editing) "public")
+          [:div.sectoin-editor-access-public-description
+            "Public sections are visible to the world, including search engines."])
         (when (= (:access section-editing) "private")
           [:div.section-editor-add-label
             "Invite member"])


### PR DESCRIPTION
Card: https://trello.com/c/ZKnzdbch
Item:
> when creating a new public section, add this copy so it's clear what happens with public sections "Public sections are visible to the world, including search engines."   https://share.goabstract.com/0213afa9-7312-4f30-b1f3-0ecff314bbb9

To test check that you see the copy only when public is selected as section type.
