### PR TITLE
Fix body inline media

### DIFF
--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -70,6 +70,7 @@
 
 (defn add-attachment [s editable]
   (let [editable (or editable (get-media-picker-extension s))]
+    (.saveSelection editable)
     (reset! (::media-attachment s) true)
     (iu/upload!
      nil
@@ -79,37 +80,11 @@
      (fn []
        (utils/after 400 #(media-attachment-dismiss-picker s editable))))))
 
-;; Chart
-
-(defn add-chart [s]
-  (dis/dispatch! [:input [:media-input :media-chart] true])
-  (reset! (::media-chart s) true))
-
-(defn get-chart-thumbnail [chart-id oid]
-  (str
-   "https://docs.google.com/spreadsheets/d/"
-   chart-id
-   "/embed/oimg?id="
-   chart-id
-   "&oid="
-   oid
-   "&disposition=ATTACHMENT&bo=false&zx=sohupy30u1p"))
-
-(defn media-chart-add [s editable chart-url]
-  (if (nil? chart-url)
-    (.addChart editable nil nil nil)
-    (let [url-fragment (last (clojure.string/split chart-url #"/spreadsheets/d/"))
-          chart-proxy-uri (str "/_/sheets-proxy/spreadsheets/d/" url-fragment)
-          parsed-uri (guri/parse chart-url)
-          oid (.get (.getQueryData parsed-uri) "oid")
-          splitted-path (clojure.string/split (.getPath parsed-uri) #"/")
-          chart-id (nth splitted-path (- (count splitted-path) 2))
-          chart-thumbnail (get-chart-thumbnail chart-id oid)]
-      (.addChart editable chart-proxy-uri chart-id chart-thumbnail))))
-
 ;; Video
 
-(defn add-video [s]
+(defn add-video [s editable]
+  (let [editable (or editable (get-media-picker-extension s))]
+    (.saveSelection editable))
   (dis/dispatch! [:input [:media-input :media-video] true])
   (reset! (::media-video s) true))
 
@@ -183,6 +158,7 @@
 
 (defn add-photo [s editable]
   (let [editable (or editable (get-media-picker-extension s))]
+    (.saveSelection editable)
     (reset! (::media-photo s) true)
     (let [props (first (:rum/args s))
           upload-progress-cb (:upload-progress-cb props)]
@@ -240,9 +216,7 @@
     (= type "photo")
     (add-photo s editable)
     (= type "video")
-    (add-video s)
-    (= type "chart")
-    (add-chart s)
+    (add-video s editable)
     (= type "attachment")
     (add-attachment s editable)))
 
@@ -373,7 +347,6 @@
                                (rum/local nil ::media-picker-ext)
                                (rum/local false ::media-photo)
                                (rum/local false ::media-video)
-                               (rum/local false ::media-chart)
                                (rum/local false ::media-attachment)
                                (rum/local false ::media-photo-did-success)
                                (rum/local false ::media-attachment-did-success)
@@ -391,8 +364,7 @@
                                  s)
                                 :will-update (fn [s]
                                  (let [data @(drv/get-ref s :media-input)
-                                       video-data (:media-video data)
-                                       chart-data (:media-chart data)]
+                                       video-data (:media-video data)]
                                     (when (and @(::media-video s)
                                                (or (= video-data :dismiss)
                                                    (map? video-data)))
@@ -402,17 +374,7 @@
                                         (dis/dispatch! [:input [:media-input :media-video] nil]))
                                       (if (map? video-data)
                                         (media-video-add s @(::media-picker-ext s) video-data)
-                                        (media-video-add s @(::media-picker-ext s) nil)))
-                                    (when (and @(::media-chart s)
-                                               (or (= chart-data :dismiss)
-                                                   (string? chart-data)))
-                                      (when (or (= chart-data :dismiss)
-                                                (string? chart-data))
-                                        (reset! (::media-chart s) false)
-                                        (dis/dispatch! [:input [:media-input :media-chart] nil]))
-                                      (if (string? chart-data)
-                                        (media-chart-add s @(::media-picker-ext s) chart-data)
-                                        (media-chart-add s @(::media-picker-ext s) nil))))
+                                        (media-video-add s @(::media-picker-ext s) nil))))
                                  s)
                                 :will-unmount (fn [s]
                                  (when @(::editor s)
@@ -433,7 +395,7 @@
          (multi-picker
           {:toggle-button-id default-mutli-picker-button-id
            :add-photo-cb #(add-photo s nil)
-           :add-video-cb #(add-video s)
+           :add-video-cb #(add-video s nil)
            :add-attachment-cb #(add-attachment s nil)})
          multi-picker-container)))
     [:div.rich-body-editor


### PR DESCRIPTION
Bug: images, videos and attachments are not added inline at cursor position anymore but always at the bottom of the body.

To test:
- create a new post
- add 3 paragraph with some text
- move the cursor to the paragraph in the middle
- add an image
- [ ] was it added in the right place? Good
- try again with an attachment
- [ ] was it added in the right place? Good
- try again with a youtube or vimeo video
- [ ] was it added in the right place? Good
- merge
- [ ] dance