### PR TITLE
Fix edit footer buttons

### DIFF
--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -402,7 +402,6 @@
           (emoji-picker {:add-emoji-cb (partial add-emoji-cb s)
                          :width 20
                          :height 20
-                         :position "bottom"
                          :default-field-selector "div.entry-edit-modal div.rich-body-editor"
                          :container-selector "div.entry-edit-modal"})
           [:div.entry-edit-legend-container

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -413,7 +413,6 @@
                :title "Shortcuts"
                :data-toggle "tooltip"
                :data-placement "top"
-               :data-container "body"
-               :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"}]
+               :data-container "body"}]
             (when @(::show-legend s)
               [:div.entry-edit-legend-image])]]]]))

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -402,6 +402,7 @@
           (emoji-picker {:add-emoji-cb (partial add-emoji-cb s)
                          :width 20
                          :height 20
+                         :position "bottom"
                          :default-field-selector "div.entry-edit-modal div.rich-body-editor"
                          :container-selector "div.entry-edit-modal"})
           [:div.entry-edit-legend-container

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -429,7 +429,6 @@
                   (emoji-picker {:add-emoji-cb (partial add-emoji-cb s)
                                  :width 20
                                  :height 20
-                                 :position "bottom"
                                  :default-field-selector "div.fullscreen-post div.rich-body-editor"
                                  :container-selector "div.fullscreen-post"})
                   [:div.fullscreen-post-box-footer-legend-container

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -440,8 +440,7 @@
                        :title "Shortcuts"
                        :data-toggle "tooltip"
                        :data-placement "top"
-                       :data-container "body"
-                       :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"}]
+                       :data-container "body"}]
                     (when @(::show-legend s)
                       [:div.fullscreen-post-box-footer-legend-image])]]]
                 [:div.fullscreen-post-box-footer.group

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -429,6 +429,7 @@
                   (emoji-picker {:add-emoji-cb (partial add-emoji-cb s)
                                  :width 20
                                  :height 20
+                                 :position "bottom"
                                  :default-field-selector "div.fullscreen-post div.rich-body-editor"
                                  :container-selector "div.fullscreen-post"})
                   [:div.fullscreen-post-box-footer-legend-container

--- a/src/oc/web/components/ui/emoji_picker.cljs
+++ b/src/oc/web/components/ui/emoji_picker.cljs
@@ -126,7 +126,6 @@
          :data-placement "top"
          :data-container "body"
          :data-toggle "tooltip"
-         :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"
          :disabled (and (not default-field-selector) (not force-enabled) @(::disabled s))
          :on-mouse-down #(when (or default-field-selector force-enabled (not @(::disabled s)))
                            (save-caret-position s)

--- a/src/oc/web/components/ui/multi_picker.cljs
+++ b/src/oc/web/components/ui/multi_picker.cljs
@@ -27,7 +27,6 @@
        :data-toggle "tooltip"
        :data-placement "top"
        :data-container "body"
-       :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"
        :title "Add media and attachments"
        :id toggle-button-id
        :on-click #(swap! (::show-menu s) not)}]


### PR DESCRIPTION
Card: https://trello.com/c/ZKnzdbch

Item:
> consistent handling of media, emoji and shortcuts actions in post editing https://www.useloom.com/share/2861d356a2ad4410b19b5a8e99415fc0

To test:
- Compose
- [x] do you see the tooltip disappear when you click one of the buttons in the footer? Good