### PR TITLE
Use tooltips when Slack is disabled in invite panel.

### DIFF
--- a/scss/partials/_org_settings_invite_panel.scss
+++ b/scss/partials/_org_settings_invite_panel.scss
@@ -20,7 +20,6 @@ div.org-settings div.org-settings-inner {
 
         &.disabled {
           opacity: 0.3;
-          cursor: not-allowed;
         }
 
         &:not(.disabled).active {

--- a/src/oc/web/components/ui/org_settings_invite_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_invite_panel.cljs
@@ -118,10 +118,17 @@
             {:on-click #(user-type-did-change s invite-users "email")
              :class (utils/class-set {:active (= "email" @(::inviting-from s))})}
             "Email"]
-          (let [slack-enabled? (:can-slack-invite team-data)]
+          (let [has-slack-org? (:has-slack-org team-data)
+                slack-enabled? (:can-slack-invite team-data)]
             [:div.org-settings-panel-choice
               {:on-click #(when slack-enabled?
                             (user-type-did-change s invite-users "slack"))
+               :data-toggle (when-not slack-enabled? "tooltip")
+               :data-placement "top"
+               :data-container "body"
+               :title (if has-slack-org?
+                        "Enable Carrot bot for Slack"
+                        "Enable Slack for Carrot")
                :class (utils/class-set {:disabled (not slack-enabled?)
                                         :active (= "slack" @(::inviting-from s))})}
               "Slack"])]


### PR DESCRIPTION
Item:
> * On invite panel, add a tooltip when SLACK is disabled prompting to add a slack team or the slack bot depending on what you have or haven't.

From:
https://docs.google.com/document/d/1BNtz1uMJnqNablvaThGUzOFu7zEEcQoeNsoh3O1ry3M/edit

To test:
- login with email
- go to invite panel
- [x] do you see a tooltip when you hover on Slack asking to add Carrot for Slack? Good
- now signup with Slack but don't add the bot
- go to invite panel
- [x] do you see a tooltip when you hover on Slack asking to add Slack bot for Carrot? Good
- now add the bot
- go to invite
- [x] do you see Slack enabled? Good