### PR TITLE
Change top and bottom margin of all nux tooltips from 32 to 8 pixels.

### DIFF
--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -432,13 +432,15 @@ div.cmail-outer {
           background-color: #FDF6E4;
           border-radius: 6px;
           padding: 24px 24px;
-          margin: 32px 0px;
+          margin: 8px 0px;
           position: relative;
-           @include tablet() {
+
+          @include tablet() {
             width: calc(100% - 48px);
             margin: 32px 24px;
           }
-           button.edit-tooltip-dismiss {
+
+          button.edit-tooltip-dismiss {
             position: absolute;
             top: 16px;
             right: 16px;
@@ -449,26 +451,31 @@ div.cmail-outer {
             background-position: center;
             background-repeat: no-repeat;
           }
-           div.edit-tooltips {
+
+          div.edit-tooltips {
             width: 100%;
-             div.edit-tooltip-title {
+
+            div.edit-tooltip-title {
               @include avenir_H();
               font-size: 18px;
               color: $deep_navy;
               line-height: 20px;
             }
-             div.edit-tooltip {
+
+            div.edit-tooltip {
               @include avenir_R();
               font-size: 14px;
               color: $deep_navy;
               line-height: 18px;
               margin-top: 8px;
-               @include tablet() {
+
+              @include tablet() {
                 float: unset;
                 margin: 24px auto 0px;
                 width: 100%;
               }
-               button.edit-tooltip-record-video-bt {
+
+              button.edit-tooltip-record-video-bt {
                 display: inline;
                 background-color: transparent;
                 padding: 0;

--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -92,7 +92,7 @@ div.dashboard-layout {
         background-color: #FDF6E4;
         border-radius: 6px;
         padding: 34px 40px;
-        margin: 32px 0px;
+        margin: 8px 0px;
         position: relative;
 
         @include tablet() {
@@ -194,7 +194,7 @@ div.dashboard-layout {
         background-color: #FDF6E4;
         border-radius: 6px;
         padding: 34px 40px;
-        margin: 32px 0px;
+        margin: 8px 0px;
         position: relative;
 
         @include tablet() {
@@ -292,7 +292,7 @@ div.dashboard-layout {
         background-color: #FDF6E4;
         border-radius: 6px;
         padding: 34px 40px;
-        margin: 32px 0px;
+        margin: 8px 0px;
         position: relative;
 
         @include tablet() {

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -463,7 +463,7 @@ div.stream-item {
       background-color: #FDF6E4;
       border-radius: 6px;
       padding: 24px 24px;
-      margin: 32px 0;
+      margin: 8px 0;
       position: relative;
 
       button.add-comment-tooltip-dismiss {


### PR DESCRIPTION
From:
https://paper.dropbox.com/doc/Misc-UX--ANCZ6eHtJr7AJ~F8CVomKn~hAg-zmqEXqPjOZGPJJSxUfPxC

Item:
> Change yellow-tool tip margin top/bottom to 8px instead of 32px

only desktop

To test:
- signup with desktop
- [x] check tooltips look good
- [x] check margin above the below all tooltips is 8px instead of 32px: land tooltip, expand post tooltip, post published tooltip, draft tooltip and edit tooltip