### PR TITLE
Fix compose check

### DIFF
--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -167,10 +167,7 @@
         board-switch (::board-switch s)
         show-drafts (pos? (:count drafts-link))
         mobile-navigation-sidebar (drv/react s :mobile-navigation-sidebar)
-        can-compose (or (and (not board-data)
-                             (pos? (count all-boards)))
-                        (and board-data
-                             (not (:read-only board-data))))
+        can-compose (pos? (count all-boards))
         should-show-top-compose (jwt/user-is-part-of-the-team (:team-id org-data))]
       ;; Entries list
       [:div.dashboard-layout.group

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -68,7 +68,8 @@
 
 (defn get-board-for-edit [s]
   (let [board-data @(drv/get-ref s :board-data)]
-    (if-not board-data
+    (if (or (not board-data)
+            (= (:slug board-data) utils/default-drafts-board-slug))
       (get-default-section s)
       {:board-slug (:slug board-data)
        :board-name (:name board-data)})))


### PR DESCRIPTION
BUG: go to drafts board and click New, it's disabled because drafts is not editable.

Fix: pick a board different than the draft boards to add the new post too

To test:
- go to drafts board
- click New
- [x] do you see the new post defaulted to a board A different then Draft? Good
- go to a board B different than board A
- click New
- [x] do you see the same B board picked and not A? Good