### PR TITLE
Ryan tweaks

### DIFF
--- a/resources/public/img/ML/tile_comments_icon.svg
+++ b/resources/public/img/ML/tile_comments_icon.svg
@@ -5,7 +5,7 @@
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Mobile-density-udpates" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Mobile:-No-comments" transform="translate(-248.000000, -378.000000)" fill="#34414F">
+        <g id="Mobile:-No-comments" transform="translate(-248.000000, -378.000000)" fill="#898D93">
             <g id="Group-2" transform="translate(113.000000, 129.000000)">
                 <g id="Group-7" transform="translate(135.000000, 247.000000)">
                     <path d="M12,13.317309 C12,13.9818139 11.5677307,14.1971505 11.0409577,13.8031077 L8.1,11.6031786 L1.20000766,11.6031786 C0.537261729,11.6031786 0,11.0662926 0,10.4015035 L0,3.20167506 C0,2.53800825 0.538927428,2 1.20000766,2 L10.7999923,2 C11.4627383,2 12,2.53688596 12,3.20167506 L12,13.317309 Z" id="Combined-Shape"></path>

--- a/scss/partials/_comments_summary.scss
+++ b/scss/partials/_comments_summary.scss
@@ -44,7 +44,10 @@ div.is-comments {
     // max-width: 74%;
     overflow: hidden;
     text-overflow: ellipsis;
-    opacity: 0.3;
+
+    &.add-a-comment {
+      opacity: 0.3;
+    }
 
     @include mobile() {
       max-width: 68vw;

--- a/scss/partials/_site_header.scss
+++ b/scss/partials/_site_header.scss
@@ -202,9 +202,10 @@ nav.site-navbar {
           margin-top: 2px;
           width: 72px;
           // text-align: center;
-          padding: 2px 0px 0px;
+          padding: 4px 0px 0px;
           font-size: 13px;
           letter-spacing: 0.46px;
+          min-width: 64px;
         }
 
         span.slack-orange-icon {

--- a/src/oc/web/components/activity_card.cljs
+++ b/src/oc/web/components/activity_card.cljs
@@ -67,7 +67,9 @@
             (:name publisher)]
           [:div.time-since
             (let [t (or (:published-at activity-data) (:created-at activity-data))]
-              (utils/time-since t))]]
+              [:time
+                {:date-time t}
+                (utils/time-since t)])]]
         [:div.activity-card-preview-title
           {:dangerouslySetInnerHTML (utils/emojify (:headline activity-data))}]
         [:div.activity-card-preview-body

--- a/src/oc/web/components/ui/comments_summary.cljs
+++ b/src/oc/web/components/ui/comments_summary.cljs
@@ -61,7 +61,8 @@
               (user-avatar-image user-data (not (responsive/is-tablet-or-mobile?)))])]
         ; Comments count
         [:div.is-comments-summary.fs-hide
-          {:class (str "comments-count-" (:uuid entry-data))}
+          {:class (utils/class-set {(str "comments-count-" (:uuid entry-data)) true
+                                    :add-a-comment (not (pos? comments-count))})}
           (if (responsive/is-tablet-or-mobile?)
             (comment-summary-string comments-authors)
             (if (pos? comments-count)

--- a/src/oc/web/components/ui/stream_attachments.cljs
+++ b/src/oc/web/components/ui/stream_attachments.cljs
@@ -20,16 +20,18 @@
     (when (pos? atc-num)
       [:div.stream-attachments
         [:div.stream-attachments-content
-          (for [atch attachments-list
-                :let [created-at (:created-at atch)
+          (for [idx (range (count attachments-list))
+                :let [atch (nth attachments-list idx)
+                      atch-key (str "attachment-" idx "-" (:file-url atch))
+                      created-at (:created-at atch)
                       file-name (:file-name atch)
                       size (:file-size atch)
                       subtitle (when size
                                  (filesize size :binary false :format "%.2f"))]]
             [:div.stream-attachments-item.group
+              {:key atch-key}
               [:a.group
-                {:key (str "attachment-" size "-" (:file-url atch))
-                 :href (:file-url atch)
+                {:href (:file-url atch)
                  :target "_blank"}
                 [:div.attachment-info
                   {:class (when editable? "editable")}


### PR DESCRIPTION
Ryan suggestions to fix a couple of small UI things:
- Start button on marketing site on mobile was off center and too big
- comments icon in grid view was wrong color
- stream view comments summary has wrong color/hover state

Also there are 2 other tweaks needed for dev mostly:
- in the grid view preview use the time HTML tag instead of a simple DIV to keep it consistence with the other items
- fix a warning of missing `key` from react when rendering the attachments in the stream view