### PR TITLE
Dismiss create section on navigation

### DIFF
--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -22,7 +22,9 @@
   (vec (sort-by :name boards)))
 
 (defn anchor-nav! [e url]
-  (utils/event-stop e)
+  (when (and e
+             (.-preventDefault e))
+    (.preventDefault e))
   (router/nav! url)
   (close-navigation-sidebar))
 


### PR DESCRIPTION
Card: https://trello.com/c/ZKnzdbch

Item:
> If open Section settings, and then click on another section, it still has settings open. Should close.

To test:
- click + to add a new section
- nav to another section or AP
- [x] did it dismiss? Good