### PR TITLE
Fix last used section

### DIFF
--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -82,7 +82,10 @@
 (defn section-delete [section-slug]
   (api/delete-board section-slug (fn [status success body]
     (if success
-      (let [org-slug (router/current-org-slug)]
+      (let [org-slug (router/current-org-slug)
+            last-used-section-slug (au/last-used-section)]
+        (when (= last-used-section-slug section-slug)
+          (au/save-last-used-section nil))
         (if (= section-slug (router/current-board-slug))
           (router/redirect! (oc-urls/all-posts org-slug))
           (dispatcher/dispatch! [:section-delete org-slug section-slug])))

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -8,9 +8,10 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
+            [oc.web.utils.activity :as au]
             [oc.web.mixins.ui :as ui-mixins]
-            [oc.web.lib.responsive :as responsive]
             [oc.web.actions.nux :as nux-actions]
+            [oc.web.lib.responsive :as responsive]
             [oc.web.actions.section :as section-actions]
             [oc.web.actions.activity :as activity-actions]
             [oc.web.components.all-posts :refer (all-posts)]
@@ -59,10 +60,10 @@
 (defn get-default-section [s]
   (let [editable-boards @(drv/get-ref s :editable-boards)
         org-slug (router/current-org-slug)
-        cookie-name (router/last-used-board-slug-cookie org-slug)
-        cookie-value (cook/get-cookie cookie-name)
+        cookie-value (au/last-used-section)
         board-from-cookie (some #(when (= (:slug %) cookie-value) %) (vals editable-boards))
-        board-data (or board-from-cookie (first (sort-by :name (vals editable-boards))))]
+        filtered-boards (filterv #(not (:draft %)) (vals editable-boards))
+        board-data (or board-from-cookie (first (sort-by :name filtered-boards)))]
     {:board-name (:name board-data)
      :board-slug (:slug board-data)}))
 

--- a/src/oc/web/utils/activity.cljs
+++ b/src/oc/web/utils/activity.cljs
@@ -6,6 +6,7 @@
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
+            [oc.web.lib.cookies :as cook]
             [oc.web.lib.responsive :as responsive]))
 
 (defn board-by-uuid [board-uuid]
@@ -291,3 +292,17 @@
         request-set (set item-ids)
         diff-ids (clojure.set/difference request-set all-items)]
     (into [] diff-ids)))
+
+;; Last used section
+
+(defn last-used-section []
+  (let [org-slug (router/current-org-slug)
+        cookie-name (router/last-used-board-slug-cookie org-slug)]
+    (cook/get-cookie cookie-name)))
+
+(defn save-last-used-section [section-slug]
+  (let [org-slug (router/current-org-slug)
+        last-board-cookie (router/last-used-board-slug-cookie org-slug)]
+    (if section-slug
+      (cook/set-cookie! last-board-cookie section-slug (* 60 60 24 365))
+      (cook/remove-cookie! last-board-cookie))))


### PR DESCRIPTION
Gdoc: https://docs.google.com/document/d/1BNtz1uMJnqNablvaThGUzOFu7zEEcQoeNsoh3O1ry3M/edit

Item:
> Delete a section and it takes you to AP; go to create a new post and it's defaulted to the section that no longer exists.

To test:
- with user A add a Section 1
- add a draft to Section 1 (this avoid to completely delete the section but keep it hidden)
- with user B add a post in Section 1 (this set the last used section cookie)
- with user B delete Section 1
- when you are redirected to AP select New post
- [x] do you see a section different than Section 1 as default for the new post? Good
- [x] the new default section is one visible in the left nav? Good
