### PR TITLE
Fix onboard overlay

### DIFF
--- a/src/oc/web/actions/nux.cljs
+++ b/src/oc/web/actions/nux.cljs
@@ -124,7 +124,8 @@
         (when (= step 1)
           (if should-show-first-tip
             (dis/dispatch! [:input [:show-add-post-tooltip] true])
-            (dis/dispatch! [:input [:show-onboard-overlay] true])))
+            (when-not (:show-add-post-tooltip @dis/app-state)
+              (dis/dispatch! [:input [:show-onboard-overlay] true]))))
         (when (and (= step 2)
                    ;; Wait for the user to add at least a post
                    can-proceed-to-second-step?)


### PR DESCRIPTION
Stuart's bug: 
> chrome/desktop. created a newco with email.
> first thing I did was create a new section. I didn’t dismiss the yellow tip. just went straight to create a new section.
> my email was stuartlevinson+myeyedr@gmail.com, so it was a new email

To test:
- replicate the scenario
- [ ] do you NOT see the onboard overlay after adding a new section? Good