### PR TITLE
Unique IDs

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -319,7 +319,7 @@
                     (= (count (:fixed-items board-data)) 1)
                     first-post
                     ;; from CarrotHQ
-                    (= (:user-id first-post-author) "0000-0000-0000"))
+                    (= (:user-id first-post-author) "1111-1111-1111"))
                 ;; has no posts
                (zero? (count (:fixed-items board-data))))))))
 


### PR DESCRIPTION
Related PR: https://github.com/open-company/open-company-storage/pull/133/files

Change the first post user-id since it was equal to the draft board uuid.

To test:
- signup for new org
- go through all the onboarding
- [x] do you see the add post tooltip once you dismiss the orange welcome screen? Good