### PR TITLE
Pre flight 2

### DIFF
--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -228,11 +228,11 @@
       (dispatcher/dispatch! [:input [:section-editing] next-section-editing])
       (success-cb next-section-editing))))
 
-(defn pre-flight-check [section-name]
+(defn pre-flight-check [section-slug section-name]
   (dispatcher/dispatch! [:input [:section-editing :pre-flight-loading] true])
   (let [org-data (dispatcher/org-data)
         pre-flight-link (utils/link-for (:links org-data) "pre-flight-create")]
-    (api/pre-flight-section-check pre-flight-link section-name
+    (api/pre-flight-section-check pre-flight-link section-slug section-name
      (fn [{:keys [success body status]}]
        (when-not success
          (section-name-error status))

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -463,12 +463,13 @@
          :json-params (cljs->json with-personal-note)}
         callback))))
 
-(defn pre-flight-section-check [pre-flight-link section-name callback]
+(defn pre-flight-section-check [pre-flight-link section-slug section-name callback]
   (when (and pre-flight-link
              section-name)
     (storage-http (method-for-link pre-flight-link) (relative-href pre-flight-link)
      {:headers (headers-for-link pre-flight-link)
       :json-params (cljs->json {:name section-name
+                                :exclude (vec (remove nil? [section-slug]))
                                 :pre-flight true})}
      callback)))
 

--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -82,11 +82,10 @@
         (when (:section-name-error section-editing)
           (dis/dispatch! [:input [:section-editing :section-name-error] nil]))
         (if (>= (count sec-name) section-actions/min-section-name-length)
-          (if (not= (:slug section-editing) utils/default-section-slug)
-            (do
-              (section-actions/pre-flight-check sec-name)
-              (reset! (::pre-flight-check s) true))
-            (reset! (::pre-flight-check s) false))
+          (do
+            (section-actions/pre-flight-check (when @(::editing-existing-section s) (:slug section-editing))
+             sec-name)
+            (reset! (::pre-flight-check s) true))
           (reset! (::pre-flight-check s) false))))))
 
 (rum/defcs section-editor < rum/reactive

--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -130,7 +130,7 @@
                                 #(when-not (utils/event-inside? % (rum/dom-node s))
                                    (dismiss))))
                               s)
-                             :did-remount (fn [_ s]
+                             :will-update (fn [s]
                               (let [section-editing @(drv/get-ref s :section-editing)]
                                 (when @(::pre-flight-check s)
                                   (when-not (:pre-flight-loading section-editing)


### PR DESCRIPTION
### Review with https://github.com/open-company/open-company-storage/pull/147

Extend preflight checks on section names to section creation too, not only on section update.
Checks if the section name already exists against the sections loaded locally and then, if not match is found, execute the server checks.
Also fixes a bug that was showing the spinner always even after the preflight checks finished.

To test:
- navigate to a single section
- go to section settings
- change the section name: names should have at least 3 chars and be different than any other section except this one case insensitive
- [x] can you NOT enter the name of another section? Good
- [x] can you NOT enter the name of another section with a different accent or case? Good (if you have all-hands try entering àll-Hands)
- [x] can you enter a new section name? Good
- [x] can you change it back to the original section name? Good
- [ ] section name that has less than 3 chars it fails
- now try to add a new section
- [x] can you NOT enter the name of another section? Good
- [x] can you NOT enter the name of another section with a different accent or case? Good (if you have all-hands try entering àll-Hands)
- [x] can you enter a new section name? Good
- save the new section