### PR TITLE
Settings infinite loading loop

### DIFF
--- a/src/oc/web/stores/org.cljs
+++ b/src/oc/web/stores/org.cljs
@@ -1,7 +1,6 @@
 (ns oc.web.stores.org
   (:require [oc.web.lib.utils :as utils]
             [taoensso.timbre :as timbre]
-            [oc.web.router :as router]
             [oc.web.dispatcher :as dispatcher]))
 
 (defn read-only-org
@@ -20,9 +19,7 @@
   ;; We need to remove the boards that are no longer in the org except all-posts and drafts
   (let [boards-key (dispatcher/boards-key (:slug org-data))
         old-boards (get-in db boards-key)
-        keep-boards (case (router/current-board-slug)
-                     "all-posts" [:all-posts]
-                     [])
+        keep-boards [:all-posts]
         board-slugs (set (concat (map (comp keyword :slug) (:boards org-data)) keep-boards))
         filter-board (fn [[k v]]
                        (board-slugs k))

--- a/src/oc/web/stores/org.cljs
+++ b/src/oc/web/stores/org.cljs
@@ -1,6 +1,7 @@
 (ns oc.web.stores.org
   (:require [oc.web.lib.utils :as utils]
             [taoensso.timbre :as timbre]
+            [oc.web.router :as router]
             [oc.web.dispatcher :as dispatcher]))
 
 (defn read-only-org
@@ -19,7 +20,10 @@
   ;; We need to remove the boards that are no longer in the org except all-posts and drafts
   (let [boards-key (dispatcher/boards-key (:slug org-data))
         old-boards (get-in db boards-key)
-        board-slugs (set (map (comp keyword :slug) (:boards org-data)))
+        keep-boards (case (router/current-board-slug)
+                     "all-posts" [:all-posts]
+                     [])
+        board-slugs (set (concat (map (comp keyword :slug) (:boards org-data)) keep-boards))
         filter-board (fn [[k v]]
                        (board-slugs k))
         next-boards (into {} (filter filter-board old-boards))]


### PR DESCRIPTION
Bug: on mainline and master right now, if you open the settings panel when you are on AP (and on Must see) you get a infinite loop of the loading spinner and the settings panel overlay.

This fixes the bug described above. The problem is that in one of the latest PR to correctly react to change services i had to make sure we were removing the sections not present in the org response payload. With that change i was removing AP data too since that's never contained in the list of boards.

To test:
- go to AP
- click the user menu
- click on invite people
- [x] do you see the settings panel? Good
- [x] do you NOT see it reloading and reloading over and over? Good

@thepug i assigned this PR  to you since you need to add `:must-see` key too in oc.web.stores.org line 22 to avoid happening the same when you open the settings panel on must see. Ping me with any question