### PR TITLE
Fix arrow position for search box.

### DIFF
--- a/scss/partials/_search.scss
+++ b/scss/partials/_search.scss
@@ -82,7 +82,7 @@ div.search-results.inactive {
 
 div.triangle {
   position: absolute;
-  top: 82px;
+  top: 67px;
   left: 96px;
   background-color: white;
   border-top: 1px solid rgba(177,184,192,0.50);
@@ -103,7 +103,7 @@ div.search-results {
   border: 1px solid rgba(177,184,192,0.50);
   border-radius: 5px;
 
-  margin: 41px 0px 0px 45px;
+  margin: 31px 0px 0px 45px;
   width: 450px;
   box-shadow: 0 4px 6px 0 rgba(0,0,0,0.07);
 


### PR DESCRIPTION
Gdoc: https://docs.google.com/document/d/1BNtz1uMJnqNablvaThGUzOFu7zEEcQoeNsoh3O1ry3M/edit

Item:
> Arrow is no longer aligned when searching https://trello.com/c/7L6e8w93

To test:
- focus search field in navbar
- enter some chars
- [ ] do you see the results box appear? Good
- [ ] the arrow is positioned well at the top of the box? Good