### PR TITLE
Sticky footer on post edit

### DIFF
--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -293,10 +293,20 @@ div.entry-edit-modal-container {
           @include avenir_R();
           font-size: 16px;
           line-height: 22px;
-          min-height: 240px;
-          max-height: calc(100vh - 315px);
-          overflow-y: auto;
-          overflow-x: hidden;
+
+          @media screen and (min-height: 556px) {
+            min-height: 240px;
+            max-height: calc(100vh - 315px);
+            overflow-y: auto;
+            overflow-x: hidden;
+          }
+
+          @include mobile() {
+            min-height: initial;
+            max-height: initial;
+            overflow-x: auto;
+            overflow-y: auto;
+          }
 
           & > *:first-child {
             margin-top: 0px;

--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -293,7 +293,7 @@ div.entry-edit-modal-container {
           @include avenir_R();
           font-size: 16px;
           line-height: 22px;
-          min-height: 160px;
+          min-height: 240px;
           max-height: calc(100vh - 315px);
           overflow-y: auto;
           overflow-x: hidden;

--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -155,7 +155,7 @@ div.entry-edit-modal-container {
 
   div.entry-edit-modal {
     width: 720px;
-    margin: 112px auto 32px;
+    margin: 112px auto 0px;
     position: relative;
     background-color: white;
     border-radius: 6px;
@@ -294,6 +294,9 @@ div.entry-edit-modal-container {
           font-size: 16px;
           line-height: 22px;
           min-height: 160px;
+          max-height: calc(100vh - 315px);
+          overflow-y: auto;
+          overflow-x: hidden;
 
           & > *:first-child {
             margin-top: 0px;

--- a/scss/partials/_fullscreen_post.scss
+++ b/scss/partials/_fullscreen_post.scss
@@ -332,13 +332,12 @@ div.fullscreen-post-container {
             @include avenir_R();
             font-size: 16px;
             line-height: 22px;
-            min-height: 240px;
-            max-height: calc(100vh - 315px);
-            overflow-y: auto;
-            overflow-x: hidden;
-
-            @include mobile() {
-              min-height: initial;
+            
+            @media screen and (min-height: 556px) {
+              min-height: 240px;
+              max-height: calc(100vh - 315px);
+              overflow-y: auto;
+              overflow-x: hidden;
             }
 
             & > *:first-child {

--- a/scss/partials/_fullscreen_post.scss
+++ b/scss/partials/_fullscreen_post.scss
@@ -46,6 +46,7 @@ div.fullscreen-post-container {
       padding: 32px 40px;
       border: 1px solid transparent;
       box-shadow: 0px 2px 4px 0px rgba(#E4E3DE, 0.5);
+      margin: 112px auto 0px;
 
       div.fullscreen-post-right-column {
         display: none;
@@ -332,6 +333,9 @@ div.fullscreen-post-container {
             font-size: 16px;
             line-height: 22px;
             min-height: 160px;
+            max-height: calc(100vh - 315px);
+            overflow-y: auto;
+            overflow-x: hidden;
 
             @include mobile() {
               min-height: initial;

--- a/scss/partials/_fullscreen_post.scss
+++ b/scss/partials/_fullscreen_post.scss
@@ -332,7 +332,7 @@ div.fullscreen-post-container {
             @include avenir_R();
             font-size: 16px;
             line-height: 22px;
-            min-height: 160px;
+            min-height: 240px;
             max-height: calc(100vh - 315px);
             overflow-y: auto;
             overflow-x: hidden;

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -402,7 +402,7 @@
           (emoji-picker {:add-emoji-cb (partial add-emoji-cb s)
                          :width 20
                          :height 20
-                         :position "bottom"
+                         :position "top"
                          :default-field-selector "div.entry-edit-modal div.rich-body-editor"
                          :container-selector "div.entry-edit-modal"})
           [:div.entry-edit-legend-container

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -428,7 +428,7 @@
                   (emoji-picker {:add-emoji-cb (partial add-emoji-cb s)
                                  :width 20
                                  :height 20
-                                 :position "bottom"
+                                 :position "top"
                                  :default-field-selector "div.fullscreen-post div.rich-body-editor"
                                  :container-selector "div.fullscreen-post"})
                   [:div.fullscreen-post-box-footer-legend-container


### PR DESCRIPTION
Card: https://trello.com/c/esSCYxRj
Item:
> Sticky compose icons/menus

Abstract: https://projects.invisionapp.com/share/XPKHEVITVHM#/screens

To test:
- New post
- insert some content in the body
- [x] can you always see the footer buttons? Good
- [x] can you use those buttons? Good
- save the post (with a tall body)
- click on the item in grid view to enter fullscreen
- [x] can you see the full content of the post scrolling the page? Good
- [x] can you see the add comment and the comments if any? Good
- click edit post
- [x] can you see the footer buttons without scrolling? Good
- [x] can you use those buttons? Good