### PR TITLE
Redirect to the AP page when deleting the currently selecteced board.

### DIFF
--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -89,7 +89,9 @@
   (api/delete-board section-slug (fn [status success body]
     (if success
       (let [org-slug (router/current-org-slug)]
-        (dispatcher/dispatch! [:section-delete org-slug section-slug]))
+        (if (= section-slug (router/current-board-slug))
+          (router/redirect! (oc-urls/all-posts org-slug))
+          (dispatcher/dispatch! [:section-delete org-slug section-slug])))
       (.reload (.-location js/window))))))
 
 (defn refresh-org-data []


### PR DESCRIPTION
BUG: if you delete a section now on mainline you get a 404.

Fix: redirect immediately after deleting a section if the user deleted the currently selected section, remove it from the app state only if it's not the currently selected.

To test:
- go to section "A"
- delete section "A"
- [x] are you redirected to AP of the current org? Good
- [x] do you NOT see a 404 page? Good 