### PR TITLE
Fix navigation height calc

### DIFF
--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -168,7 +168,7 @@
 div.left-navigation-sidebar {
   position: absolute;
   position: fixed;
-  max-height: calc(100vh - 84px);
+  max-height: calc(100vh - 96px);
   overflow-y: auto;
   overflow-x: visible;
   padding-bottom: 20px;
@@ -592,7 +592,7 @@ div.left-navigation-sidebar {
   div.left-navigation-sidebar-footer {
     margin-left: 20px;
     position: relative;
-    bottom: 46px;
+    padding-bottom: 46px;
 
     @include mobile() {
       // Temp remove bottom links on mobile

--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -607,6 +607,12 @@ div.left-navigation-sidebar {
       }
     }
 
+    &.navigation-sidebar-overflow {
+      position: absolute;
+      bottom: 46px;
+      padding-bottom: 0px;
+    }
+
     div.invite-people-tooltip-container {
       border: 2px dashed $carrot_gold;
       background-color: $light_gold;

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -37,7 +37,7 @@
       (when (not= height @(::content-height s))
         (reset! (::content-height s) height))))
   (when-let [navigation-sidebar-footer (rum/ref-node s "left-navigation-sidebar-footer")]
-    (let [footer-height (.height (js/$ navigation-sidebar-footer))]
+    (let [footer-height (+ (.height (js/$ navigation-sidebar-footer)) 86)]
       (when (not= footer-height @(::footer-height s))
         (reset! (::footer-height s) footer-height)))))
 
@@ -198,7 +198,7 @@
                      :dangerouslySetInnerHTML (utils/emojify (or (:name board) (:slug board)))}]]])])]
       [:div.left-navigation-sidebar-footer
         {:ref "left-navigation-sidebar-footer"
-         :style {:position (if is-tall-enough? "absolute" "relative")}}
+         :class (utils/class-set {:navigation-sidebar-overflow is-tall-enough?})}
         ;; invite people tooltip
         (when show-invite-people-tooltip
           [:div.invite-people-tooltip-container.group


### PR DESCRIPTION
Fix the navigation button, make sure the invite people button is in the right place when the screen is not tall enough to have the absolutely positioned navigation sidebar and when it's not tall enough.

To test:
- use an org with some sections
- resize the screen height
- make sure the invite people button is always in the right place and it's always reachable (scrolling or not)