### PR TITLE
Fix single emoji comment

### DIFF
--- a/scss/partials/_add_comment.scss
+++ b/scss/partials/_add_comment.scss
@@ -43,7 +43,7 @@ div.add-comment-box-container {
     }
 
     div.add-comment-internal{
-      min-height: 24px;
+      min-height: 49px;
       width: 100%;
       background-color: white;
       border-radius: 4px;
@@ -63,13 +63,14 @@ div.add-comment-box-container {
         color: $deep_navy;
         font-size: 16px;
         cursor: text;
-        height: 24px;
+        height: 27px;
         min-height: initial;
         white-space: pre-wrap;
         word-wrap: break-word;
         padding: 4px 0px 0px 0px;
         margin: 0px;
         height: auto;
+        min-height: 27px;
 
         &.medium-editor-placeholder:after {
           @include avenir_R();

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -123,8 +123,8 @@
             [:button.mlb-reset.reply-btn
               {:on-click #(let [add-comment-div (rum/ref-node s "add-comment")
                                 comment-body (cu/add-comment-content add-comment-div)]
-                            (comment-actions/add-comment activity-data comment-body)
-                            (set! (.-innerHTML add-comment-div) ""))
+                            (set! (.-innerHTML add-comment-div) "")
+                            (comment-actions/add-comment activity-data comment-body))
                :disabled @(::add-button-disabled s)}
               "Comment"]
             [:button.mlb-reset.cancel-btn

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -22,6 +22,17 @@
 (defn editable-input-change [s editable event]
   (enable-add-comment? s))
 
+(defn add-comment-focus [s]
+  (enable-add-comment? s)
+  (comment-actions/add-comment-focus (:uuid (first (:rum/args s)))))
+
+(defn disable-add-comment-if-needed [s]
+  (let [add-comment-node (rum/ref-node s "add-comment")]
+    (enable-add-comment? s)
+    (when (and (zero? (count (.-innerText add-comment-node)))
+               (not @(::emoji-picker-open s)))
+      (comment-actions/add-comment-blur))))
+
 (rum/defcs add-comment < rum/reactive
                          rum/static
                          ;; Mixins
@@ -34,6 +45,7 @@
                          (rum/local nil ::esc-key-listener)
                          (rum/local nil ::focus-listener)
                          (rum/local nil ::blur-listener)
+                         (rum/local false ::emoji-picker-open)
                          {:did-mount (fn [s]
                            (utils/after 2500 #(js/emojiAutocomplete))
                            (let [add-comment-node (rum/ref-node s "add-comment")
@@ -44,15 +56,10 @@
                               (partial editable-input-change s))
                              (reset! (::focus-listener s)
                               (events/listen add-comment-node EventType/FOCUS
-                               (fn [e]
-                                 (enable-add-comment? s)
-                                 (comment-actions/add-comment-focus (:uuid (first (:rum/args s)))))))
+                               #(add-comment-focus s)))
                              (reset! (::blur-listener s)
                               (events/listen add-comment-node EventType/BLUR
-                               (fn [e]
-                                 (enable-add-comment? s)
-                                 (when (zero? (count (.-innerText add-comment-node)))
-                                   (comment-actions/add-comment-blur)))))
+                               #(disable-add-comment-if-needed s)))
                              (reset! (::esc-key-listener s)
                                (events/listen
                                 js/window
@@ -105,6 +112,11 @@
                                                     false))
                                                  (enable-add-comment? s)))))
                            :force-enabled true
+                           :will-open-picker #(reset! (::emoji-picker-open s) true)
+                           :will-close-picker #(do
+                                                 (reset! (::emoji-picker-open s) false)
+                                                 (when-not add-comment-focus
+                                                   (disable-add-comment-if-needed s)))
                            :container-selector "div.add-comment-box"}))]
         (when add-comment-focus
           [:div.add-comment-footer.group
@@ -119,5 +131,5 @@
               {:on-click #(let [add-comment-div (rum/ref-node s "add-comment")
                                 comment-body (cu/add-comment-content add-comment-div)]
                             (set! (.-innerHTML add-comment-div) "")
-                            (comment-actions/add-comment-focus nil))}
+                            (comment-actions/add-comment-blur))}
               "Cancel"]])]]))


### PR DESCRIPTION
BUG: we moved the emoji picker inside the add comment box. It appears only when the add comment is focused so if the user focus the filed then click to pick an emoji the add comment field blur and the picker disappear.

To test:
- focus add comment
- click emoji picker
- [x] do you see the picker appear? Good
- [x] do you see the add comment field still expanded? Good
- now click outside the picker to dismiss it
- [x] did it dismiss? Good
- [x] did the add comment field collapse? Good
- now do the same and pick an emoji
- [x] the add comment field stays open? Good
- [x] do you see the emoji in the field? Good
- add the comment with only one emoji
- now focus the add comment field
- type something
- click the emoji picker button
- click out to dismiss it
- [x] the add comment field is still expanded? Good
- add the comment
- now open FF
- add a comment
- [x] do you see the add comment filed going back to the right size after you added the comment? Good