### PR TITLE
Fix cmail text style

### DIFF
--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -251,7 +251,7 @@ $h2_top_margin: 24;
 
   h2 {
     @include avenir_H();
-    font-size: #{$font-size}px;
+    font-size: #{$font-size + 2}px;
     line-height: #{$separator}px
   }
 

--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -249,10 +249,16 @@ $h2_top_margin: 24;
     margin-top: #{$separator}px;
   }
 
+  h2 + p {
+    margin-top: 0px !important;
+  }
+
   h2 {
     @include avenir_H();
     font-size: #{$font-size + 2}px;
-    line-height: #{$separator}px
+    line-height: #{$separator}px;
+    padding-bottom: 0px;
+    margin-bottom: 0px !important;
   }
 
   a, span[data-auto-link] {

--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -432,13 +432,15 @@ div.cmail-outer {
           background-color: #FDF6E4;
           border-radius: 6px;
           padding: 24px 24px;
-          margin: 32px 0px;
+          margin: 8px 0px;
           position: relative;
-           @include tablet() {
+
+          @include tablet() {
             width: calc(100% - 48px);
             margin: 32px 24px;
           }
-           button.edit-tooltip-dismiss {
+
+          button.edit-tooltip-dismiss {
             position: absolute;
             top: 16px;
             right: 16px;
@@ -449,26 +451,31 @@ div.cmail-outer {
             background-position: center;
             background-repeat: no-repeat;
           }
-           div.edit-tooltips {
+
+          div.edit-tooltips {
             width: 100%;
-             div.edit-tooltip-title {
+
+            div.edit-tooltip-title {
               @include avenir_H();
               font-size: 18px;
               color: $deep_navy;
               line-height: 20px;
             }
-             div.edit-tooltip {
+
+            div.edit-tooltip {
               @include avenir_R();
               font-size: 14px;
               color: $deep_navy;
               line-height: 18px;
               margin-top: 8px;
-               @include tablet() {
+
+              @include tablet() {
                 float: unset;
                 margin: 24px auto 0px;
                 width: 100%;
               }
-               button.edit-tooltip-record-video-bt {
+
+              button.edit-tooltip-record-video-bt {
                 display: inline;
                 background-color: transparent;
                 padding: 0;

--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -344,7 +344,7 @@ div.cmail-outer {
           cursor: text;
           @include activity-headline();
           @include avenir_H();
-          font-size: 18px;
+          font-size: 22px;
           color: $deep_navy;
           white-space: pre-wrap;
           word-wrap: break-word;

--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -92,7 +92,7 @@ div.dashboard-layout {
         background-color: #FDF6E4;
         border-radius: 6px;
         padding: 34px 40px;
-        margin: 32px 0px;
+        margin: 8px 0px;
         position: relative;
 
         @include tablet() {
@@ -194,7 +194,7 @@ div.dashboard-layout {
         background-color: #FDF6E4;
         border-radius: 6px;
         padding: 34px 40px;
-        margin: 32px 0px;
+        margin: 8px 0px;
         position: relative;
 
         @include tablet() {
@@ -292,7 +292,7 @@ div.dashboard-layout {
         background-color: #FDF6E4;
         border-radius: 6px;
         padding: 34px 40px;
-        margin: 32px 0px;
+        margin: 8px 0px;
         position: relative;
 
         @include tablet() {

--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -341,7 +341,7 @@ div.entry-edit-modal-container {
         cursor: text;
         @include activity-headline();
         @include avenir_H();
-        font-size: 22px;
+        font-size: 24px;
         color: $deep_navy;
         white-space: pre-wrap;
         word-wrap: break-word;

--- a/scss/partials/_entry_edit.scss
+++ b/scss/partials/_entry_edit.scss
@@ -350,8 +350,6 @@ div.entry-edit-modal-container {
 
         @include tablet() {
           width: 100%;
-          @include avenir_H();
-          font-size: 20px;
           margin: 0px;
         }
 

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -463,7 +463,7 @@ div.stream-item {
       background-color: #FDF6E4;
       border-radius: 6px;
       padding: 24px 24px;
-      margin: 32px 0;
+      margin: 8px 0;
       position: relative;
 
       button.add-comment-tooltip-dismiss {


### PR DESCRIPTION
### Merge after https://github.com/open-company/open-company-web/pull/627

From:
https://paper.dropbox.com/doc/Misc-UX--ANCZ6eHtJr7AJ~F8CVomKn~hAg-zmqEXqPjOZGPJJSxUfPxC

Item:
> Post title, H1, and bold font updates (see Abstract)
> Mobile H1 and bold updates (see Abstract)

So on desktop:
- headline: 22px Avenir Heavy
- body: 16px Avenir Roman
- bold: 16px Avenir Roman weight 700
- H1: 18px Avenir Heavy

Mobile:
- headline: 24px Avenir Heavy
- body: 18px Avenir Roman
- bold: 18px Avenir Roman weight 700
- H1: 20px Avenir Heavy

To test:
- open cmail on desktop
- [x] check with Whatfont or the dev tools the 4 styles above
- [x] now check the mobile styles
- [x] also add a title and make sure when you hit enter the next paragraph has no margin above (there is no margin or padding btw H2 and P elements)