### PR TITLE
Turn off Slack mirror when selecting private section

### DIFF
--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -254,6 +254,9 @@
               {:on-click #(do
                             (utils/event-stop %)
                             (reset! (::show-access-list s) false)
+                            (when show-slack-channels?
+                              (reset! (::slack-enabled s) false)
+                              (dis/dispatch! [:input [:section-editing :slack-mirror] nil]))
                             (dis/dispatch! [:input [:section-editing :access] "private"]))}
               private-access]
             [:div.access-list-row


### PR DESCRIPTION
Item:
> * Toggle auto-share to Slack to off if they change section privacy level to private (they can still toggle it back on, we just don't want them to leave it on by mistake when they think they are making the section private)

From:
https://docs.google.com/document/d/1BNtz1uMJnqNablvaThGUzOFu7zEEcQoeNsoh3O1ry3M/edit

To test:
- use an org with Slack bot
- go to section settings
- select a slack channel to mirror to
- now change the audience to private
- [x] did you see the slack mirror turning off? Good
- now turn it back on and select a channel
- change the audience to team or public
- [x] did you NOT see the slack mirror turning off? Good

