### PR TITLE
June navigation update

### DIFF
--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -39,7 +39,7 @@ div.dashboard-layout {
     width: auto;
     width: 100%;
     position: relative;
-    max-width: 944px;
+    max-width: 952px;
 
     @include mobile(){
       padding: 0px;

--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -38,6 +38,8 @@ div.dashboard-layout {
     margin: 0 auto;
     width: auto;
     width: 100%;
+    position: relative;
+    max-width: 944px;
 
     @include mobile(){
       padding: 0px;
@@ -47,6 +49,7 @@ div.dashboard-layout {
       width: #{$board_container_width}px;
       background-color: $oc_gray_8;
       position: relative;
+      float: right;
 
       @include mobile() {
         width: 100%;

--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -96,8 +96,7 @@
 
 @mixin item-selected() {
   background-color: $feint_emerald;
-  border-top-right-radius: 100px;
-  border-bottom-right-radius: 100px;
+  border-radius: 6px;
 
   @include mobile() {
     background-color: transparent;
@@ -133,8 +132,7 @@
 
 @mixin item-hover(){
   background-color: rgba($carrot_light_gray_4, 0.2);
-  border-top-right-radius: 100px;
-  border-bottom-right-radius: 100px;
+  border-radius: 6px;
 
   @include mobile() {
     background-color: transparent;
@@ -174,7 +172,6 @@ div.left-navigation-sidebar {
   padding-bottom: 20px;
   width: #{$left_navigation_sidebar_width}px;
   top: 96px;
-  left: 0px;
   height: calc(100vh - 80px);
   @include no-user-select();
 

--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -26,7 +26,7 @@
 
   .internal {
     @include avenir_M();
-    font-size: 15px;
+    font-size: 14px;
     line-height: 1.71;
     color: $ui_grey;
     text-decoration: none;
@@ -106,7 +106,7 @@
   .internal, div.all-posts-label, div.drafts-label {
     color: $carrot_green;
     @include avenir_M();
-    font-size: 15px;
+    font-size: 14px;
     line-height: 1.71;
     text-decoration: none;
 
@@ -123,6 +123,10 @@
         font-size: 14px;
       }
     }
+  }
+
+  div.all-posts-label, div.drafts-label {
+    font-size: 15px;
   }
 
   div.all-posts-label {
@@ -142,7 +146,7 @@
   .internal {
     color: $deep_navy;
     @include avenir_M();
-    font-size: 15px;
+    font-size: 14px;
     line-height: 1.71;
     text-decoration: none;
 

--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -26,7 +26,7 @@
 
   .internal {
     @include avenir_M();
-    font-size: 16px;
+    font-size: 15px;
     line-height: 1.71;
     color: $ui_grey;
     text-decoration: none;
@@ -45,7 +45,7 @@
 
   div.drafts-label {
     @include avenir_M();
-    font-size: 16px;
+    font-size: 15px;
     line-height: 1.71;
     color: $ui_grey;
     text-decoration: none;
@@ -58,7 +58,7 @@
 
     span.count {
       @include avenir_M();
-      font-size: 16px;
+      font-size: 15px;
       color: #C5C6C8;
 
       @include mobile() {
@@ -74,7 +74,7 @@
 
   div.all-posts-label {
     @include avenir_H();
-    font-size: 16px;
+    font-size: 15px;
     line-height: 1.71;
     color: $deep_navy;
     text-decoration: none;
@@ -88,7 +88,7 @@
 
     span.count {
       @include avenir_M();
-      font-size: 16px;
+      font-size: 15px;
       color: #C5C6C8;
     }
   }
@@ -106,7 +106,7 @@
   .internal, div.all-posts-label, div.drafts-label {
     color: $carrot_green;
     @include avenir_M();
-    font-size: 16px;
+    font-size: 15px;
     line-height: 1.71;
     text-decoration: none;
 
@@ -142,7 +142,7 @@
   .internal {
     color: $deep_navy;
     @include avenir_M();
-    font-size: 16px;
+    font-size: 15px;
     line-height: 1.71;
     text-decoration: none;
 
@@ -157,7 +157,7 @@
 
   div.all-posts-label, div.drafts-label {
     color: $deep_navy;
-    font-size: 16px;
+    font-size: 15px;
     line-height: 1.71;
     text-decoration: none;
   }
@@ -299,7 +299,7 @@ div.left-navigation-sidebar {
     }
 
     div.all-posts-label, div.drafts-label {
-      padding: 7px 5px 2px 5px;
+      padding: 2px 5px 1px 5px;
       width: 148px;
       text-align: left;
       margin-left: 16px;
@@ -313,12 +313,12 @@ div.left-navigation-sidebar {
 
     div.all-posts-icon {
       background-image: cdnUrl("/img/ML/digest_icon_grey.svg");
-      background-size: 18px 18px;
-      width: 18px;
-      height: 18px;
+      background-size: 18px 16px;
+      width: 16px;
+      height: 16px;
       float: left;
       margin-left: -4px;
-      margin-top: 8px;
+      margin-top: 6px;
 
       @include mobile() {
         margin-left: 0px;
@@ -337,9 +337,9 @@ div.left-navigation-sidebar {
 
       @include mobile() {
         background-image: cdnUrl("/img/ML/drafts_icon_grey.svg");
-        background-size: 18px 18px;
-        width: 18px;
-        height: 18px;
+        background-size: 16px 16px;
+        width: 16px;
+        height: 16px;
         float: left;
         margin-left: 0px;
         margin-top: 0px;
@@ -652,7 +652,7 @@ div.left-navigation-sidebar {
 
       div.invite-people-tooltip-title {
         @include avenir_H();
-        font-size: 16px;
+        font-size: 15px;
         color: $deep_navy;
         width: 100%;
         margin: 24px auto 0px;

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -207,7 +207,7 @@
                   (when (router/current-board-slug)
                     [:div.board-name-with-icon
                       {:dangerouslySetInnerHTML (if is-all-posts
-                                                  #js {"__html" "All Posts"}
+                                                  #js {"__html" "All posts"}
                                                   (utils/emojify (:name board-data)))}])
                   ;; Settings button
                   (when (and (router/current-board-slug)

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -154,18 +154,6 @@
         is-mobile? (responsive/is-tablet-or-mobile?)
         empty-board? (and (not nux)
                           (zero? (count (:fixed-items board-data))))
-        sidebar-width (+ responsive/left-navigation-sidebar-width
-                         responsive/left-navigation-sidebar-minimum-right-margin)
-        board-container-style {:marginLeft (if is-mobile?
-                                             "0px"
-                                             (str (max
-                                                   sidebar-width
-                                                   (+
-                                                    (/
-                                                     (- @(::ww s) responsive/dashboard-container-width sidebar-width)
-                                                     2)
-                                                    sidebar-width))
-                                             "px"))}
         is-drafts-board (= (:slug board-data) utils/default-drafts-board-slug)
         all-boards (drv/react s :editable-boards)
         board-view-cookie (router/last-board-view-cookie (router/current-org-slug))
@@ -210,8 +198,7 @@
           (when (or (not is-mobile?)
                     (not mobile-navigation-sidebar))
             [:div.board-container.group
-              {:class (when is-all-posts "all-posts-container")
-               :style board-container-style}
+              {:class (when is-all-posts "all-posts-container")}
               ;; Board name row: board name, settings button and say something button
               [:div.board-name-container.group
                 {:on-click #(dis/dispatch! [:input [:mobile-navigation-sidebar] (not mobile-navigation-sidebar)])}

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -122,12 +122,12 @@
       {:class (utils/class-set {:show-mobile-boards-menu mobile-navigation-sidebar
                                 :showing-invite-people-tooltip show-invite-people-tooltip})
        :style {:left (when-not is-mobile?
-                      (str (/ (- @(::window-width s) 944) 2) "px"))}}
+                      (str (/ (- @(::window-width s) 952) 2) "px"))}}
       [:div.mobile-board-name-container
         {:on-click #(dis/dispatch! [:input [:mobile-navigation-sidebar] (not mobile-navigation-sidebar)])}
         [:div.board-name
           (cond
-            is-all-posts "All Posts"
+            is-all-posts "All posts"
             is-drafts-board "Drafts"
             :else (:name board-data))]]
       [:div.left-navigation-sidebar-content
@@ -142,7 +142,7 @@
             [:div.all-posts-icon
               {:class (when is-all-posts "selected")}]
             [:div.all-posts-label
-              "All Posts"]])
+              "All posts"]])
         (when show-drafts
           (let [board-url (oc-urls/board (:slug drafts-board))]
             [:a.drafts.hover-item.group


### PR DESCRIPTION
Move the navigation sidebar closer to the board content instead of being to the far left of the window.

Card: https://trello.com/c/esSCYxRj
Item:
> Updated navigation

Abstract: https://invis.io/9SKHEPMUJ3Q

To test:
- load on desktop
- resize the window
- [x] does the left navigation sidebar stays where it belongs? Good
- switch to mobile and refresh
- [x] do you NOT see the navigation menu? Good
- open the navigation menu tapping the chevron besides the board name
- [x] do you see the menu? Good
- [x] is it ok? Good