### PR TITLE
AP and MS preload

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -425,8 +425,8 @@
         org-data (dis/org-data)
         must-see-count (:must-see-count dis/org-data)
         new-must-see-count (if (not must-see)
-                              (+ must-see-count 1)
-                              (- must-see-count 1))]
+                              (inc must-see-count)
+                              (dec must-see-count))]
     (dis/dispatch! [:org-loaded
                     (assoc org-data :must-see-count new-must-see-count)
                     false])
@@ -440,7 +440,8 @@
                           (api/get-org org-data
                             (fn [{:keys [status body success]}]
                               (let [api-org-data (json->cljs body)]
-                                (dis/dispatch! [:org-loaded api-org-data false]))))
+                                (dis/dispatch! [:org-loaded api-org-data false])
+                                (must-see-get org-data))))
                           (dis/dispatch! [:entry
                                           (dis/current-board-key)
                                           (:uuid activity-data)

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -108,7 +108,8 @@
         show-boards (or create-link (pos? (count boards)))
         show-all-posts (and (jwt/user-is-part-of-the-team (:team-id org-data))
                             (utils/link-for (:links org-data) "activity"))
-        show-must-see (pos? (:must-see-count org-data))
+        show-must-see (or is-must-see
+                          (pos? (:must-see-count org-data)))
         drafts-board (first (filter #(= (:slug %) utils/default-drafts-board-slug) all-boards))
         drafts-link (utils/link-for (:links drafts-board) "self")
         show-drafts (or (= (router/current-board-slug) utils/default-drafts-board-slug)


### PR DESCRIPTION
### Review after #576

Always preload AP and MS if an activity link is available.

To test:
- go to a single board
- check the network tab
- [x] do you see a request for AP (ending in /activity)? Good
- [x] do you see a request for MS (ending in /activity?must-see=true)? Good
- now click on AP
- [x] did you NOT see the shaking carrot before the AP content appeared? Good
- now add a Must See
- add another
- go to MS
- [x] did you NOT see a shaking carrot before the MS content appeared? Good
- [x] did you find all the correct posts in MS? Good