### PR TITLE
Fix WST requests

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -36,11 +36,17 @@
 
 ;; Reads data
 
-(defn request-reads-data [item-id]
+(defn request-reads-data
+  "Request the list of readers of the given item."
+  [item-id]
   (api/request-reads-data item-id))
 
-(defn request-reads-count [item-ids]
-  (api/request-reads-data item-ids))
+(defn request-reads-count
+  "Request the reads count data only for the items we don't have already."
+  [item-ids]
+  (let [cleaned-ids (au/clean-who-reads-count-ids item-ids (dis/activities-read-data))]
+    (when (seq cleaned-ids)
+      (api/request-reads-data cleaned-ids))))
 
 ;; All Posts
 (defn all-posts-get-finish [from {:keys [body success]}]

--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -46,7 +46,7 @@
   [item-ids]
   (let [cleaned-ids (au/clean-who-reads-count-ids item-ids (dis/activities-read-data))]
     (when (seq cleaned-ids)
-      (api/request-reads-data cleaned-ids))))
+      (api/request-reads-count cleaned-ids))))
 
 ;; All Posts
 (defn all-posts-get-finish [from {:keys [body success]}]

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -701,11 +701,9 @@
                                 :body (when (seq body) (json->cljs body))}))))))
 
 (defn request-reads-data [item-id]
-  (ws-cc/who-read item-id))
+  (when (seq item-id)
+    (ws-cc/who-read item-id)))
 
 (defn request-reads-count [item-ids]
-  (let [activities-read-data (dispatcher/activities-read-data)
-        all-items (set (keys activities-read-data))
-        request-set (set item-ids)
-        needed-ids (into [] (clojure.set/difference request-set all-items))]
-    (ws-cc/who-read-count needed-ids)))
+  (when (seq item-ids)
+    (ws-cc/who-read-count item-ids)))

--- a/src/oc/web/lib/ws_change_client.cljs
+++ b/src/oc/web/lib/ws_change_client.cljs
@@ -72,7 +72,7 @@
 
 (defn who-read [item-ids]
   (when @chsk-send!
-    (timbre/debug "Sending item/who-read-count for item-ids:" item-ids)
+    (timbre/debug "Sending item/who-read for item-ids:" item-ids)
     (@chsk-send! [:item/who-read item-ids] 1000)))
 
 (defn subscribe

--- a/src/oc/web/utils/activity.cljs
+++ b/src/oc/web/utils/activity.cljs
@@ -247,3 +247,12 @@
               (> (.-bottom rect) responsive/navbar-height))
          ;; Item right is less than the screen width
          (<= (.-right rect) win-width))))
+
+(defn clean-who-reads-count-ids
+  "Given a list of items we want to request the who reads count
+   and the current read data, filter out the ids we already have data."
+  [item-ids activities-read-data]
+  (let [all-items (set (keys activities-read-data))
+        request-set (set item-ids)
+        diff-ids (clojure.set/difference request-set all-items)]
+    (into [] diff-ids)))


### PR DESCRIPTION
BUG: if you check the CS logs starting the web app on mainline right now you get this error every now and then:
```
18-07-17 15:51:25 bagoPro.local INFO [oc.change.async.persistence:?] - Who read request for: () by: c891c6cf-a683-477c-b8a6-69a611fe37eb
18-07-17 15:51:25 bagoPro.local ERROR [oc.change.async.persistence:204] -
                                                               java.lang.Thread.run              Thread.java:  745
                                 java.util.concurrent.ThreadPoolExecutor$Worker.run  ThreadPoolExecutor.java:  617
                                  java.util.concurrent.ThreadPoolExecutor.runWorker  ThreadPoolExecutor.java: 1142
                                                                                ...
                                                  clojure.core.async/thread-call/fn                async.clj:  441
oc.change.async.persistence/persistence-loop/fn/state-machine--auto--/fn/inst-29242          persistence.clj:  202
                                                                                ...
                             oc.change.async.persistence/handle-persistence-message          persistence.clj:   85 (repeats 2 times)
                          oc.change.async.persistence/handle-persistence-message/fn          persistence.clj:   85
                                        oc.change.resources.read/eval29087/retrieve                 read.clj:   37
clojure.lang.ExceptionInfo: Input to retrieve does not match schema:

                            	   [(named (not (oc.lib.schema/unique-id? ())) item-id)]


     error: [(named (not (oc.lib.schema/unique-id? ())) item-id)]
    schema: [{:schema (pred oc.lib.schema/unique-id?),
              :optional? false,
              :name item-id}]
      type: :schema.core/error
     value: [()]
```
As you can see the problem is that the client sends requests with an empty list of items. This happens because to avoid loading multiple times the same data we filter the list of item ids with the list of counts we already have. After the initial loads this difference is often empty since we have already loaded all the count data.

To test:
- start this branch
- go to AP
- [x] check that you get the reads count
- hover on some posts views count to load the reads list
- [x] check that you get the list of reads
- switch to a section
- [x] check that you still have the reads data
- hover on some posts views count to load the reads list
- [x] check that you get the list of reads
- refresh on the section
- [x] check that you see the reads count for all the posts
- hover on some posts
- [x] check that you see the reads list
- switch to AP (no refresh)
- [x] check that you see the reads count for the posts that are not in the section you were before
- hover on some posts from the section you came from and not
- [x] check that you see the reads list for all of them