### PR TITLE
Refresh draft count (org data) when receiving a draft section change

### DIFF
--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -56,11 +56,15 @@
       (fn [status body success]
         (section-get-finish (json->cljs body))))))
 
+(declare refresh-org-data)
+
 (defn section-change
   [section-uuid]
   (timbre/debug "Section change:" section-uuid)
   (utils/after 0 (fn []
     (let [current-section-data (dispatcher/board-data)]
+      (when (= section-uuid (:uuid utils/default-drafts-board))
+        (refresh-org-data))
       (if (= section-uuid (:uuid current-section-data))
         ;; Reload the current board data
         (api/get-board (utils/link-for (:links current-section-data) "self")

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -145,7 +145,8 @@
                "Must see"]])
         (when drafts-link
           (let [board-url (oc-urls/board (:slug drafts-board))
-                draft-posts (dis/draft-posts-data)]
+                draft-posts (dis/draft-posts-data)
+                draft-count (or (count draft-posts) (:count drafts-link))]
             [:a.drafts.hover-item.group
               {:class (when (and (not is-all-posts)
                                  (= (router/current-board-slug) (:slug drafts-board)))
@@ -156,9 +157,8 @@
                :on-click #(nav-actions/nav-to-url! % board-url)}
               [:div.drafts-label.group
                 "Drafts "
-                (when (or (pos? (count draft-posts))
-                          (pos? (:count drafts-link)))
-                  [:span.count "(" (or (count draft-posts) (:count drafts-link)) ")"])]]))
+                (when (pos? draft-count)
+                  [:span.count "(" draft-count ")"])]]))
         ;; Boards list
         (when show-boards
           [:div.left-navigation-sidebar-top.group


### PR DESCRIPTION
Supports https://github.com/open-company/open-company-change/pull/8

Test steps.

Follow the steps at https://github.com/open-company/open-company-change/pull/8

But in this case go to a single section url (http://localhost:3669/all-hands)