### PR TITLE
Inline comment agree

### DIFF
--- a/scss/partials/_stream_comments.scss
+++ b/scss/partials/_stream_comments.scss
@@ -156,7 +156,11 @@ div.stream-comments {
           display: inline;
 
           & > *:last-child {
-            display: inline-block;
+            display: inline;
+          }
+
+          & > *:not(:last-child) {
+            display: block;
           }
 
           &.editing {

--- a/scss/partials/_stream_comments.scss
+++ b/scss/partials/_stream_comments.scss
@@ -11,6 +11,16 @@ div.stream-comments {
     div.stream-comment {
       padding: 24px 0px 0px;
 
+      &:hover, &.showing-more-menu {
+        div.stream-comment-header {
+          div.stream-comment-more-menu-container {
+            button.comment-more-menu {
+              display: block;
+            }
+          }
+        }
+      }
+
       div.stream-comment-author-avatar {
         float: left;
         width: 32px;
@@ -50,75 +60,11 @@ div.stream-comments {
             text-transform: capitalize;
           }
         }
-      }
-
-      div.stream-comment-content {
-        text-align: left;
-
-        div.stream-comment-body {
-          @include avenir_R();
-          font-size: 16px;
-          color: $deep_navy;
-          white-space: pre-wrap;
-          word-wrap: break-word;
-          line-height: 20px;
-
-          &:hover {
-            a.read-more {
-              color: $carrot_green;
-            }
-          }
-
-          a.read-more {
-            @include avenir_H();
-            font-size: 12px;
-            color: $deep_navy;
-          }
-
-          &.medium-editor-element {
-            // editing comment
-            border-radius: 4px;
-            border: 1px solid $ui_grey;
-            box-shadow: 0px 2px 6px 0px rgba(0,0,0, 0.1);
-            border: 2px solid $light_ui_grey;
-            background-color: white;
-            outline: none;
-            padding: 4px;
-          }
-
-          * {
-            white-space: pre-wrap;
-            word-wrap: break-word;
-          }
-
-          margin-bottom: 0px;
-
-          &>*:last-child {
-            margin-bottom: 0px;
-          }
-
-          &.emoji-comment {
-            font-size: 50px;
-            height: 50px;
-            line-height: 50px;
-
-            // & > * {
-            //   line-height: 20px;
-            //   margin-top: 20px;
-            // }
-          }
-        }
-      }
-
-      div.stream-comment-footer {
-        height: 24px;
-        margin-top: 2px;
 
         div.stream-comment-more-menu-container {
-          float: left;
           position: relative;
+          float: right;
           margin-left: 8px;
-          margin-top: 6px;
 
           button.comment-more-menu {
             width: 24px;
@@ -130,6 +76,7 @@ div.stream-comments {
             background-size: 20px 4px;
             background-repeat: no-repeat;
             opacity: 0.4;
+            display: none;
 
             &:hover, &:hover, &.active {
               opacity: 1;
@@ -139,7 +86,7 @@ div.stream-comments {
           div.stream-comment-more-menu {
             position: absolute;
             top: -8px;
-            left: 100%;
+            right: 100%;
             background-color: white;
             width: 136px;
             border: 1px solid $deep_tan;
@@ -193,19 +140,91 @@ div.stream-comments {
             }
           }
         }
+      }
+
+      div.stream-comment-content {
+        text-align: left;
+        position: relative;
+
+        div.stream-comment-body {
+          @include avenir_R();
+          font-size: 16px;
+          color: $deep_navy;
+          white-space: pre-wrap;
+          word-wrap: break-word;
+          line-height: 20px;
+          display: inline;
+
+          & > *:last-child {
+            display: inline-block;
+          }
+
+          &.editing {
+            display: block;
+            margin-top: 6px;
+          }
+
+          &:hover {
+            a.read-more {
+              color: $carrot_green;
+            }
+          }
+
+          a.read-more {
+            @include avenir_H();
+            font-size: 12px;
+            color: $deep_navy;
+          }
+
+          &.medium-editor-element {
+            // editing comment
+            border-radius: 4px;
+            border: 1px solid $ui_grey;
+            box-shadow: 0px 2px 6px 0px rgba(0,0,0, 0.1);
+            border: 2px solid $light_ui_grey;
+            background-color: white;
+            outline: none;
+            padding: 4px;
+          }
+
+          * {
+            white-space: pre-wrap;
+            word-wrap: break-word;
+          }
+
+          margin-bottom: 0px;
+
+          &>*:last-child {
+            margin-bottom: 0px;
+          }
+
+          &.emoji-comment {
+            font-size: 50px;
+            height: 50px;
+            line-height: 50px;
+
+            // & > * {
+            //   line-height: 20px;
+            //   margin-top: 20px;
+            // }
+          }
+        }
 
         button.stream-comment-reaction {
-          height: 24px;
+          height: 16px;
           @include avenir_M();
           font-size: 12px;
           color: $ui_grey;
-          float: left;
-          padding: 4px 14px 2px 0px;
+          padding: 0;
+          margin-left: 10px;
+          margin-top: 0;
+          padding: 0 6px;
+          display: inline;
 
           div.stream-comment-reaction-icon {
             float: left;
             width: 14px;
-            height: 14px;
+            height: 16px;
             background-repeat: no-repeat;
             background-image: cdnUrl("/img/ML/comment_agree_off.svg");
             background-size: 14px 14px;
@@ -216,12 +235,13 @@ div.stream-comments {
           }
 
           div.stream-comment-reaction-count {
+            height: 16px;
             float: left;
             margin-left: 6px;
-            margin-top: 2px;
             color: $ui_grey;
             @include avenir_M();
             font-size: 12px;
+            line-height: 22px;
           }
 
           &.reacted {
@@ -252,6 +272,11 @@ div.stream-comments {
             }
           }
         }
+      }
+
+      div.stream-comment-footer {
+        height: 24px;
+        margin-top: 2px;
       }
 
       div.save-cancel-edit-buttons {

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -184,24 +184,15 @@
                       (when (pos? (:count reaction-data))
                         [:div.stream-comment-reaction-count
                           (:count reaction-data)])])]
-              (when (or is-editing?
-                        (and (not is-editing?)
-                             (or (and (:can-edit comment-data)
-                                      (not (:is-emoji comment-data)))
-                                 (:can-delete comment-data)))
-                        (and (not is-editing?)
-                             (not (:is-emoji comment-data))
-                             (or (:can-react comment-data)
-                                 (pos? (:count reaction-data)))))
+              (when is-editing?
                 [:div.stream-comment-footer.group
-                  (when is-editing?
-                    [:div.save-cancel-edit-buttons
-                      [:button.mlb-reset.mlb-link-green
-                        {:on-click #(edit-finished % s comment-data)
-                         :title "Save edit"}
-                        "Save"]
-                      [:button.mlb-reset.mlb-link-black
-                        {:on-click #(cancel-edit % s comment-data)
-                         :title "Cancel edit"}
-                        "Cancel"]])])]])]
+                  [:div.save-cancel-edit-buttons
+                    [:button.mlb-reset.mlb-link-green
+                      {:on-click #(edit-finished % s comment-data)
+                       :title "Save edit"}
+                      "Save"]
+                    [:button.mlb-reset.mlb-link-black
+                      {:on-click #(cancel-edit % s comment-data)
+                       :title "Cancel edit"}
+                      "Cancel"]]])]])]
       [:div.stream-comments-empty])])


### PR DESCRIPTION
Item (from Paper):
> Visual design updates to comments
>     move Agree and ellipsis to the same line to save space
Also (from Bugs list GDoc):
> Overlap between emoji and person's name here (FF): http://take.ms/kDrvw

From:
https://paper.dropbox.com/doc/Misc-UX--AMsFP80dtpKK~ftF~v8yet80Ag-zmqEXqPjOZGPJJSxUfPxC
and
https://docs.google.com/document/d/1BNtz1uMJnqNablvaThGUzOFu7zEEcQoeNsoh3O1ry3M/edit

Abstract: https://share.goabstract.com/f93ff423-3d76-41d1-9d6f-e92eb644682f
Also next pages

To test:
- add a single line comment
- add a multiple line comment
- add a multiple paragraphs comment (use enter to add a new paragraph)
- add a single emoji comment
- [x] the first 3 have the inline agree button? Good
- [x] all have the more menu in top right corner? Good
- [x] first 3 have edit and delete options, only last has only delete? Good
- [x] make sure edit and delete work
- [x] make sure agree/disagree work
- [x] make sure on FF the single emoji comment don't overlap with the name
- [x] make sure the comments are compacted one to each other, no footer white space is show below a comment except while in editing mode