### PR TITLE
Fix empty board create button

### DIFF
--- a/scss/partials/_empty_board.scss
+++ b/scss/partials/_empty_board.scss
@@ -19,7 +19,7 @@ div.empty-board {
     background-repeat: no-repeat;
     border-radius: 6px;
     height: 400px;
-    padding: 80px 153px;
+    padding: 80px 100px;
     text-align: center;
     border-collapse: collapse;
     margin: 8px auto 0;

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -314,7 +314,7 @@
                 (empty-org)
                 ;; Empty board
                 empty-board?
-                (empty-board (get-board-for-edit s))
+                (empty-board (when can-compose (get-board-for-edit s)))
                 ;; All Posts
                 (and (or is-all-posts
                          is-must-see)

--- a/src/oc/web/components/ui/empty_board.cljs
+++ b/src/oc/web/components/ui/empty_board.cljs
@@ -29,7 +29,7 @@
         [:div.empty-board-title
           (cond
            is-all-posts? "Catch up with your team"
-           is-must-see? "“Must see” posts"
+           is-must-see? "Highlight what's important"
            is-drafts-board? "Jot down your ideas and notes"
            :else "This section is empty")]
         [:div.empty-board-subtitle
@@ -38,8 +38,7 @@
            is-must-see? "When someone marks a post as “must see” everyone will see it here."
            is-drafts-board? "Keep a private draft until you're ready to share it with your team."
            :else (str "Looks like there aren’t any posts in " (:name board-data) "."))]
-        (when (and (not is-must-see?)
-                   edit-board)
+        (when edit-board
           [:button.mlb-reset.create-new-post-bt
             {:on-click #(activity-actions/entry-edit edit-board)}
             "Create a new post"])]]))

--- a/src/oc/web/components/ui/empty_board.cljs
+++ b/src/oc/web/components/ui/empty_board.cljs
@@ -38,7 +38,8 @@
            is-must-see? "When someone marks a post as “must see” everyone will see it here."
            is-drafts-board? "Keep a private draft until you're ready to share it with your team."
            :else (str "Looks like there aren’t any posts in " (:name board-data) "."))]
-        (when-not is-must-see?
+        (when (and (not is-must-see?)
+                   edit-board)
           [:button.mlb-reset.create-new-post-bt
             {:on-click #(activity-actions/entry-edit edit-board)}
             "Create a new post"])]]))


### PR DESCRIPTION
BUG: viewers can see and click the Create a new post button in empty board placeholder

Also minor addition:
- show Create new post button on MS empty state too
- change MS empty state title from: "“Must see” posts" to "Highlight what’s important"
- make sure the copy below MS empty state fit on one line

To test:
- as admin or contributor create a new section
- [x] do you see the empty section placeholder? Good
- [x] do you see the create a new post button? Good 
- [x] does it work? Good
- go to MS
- remove all posts
- [x] do you see the create a new post button? Good
- [x] do you see the correct copy (check above)? Good
- [x] do you see a copy on a single line below the title? Good
- make sure the section is empty
- login as a viewer
- navigate to the section you just created
- [x] do you see the empty section placeholder? Good
- [x] do you NOT see the create a new post button? Good
