### PR TITLE
Truncate long section names

### DIFF
--- a/scss/partials/_activity_card.scss
+++ b/scss/partials/_activity_card.scss
@@ -180,6 +180,13 @@ div.activity-card {
       &>span, &>div {
         float: left;
       }
+
+      span.board-name {
+        max-width: 60%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
 
     div.activity-card-headline {

--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -240,6 +240,10 @@ div.dashboard-layout {
             font-size: 28px;
             color: $carrot_gray;
             float: left;
+            max-width: 350px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
 
             @include mobile() {
               @include avenir_H();

--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -229,9 +229,13 @@ div.entry-edit-modal-container {
           font-size: 14px;
           float: left;
           color: $deep_navy;
+          max-width: 250px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          padding-right: 20px;
 
           &:after {
-            float: right;
             content: "";
             background-image: cdnUrl("/img/ML/board_settings.svg");
             background-size: 8px 8px;
@@ -239,8 +243,9 @@ div.entry-edit-modal-container {
             background-position: center;
             width: 20px;
             height: 20px;
-            margin-top: -2px;
-            margin-left: 4px;
+            position: absolute;
+            right: 0px;
+            top: -2px;
 
             &:hover {
               opacity: 1;

--- a/scss/partials/_fullscreen_post.scss
+++ b/scss/partials/_fullscreen_post.scss
@@ -224,9 +224,13 @@ div.fullscreen-post-container {
               position: relative;
               float: left;
               margin-left: 6px;
+              max-width: 250px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+              padding-right: 20px;
 
               &:after {
-                float: right;
                 content: "";
                 background-image: cdnUrl("/img/ML/board_settings.svg");
                 background-size: 8px 8px;
@@ -234,8 +238,9 @@ div.fullscreen-post-container {
                 background-position: center;
                 width: 20px;
                 height: 20px;
-                margin-top: -2px;
-                margin-left: 4px;
+                position: absolute;
+                right: 0px;
+                top: -2px;
 
                 &:hover {
                   opacity: 1;

--- a/scss/partials/_fullscreen_post.scss
+++ b/scss/partials/_fullscreen_post.scss
@@ -326,6 +326,10 @@ div.fullscreen-post-container {
             line-height: 18px;
             color: $deep_navy;
             float: left;
+            max-width: 350px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
           }
 
           @include new-tag();

--- a/scss/partials/_section_editor.scss
+++ b/scss/partials/_section_editor.scss
@@ -103,7 +103,7 @@ div.section-editor {
     div.section-editor-add-name {
       border-radius: 4px;
       border: 1px solid $carrot_light_gray_1;
-      height: 40px;
+      min-height: 40px;
       width: 100%;
       @include avenir_M();
       font-size: 15px;
@@ -113,6 +113,8 @@ div.section-editor {
       cursor: text;
       outline: none;
       margin-top: 8px;
+      overflow-y: auto;
+      overflow-x: hidden;
 
       &:empty:before {
         padding: 10px 16px;


### PR DESCRIPTION
Gdoc: https://docs.google.com/document/d/1BNtz1uMJnqNablvaThGUzOFu7zEEcQoeNsoh3O1ry3M/edit

Items:
> Overflow in text field w/ long section name http://take.ms/fFspx
> Formatting problem with long section name in feed header: http://take.ms/Hb1xY

To test:
- add a new section
- enter a very long name, reach the max allowed length
- [x] do you see truncated correctly in the left navbar and in the dashboard title? Good
- click New post
- [x] do you see it truncated correctly in the edit view? Good
- add a post
- go to AP
- [x] do you see truncated correctly in stream view and in grid when you hover the tile? Good
- click the grid view tile
- [x] do you see it truncated correctly in the fullscreen view? Good
- edit the post
- [x] do you see it truncated correctly in the edit view? Good