### PR TITLE
Fix activity move

### DIFF
--- a/src/oc/web/stores/activity.cljs
+++ b/src/oc/web/stores/activity.cljs
@@ -149,9 +149,8 @@
 
 (defmethod dispatcher/action :activity-move
   [db [_ activity-data org-slug board-data]]
-  (let [fixed-activity-data (merge activity-data {:board-slug (:slug board-data)
-                                                  :board-name (:name board-data)
-                                                  :board-uuid (:uuid board-data)})
+  (let [change-data (dispatcher/change-data db)
+        fixed-activity-data (au/fix-entry activity-data board-data change-data)
         all-posts-activity-key (dispatcher/activity-key
                                 org-slug
                                 :all-posts


### PR DESCRIPTION
Use `oc.web.utils.activity/fix-entry` to move an activity to another board instead of replacing only the board related keys in the entry map.
This way also the NEW badge is reset and other related stuff.

To test:
- move an activity from board A to board B
- [ ] did it work? Good
- refresh
- [ ] still in the new board? Good