### PR TITLE
Pass 2 delegate methods to know when the menu is being open/close.

### DIFF
--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -90,7 +90,7 @@
 (defn entry-point-get [org-slug]
   (api/web-app-version-check
     (fn [{:keys [success body status]}]
-      (when (= status 404)
+      (when-not (= status 404)
         (notification-actions/show-notification (assoc utils/app-update-error :expire 0)))))
   (api/get-entry-point
    (fn [success body]

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -90,7 +90,7 @@
 (defn entry-point-get [org-slug]
   (api/web-app-version-check
     (fn [{:keys [success body status]}]
-      (when-not (= status 404)
+      (when (= status 404)
         (notification-actions/show-notification (assoc utils/app-update-error :expire 0)))))
   (api/get-entry-point
    (fn [success body]

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -48,6 +48,7 @@
                          (rum/local false ::expanded)
                          (rum/local false ::truncated)
                          (rum/local false ::should-scroll-to-comments)
+                         (rum/local false ::more-menu-open)
                          ;; Mixins
                          (am/truncate-element-mixin "activity-body" (* 30 3))
                          am/truncate-comments-mixin
@@ -98,6 +99,7 @@
                    (let [ev-in? (partial utils/event-inside? e)
                          dom-node-selector (str "div." dom-node-class)]
                      (when (and is-mobile?
+                                (not @(::more-menu-open s))
                                 (not is-drafts-board)
                                 (not (ev-in? (sel1 [dom-node-selector :div.more-menu])))
                                 (not (ev-in? (rum/ref-node s :expand-button)))
@@ -129,7 +131,9 @@
                    (not is-drafts-board))
           (tile-menu activity-data dom-element-id))
         (when is-mobile?
-          (more-menu activity-data dom-element-id))
+          (more-menu activity-data dom-element-id
+           {:will-open #(reset! (::more-menu-open s) true)
+            :will-close #(reset! (::more-menu-open s) false)}))
         (when (:new activity-data)
           [:div.new-tag
             "New"])]


### PR DESCRIPTION
Card: https://trello.com/c/ZKnzdbch

Item:
> The more menu tap target is great now, but closing it should also have a bigger tap target. When it's open and I want to close it, I end up opening the post by mistake.

To test:
- open AP on mobile
- click on a post
- [x] did it open fullscreen? Good
- go back to AP
- open the ellipsis menu
- click on the post again
- [x] did it dismiss the menu but not nav to the fullscreen post? Good
- now click on the post
- [x] did it open fullscreen? Good
- go back to AP
- open the ellipsis menu
- click on the ellipsis again to dismiss it
- [x] did it dismiss the menu but not nav to the fullscreen post? Good
- now click on the post
- [x] did it open fullscreen? Good