### PR TITLE
Must see new post

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -771,6 +771,9 @@
 
 (defn activity-edit
   [activity-data]
-  (if (responsive/is-tablet-or-mobile?)
-    (entry-edit activity-data)
-    (cmail-show activity-data)))
+  (let [fixed-activity-data (if (not (seq (:uuid actvity-data)))
+                              (assoc activity-data :must-see (= (router/current-board-slug) "must-see"))
+                              activity-data)]
+    (if (responsive/is-tablet-or-mobile?)
+      (entry-edit fixed-activity-data)
+      (cmail-show fixed-activity-data))))

--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -771,7 +771,7 @@
 
 (defn activity-edit
   [activity-data]
-  (let [fixed-activity-data (if (not (seq (:uuid actvity-data)))
+  (let [fixed-activity-data (if (not (seq (:uuid activity-data)))
                               (assoc activity-data :must-see (= (router/current-board-slug) "must-see"))
                               activity-data)]
     (if (responsive/is-tablet-or-mobile?)


### PR DESCRIPTION
From:
https://paper.dropbox.com/doc/Misc-UX--ANCZ6eHtJr7AJ~F8CVomKn~hAg-zmqEXqPjOZGPJJSxUfPxC

Item:
> Default “Must See” toggle to on if the post is created from “must see” section

To test:
- clean your indexed DB (dev tools -> Application -> Indexed DB -> localforage => delete all)
- go to Must See
- remove all MS posts
- click new post in the empty board placeholder (not in top right corner)
- [x] does the new post has must see on? Good
- close it
- clean your indexed DB again
- go to AP or a board
- click New post in top right
- [x] does the new post has must see off? Good