### PR TITLE
Fix user avatars

### DIFF
--- a/scss/mixins/_reusable.scss
+++ b/scss/mixins/_reusable.scss
@@ -190,8 +190,9 @@
     img.user-avatar-img {
       width: #{$size}px;
       height: #{$size}px;
-      border-radius: #{$size / 2}px;
+      border-radius: 50%;
       vertical-align: middle;
+      object-fit: cover;
     }
   }
 }

--- a/scss/partials/_comments_summary.scss
+++ b/scss/partials/_comments_summary.scss
@@ -19,13 +19,7 @@ div.is-comments {
       border-radius: 12px;
       margin-left: -9px;
 
-      img {
-        max-width: 22px;
-        max-height: 22px;
-        margin-top: -2px;
-        margin-left: 1px;
-        border-radius: 11px;
-      }
+      @include user-profile(22);
 
       &:first-child {
         margin-left: 0px;


### PR DESCRIPTION
Bug: on Friday during our usual back look call Stuart set a landscape jpg image as his user avatar and when he added a comment the face pile of the comments were stretched.

This should fix that.

To test set the 2 images below for 2 different users and comment with both on the same post:
- [x] does NOT the face pile look stretched? Good
- [x] does NOT your user(s) avatar look stretched in top right corner? Good
- [x] does NOT your user(s) avatar look stretched in user profile panel? Good


<a href="https://user-images.githubusercontent.com/642704/44989464-38ebe280-af8e-11e8-8f20-e926f2c3472a.png"><img src="https://user-images.githubusercontent.com/642704/44989464-38ebe280-af8e-11e8-8f20-e926f2c3472a.png" align="left" width="500" /></a>


<a href="https://user-images.githubusercontent.com/642704/44989465-39847900-af8e-11e8-98d3-184ee538af80.png"><img src="https://user-images.githubusercontent.com/642704/44989465-39847900-af8e-11e8-98d3-184ee538af80.png" align="left" height="500" /></a>