### PR TITLE
Contributor invite

### DIFF
--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -479,7 +479,9 @@
   [complete-user-data invited-user invite-from user-type first-name last-name note callback]
   (when (and invited-user invite-from user-type)
     (let [org-data (dispatcher/org-data)
-          team-data (dispatcher/team-data)
+          team-data (or (dispatcher/team-data)
+                        (first (filter #(= (:team-id org-data) (:team-id %))
+                                       (dispatcher/teams-data))))
           invitation-link (utils/link-for
                            (:links team-data)
                            "add"

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -105,7 +105,7 @@
                         (pos? (:count drafts-link)))
         org-slug (router/current-org-slug)
         show-invite-people (and org-slug
-                                (jwt/is-admin? (:team-id org-data)))
+                                (utils/is-admin-or-author? org-data))
         is-tall-enough? (or (not @(::content-height s))
                             (not @(::footer-height s))
                             (< @(::content-height s)

--- a/src/oc/web/components/org_settings.cljs
+++ b/src/oc/web/components/org_settings.cljs
@@ -29,27 +29,30 @@
   (dis/dispatch! [:input [:org-settings] nil]))
 
 (rum/defc org-settings-tabs
-  [org-slug active-tab]
+  [org-data active-tab]
   [:div.org-settings-tabs.group
     [:div.org-settings-bottom-line]
-    [:div.org-settings-tab
-      {:class (when (= :main active-tab) "active")}
-      [:a.org-settings-tab-link
-        {:href "#"
-         :on-click #(do (utils/event-stop %) (show-modal :main))}
-        "SETTINGS"]]
-    [:div.org-settings-tab
-      {:class (when (= :team active-tab) "active")}
-      [:a.org-settings-tab-link
-        {:href "#"
-         :on-click #(do (utils/event-stop %) (show-modal :team))}
-        "MANAGE MEMBERS"]]
-    [:div.org-settings-tab
-      {:class (when (= :invite active-tab) "active")}
-      [:a.org-settings-tab-link
-        {:href "#"
-         :on-click #(do (utils/event-stop %) (show-modal :invite))}
-        "INVITE PEOPLE"]]])
+    (when (utils/is-admin? org-data)
+      [:div.org-settings-tab
+        {:class (when (= :main active-tab) "active")}
+        [:a.org-settings-tab-link
+          {:href "#"
+           :on-click #(do (utils/event-stop %) (show-modal :main))}
+          "SETTINGS"]])
+    (when (utils/is-admin? org-data)
+      [:div.org-settings-tab
+        {:class (when (= :team active-tab) "active")}
+        [:a.org-settings-tab-link
+          {:href "#"
+           :on-click #(do (utils/event-stop %) (show-modal :team))}
+          "MANAGE MEMBERS"]])
+    (when (utils/is-admin-or-author? org-data)
+      [:div.org-settings-tab
+        {:class (when (= :invite active-tab) "active")}
+        [:a.org-settings-tab-link
+          {:href "#"
+           :on-click #(do (utils/event-stop %) (show-modal :invite))}
+          "INVITE PEOPLE"]])])
 
 (defn close-clicked [s]
   (let [org-data @(drv/get-ref s :org-data)
@@ -171,7 +174,7 @@
                 (org-avatar (if main-tab? org-editing org-data) false false true))]
             [:div.org-name (:name org-data)]
             [:div.org-url (str ls/web-server "/" (:slug org-data))]]
-          (org-settings-tabs (:slug org-data) settings-tab)
+          (org-settings-tabs org-data settings-tab)
           (case settings-tab
             :team
             (org-settings-team-panel org-data)

--- a/src/oc/web/components/ui/menu.cljs
+++ b/src/oc/web/components/ui/menu.cljs
@@ -100,7 +100,8 @@
           [:div.org-url (str ls/web-server "/" (:slug org-data))]])
       (when (and (not is-mobile?)
                  (router/current-org-slug)
-                 (= user-role :admin))
+                 (or (= user-role :admin)
+                     (= user-role :author)))
         [:a
           {:href "#"
            :on-click invite-click}

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -665,7 +665,7 @@
         [:form
           {:on-submit (fn [e]
                         (.preventDefault e))}
-          [:div.logo-upload-container.fs-hide
+          [:div.logo-upload-container.group.fs-hide
             {:on-click (fn []
                         (when (not= (:avatar-url user-data) temp-user-avatar)
                           (dis/dispatch! [:input [:edit-user-profile :avatar-url] temp-user-avatar]))

--- a/src/oc/web/components/ui/org_settings_invite_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_invite_panel.cljs
@@ -141,7 +141,7 @@
                         "Invalid user"))]]
                 [:th.role "Role "
                   [:i.mdi.mdi-information-outline
-                    {:title "Contributors and admins can view and edit. Admins manage the team, invites and billing."
+                    {:title "Contributors and admins can edit posts and invite users. Admins manage the team, invites and billing."
                      :data-placement "top"
                      :data-toggle "tooltip"}]]
                 [:th ""]]]

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -308,6 +308,19 @@
     :else
     :viewer))
 
+(defn is-admin?
+  [org-data]
+  (let [user-data (jwt/get-contents)
+        user-type (get-user-type user-data org-data)]
+    (= :admin user-type)))
+
+(defn is-admin-or-author?
+  [org-data]
+  (let [user-data (jwt/get-contents)
+        user-type (get-user-type user-data org-data)]
+    (or (= :admin user-type)
+        (= :author user-type))))
+
 (defn index-of
   "Given a collection and a function return the index that make the function truely."
   [s f]


### PR DESCRIPTION
Allows contributors to make user invites.  Shows the correct links and settings for user invites.

Test steps. 

- sign up or get invited as a contributor
- login with contributor account
- click invite link in left nav or menu
- [x] Does the settings UI only show the invite tab?
- send an email invite
- [x]  did the invite work?