### PR TITLE
Bugfix: Slack team info lost

### DIFF
--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -253,17 +253,23 @@
   ;; Load the list of teams if it's not already
   (team-actions/teams-get-if-needed)
   (let [org-editing @(drv/get-ref s :org-editing)
-        teams-data @(drv/get-ref s :teams-data)]
-    (when (and (zero? (count (:name org-editing)))
-               (zero? (count (:logo-url org-editing)))
-               (seq teams-data))
+        teams-data @(drv/get-ref s :teams-data)
+        google-domain (jwt/get-key :google-domain)
+        with-email-domain (if (and google-domain
+                                   (clojure.string/blank? (:email-domain org-editing)))
+                            {:email-domain google-domain}
+                            {:email-domain (or (:email-domain org-editing) "")})]
+    (if (and (zero? (count (:name org-editing)))
+             (zero? (count (:logo-url org-editing)))
+             (seq teams-data))
       (let [first-team (select-keys
                         (first teams-data)
-                        [:name :logo-url :logo-width :logo-height])]
+                        [:name :logo-url :logo-width :logo-height])
+            fixed-first-team (merge first-team with-email-domain)]
         (dis/dispatch!
          [:update
           [:org-editing]
-          first-team])
+          #(merge % fixed-first-team)])
         (when (and (not (zero? (count (:logo-url first-team))))
                    (not (:logo-height first-team)))
           (let [img (gdom/createDom "img")]
@@ -277,7 +283,12 @@
                    :logo-height (.-height img)})])
                (gdom/removeNode img)))
             (gdom/append (.-body js/document) img)
-            (set! (.-src img) (:logo-url first-team))))))))
+            (set! (.-src img) (:logo-url first-team)))))
+      (when with-email-domain
+        (dis/dispatch!
+         [:update
+          [:org-editing]
+          #(merge % with-email-domain)])))))
 
 (rum/defcs lander-team < rum/reactive
                          (drv/drv :teams-data)
@@ -285,21 +296,10 @@
                          (rum/local false ::saving)
                          {:will-mount (fn [s]
                            (dis/dispatch! [:input [:org-editing :name] ""])
+                           (dis/dispatch! [:input [:org-editing :email-domain] ""])
                            s)
                           :did-mount (fn [s]
                            (setup-team-data s)
-                           (when (and (jwt/get-key :google-domain)
-                                      (clojure.string/blank?
-                                       (:email-domain @(drv/get-ref s :org-editing))))
-                             (dis/dispatch!
-                              [:input [:org-editing :email-domain]
-                               (jwt/get-key :google-domain)])
-
-                             (when-let [field (rum/ref-node
-                                                s
-                                                "um-domain-invite")]
-                               (set! (.-value field)
-                                     (jwt/get-key :google-domain))))
                            (delay-focus-field-with-ref s "org-name")
                            s)
                           :will-update (fn [s]
@@ -395,26 +395,12 @@
                  :type "text"
                  :auto-capitalize "none"
                  :pattern "@?[a-z0-9.-]+\\.[a-z]{2,4}$"
+                 :value (:email-domain org-editing)
                  :on-change #(let [domain (.. % -target -value)]
-                               (if (utils/valid-domain? domain)
-                                 (do
-                                   (dis/dispatch!
-                                    [:input [:org-editing :email-domain]
-                                     domain])
-                                   (dis/dispatch!
-                                    [:input [:org-editing :domain-error]
-                                     false]))
-                                 (do
-                                   (if (zero? (count domain))
-                                     (dis/dispatch!
-                                      [:input [:org-editing :domain-error]
-                                       false])
-                                     (dis/dispatch!
-                                      [:input [:org-editing :domain-error]
-                                       true]))
-                                   (dis/dispatch!
-                                    [:input [:org-editing :email-domain] nil]))))
-                 :placeholder "  Domain, e.g. acme.com"}]]
+                               (dis/dispatch! [:input [:org-editing :email-domain] domain])
+                               (dis/dispatch! [:input [:org-editing :domain-error] (and (seq domain)
+                                                                                        (not (utils/valid-domain? domain)))]))
+                 :placeholder "Domain, e.g. acme.com"}]]
             [:div.field-label.info "Anyone with email addresses at this domain can automatically join your team."]]
           [:button.continue
             {:class (when continue-disabled "disabled")

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -249,13 +249,14 @@
 
 (defn- setup-team-data
   ""
-  [s]
+  [s & [setup-email-domain]]
   ;; Load the list of teams if it's not already
   (team-actions/teams-get-if-needed)
   (let [org-editing @(drv/get-ref s :org-editing)
         teams-data @(drv/get-ref s :teams-data)
         google-domain (jwt/get-key :google-domain)
-        with-email-domain (if (and google-domain
+        with-email-domain (if (and setup-email-domain
+                                   google-domain
                                    (clojure.string/blank? (:email-domain org-editing)))
                             {:email-domain google-domain}
                             {:email-domain (or (:email-domain org-editing) "")})]
@@ -284,11 +285,10 @@
                (gdom/removeNode img)))
             (gdom/append (.-body js/document) img)
             (set! (.-src img) (:logo-url first-team)))))
-      (when with-email-domain
-        (dis/dispatch!
-         [:update
-          [:org-editing]
-          #(merge % with-email-domain)])))))
+      (dis/dispatch!
+       [:update
+        [:org-editing]
+        #(merge % with-email-domain)]))))
 
 (rum/defcs lander-team < rum/reactive
                          (drv/drv :teams-data)
@@ -299,7 +299,7 @@
                            (dis/dispatch! [:input [:org-editing :email-domain] ""])
                            s)
                           :did-mount (fn [s]
-                           (setup-team-data s)
+                           (setup-team-data s true)
                            (delay-focus-field-with-ref s "org-name")
                            s)
                           :will-update (fn [s]


### PR DESCRIPTION
Bug: i cleaned my DBs and signed up with Slack from scratch. I found out that the team name and logo where not inherited anymore but they were still set in the team info.

To test:
- clean your DBs
- signup with Slack
- [x] do you see the slack team name and logo in the team lander page? Good
- add an email domain
- [x] do you see the red borders only when there is a not valid domain in the field? Good
- [x] can you submit with an email domain and is that kept in settings? Good
- sign out
- signup with google (using an account that inherit the domain)
- [x] do you see the email domain set in the proper field in the team lander page? Good
- enter a team name
- add a logo
- proceed
- [x] check that all the info above are kept

@thepug check how :update differ from :input in `dispatch!`, you need to pass a function to :update not a single value: https://github.com/open-company/open-company-web/blob/mainline/src/oc/web/actions.cljs#L24
Telling you this because of a change you did in Email domain NUX PR and i didn't catch.