### PR TITLE
Goodbye black bands

### DIFF
--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -121,7 +121,7 @@ div.stream-item {
         margin-bottom: 24px;
         float: unset;
         width: 638px;
-        height: 377px;
+        height: 480px;
 
         @include tablet(){
           width: auto;
@@ -132,8 +132,8 @@ div.stream-item {
 
     div.ziggeo-player {
       margin-top: 0px;
-      width: 180px;
-      height: 106px;
+      width: 136px;
+      height: 102px;
       float: right;
 
       @include tablet(){

--- a/scss/partials/_ziggeo.scss
+++ b/scss/partials/_ziggeo.scss
@@ -12,9 +12,8 @@ div.ziggeo-player {
 
     span {
       @include avenir_H();
-      font-size: 16px;
+      font-size: 12px;
       color: #AFB3B6;
-      margin-left: 8px;
     }
 
     div.refresh-icon {

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -318,7 +318,7 @@
         show-sections-picker (drv/react s :show-sections-picker)
         published? (= (:status cmail-data) "published")
         video-size {:width 548
-                    :height 411}]
+                    :height (utils/calc-video-height 548)}]
     [:div.cmail-outer
       {:class (utils/class-set {:fullscreen (and (not (:collapse cmail-state))
                                                  (:fullscreen cmail-state))

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -318,7 +318,7 @@
         show-sections-picker (drv/react s :show-sections-picker)
         published? (= (:status cmail-data) "published")
         video-size {:width 548
-                    :height 322}]
+                    :height 411}]
     [:div.cmail-outer
       {:class (utils/class-set {:fullscreen (and (not (:collapse cmail-state))
                                                  (:fullscreen cmail-state))

--- a/src/oc/web/components/entry_edit.cljs
+++ b/src/oc/web/components/entry_edit.cljs
@@ -176,7 +176,7 @@
 
 (defn calc-video-height [s]
   (when (responsive/is-tablet-or-mobile?)
-    (reset! (::mobile-video-height s) (* (win-width) (/ 377 640)))))
+    (reset! (::mobile-video-height s) (* (win-width) (/ 3 4)))))
 
 (defn show-post-error [s message]
   (when-let [$post-btn (js/$ (rum/ref-node s "mobile-post-btn"))]
@@ -355,7 +355,7 @@
                      {:width (win-width)
                       :height @(::mobile-video-height s)}
                      {:width 640
-                      :height 377})]
+                      :height 480})]
     [:div.entry-edit-modal-container
       {:class (utils/class-set {:will-appear (or @(::dismiss s) (not @(:first-render-done s)))
                                 :appear (and (not @(::dismiss s)) @(:first-render-done s))})}

--- a/src/oc/web/components/fullscreen_post.cljs
+++ b/src/oc/web/components/fullscreen_post.cljs
@@ -288,7 +288,7 @@
 
 (defn calc-video-height [s]
   (when (responsive/is-tablet-or-mobile?)
-    (reset! (::mobile-video-height s) (* (win-width) (/ 377 640)))))
+    (reset! (::mobile-video-height s) (utils/calc-video-height (win-width)))))
 
 (rum/defcs fullscreen-post < rum/reactive
                              ;; Derivatives
@@ -429,7 +429,7 @@
                      {:width (win-width)
                       :height @(::mobile-video-height s)}
                      {:width 640
-                      :height 377})]
+                      :height (utils/calc-video-height 640)})]
     [:div.fullscreen-post-container.group
       {:class (utils/class-set {:will-appear (or @(::dismiss s)
                                                  (and @(::animate s)

--- a/src/oc/web/components/secure_activity.cljs
+++ b/src/oc/web/components/secure_activity.cljs
@@ -26,7 +26,7 @@
 (defn save-win-height [s]
   (reset! (::win-height s) (.-innerHeight js/window))
   (when (responsive/is-tablet-or-mobile?)
-    (reset! (::mobile-video-height s) (* (win-width) (/ 377 640)))))
+    (reset! (::mobile-video-height s) (utils/calc-video-height (win-width)))))
 
 (def default-activity-header-height 56)
 
@@ -57,7 +57,7 @@
                       {:width (win-width)
                        :height @(::mobile-video-height s)}
                       {:width 640
-                       :height 377}))
+                       :height (utils/calc-video-height 480)}))
         video-id (:fixed-video-id activity-data)]
     [:div.secure-activity-container
       {:style {:min-height (when is-mobile?

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -59,7 +59,7 @@
 
 (defn calc-video-height [s]
   (when (responsive/is-tablet-or-mobile?)
-    (reset! (::mobile-video-height s) (* (win-width) (/ 480 640)))))
+    (reset! (::mobile-video-height s) (utils/calc-video-height (win-width)))))
 
 (rum/defcs stream-item < rum/reactive
                          ;; Derivatives
@@ -129,7 +129,7 @@
                        {:width (win-width)
                         :height @(::mobile-video-height s)}
                        {:width (if expanded? 640 180)
-                        :height (if expanded? 377 106)}))]
+                        :height (if expanded? (utils/calc-video-height 640) (utils/calc-video-height 180))}))]
     [:div.stream-item
       {:class (utils/class-set {dom-node-class true
                                 :show-continue-reading truncated?

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -128,8 +128,8 @@
                      (if is-mobile?
                        {:width (win-width)
                         :height @(::mobile-video-height s)}
-                       {:width (if expanded? 640 180)
-                        :height (if expanded? (utils/calc-video-height 640) (utils/calc-video-height 180))}))]
+                       {:width (if expanded? 638 136)
+                        :height (if expanded? (utils/calc-video-height 638) (utils/calc-video-height 136))}))]
     [:div.stream-item
       {:class (utils/class-set {dom-node-class true
                                 :show-continue-reading truncated?

--- a/src/oc/web/components/ui/ziggeo.cljs
+++ b/src/oc/web/components/ui/ziggeo.cljs
@@ -43,7 +43,6 @@
       [:div.ziggeo-player-not-processed
         {:style {:width (str (or width 640) "px")
                  :height (str (or height 480) "px")}}
-        [:div.refresh-icon]
         [:span "Preparing video…"]]
       [:div.ziggeo-player-embed
         {:ref :ziggeo-player}])])

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -614,3 +614,6 @@
     value))
 
 (def section-name-exists-error "Section name already exists or isn't allowed")
+
+(defn calc-video-height [widht]
+  (* width (/ 3 4)))

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -615,5 +615,5 @@
 
 (def section-name-exists-error "Section name already exists or isn't allowed")
 
-(defn calc-video-height [widht]
+(defn calc-video-height [width]
   (* width (/ 3 4)))


### PR DESCRIPTION
Resize the video recorder and player to make sure the black bands are gone and we don't get a stretched cover shot while the cover picker is visible.

To test:
- record a video in cmail
- [x] do you not see black bands? Good
- while recording touch with your hand the top, the bottom, the left and the right edge of the frame
- record it and stop
- [x] do you see the cover shot picker? Good
- [x] is it NOT stretched? Good
- pick one and upload the video
- go back to stream view
- play the video in collapsed mode (click play when is small)
- [x] do you see the whole frame with your hands touching all the edges? Good
- [x] repeat with expanded video
- now share it and copy the internal URL (internal share)
- [x] repeat the edges check in the fullscreen view
- now share it with the world (secure url)
- open the secure url in an incognito window
- [x] repeat the edges check