### PR TITLE
Auto save avatars

### DIFF
--- a/scss/mixins/_org.scss
+++ b/scss/mixins/_org.scss
@@ -44,9 +44,10 @@
     }
 
     img.org-avatar-img{
-      max-width: #{$max_logo_height * 8}px;
-      max-height: #{$max_logo_height}px;
-      vertical-align: top;
+      width: #{$max_logo_height}px;
+      height: #{$max_logo_height}px;
+      object-fit: contain;
+      vertical-align: middle;
       border-radius: 8px;
     }
 

--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -60,6 +60,7 @@ div.org-settings {
         border-radius: 4px;
         width: 48px;
         height: 48px;
+        padding: 3px;
 
         &.main-panel {
           cursor: pointer;

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -204,7 +204,7 @@
          :description "Your image was succesfully updated."
          :expire 5
          :dismiss true})
-      (org-loaded (json->cljs body) true))
+      (org-loaded (json->cljs body) false))
     (do
       (dis/dispatch! [:org-avatar-update/failed])
       (notification-actions/show-notification

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -196,6 +196,27 @@
 (defn org-edit-save [org-data]
   (api/patch-org org-data org-edit-save-cb))
 
+(defn org-avatar-edit-save-cb [{:keys [success body status]}]
+  (if success
+    (do
+      (notification-actions/show-notification
+        {:title "Image update succeeded"
+         :description "Your image was succesfully updated."
+         :expire 5
+         :dismiss true})
+      (org-loaded (json->cljs body) true))
+    (do
+      (dis/dispatch! [:org-avatar-update/failed])
+      (notification-actions/show-notification
+       {:title "Image upload error"
+        :description "An error occurred while processing your company avatar. Please retry."
+        :expire 5
+        :id :org-avatar-upload-failed
+        :dismiss true}))))
+
+(defn org-avatar-edit-save [org-avatar-data]
+  (api/patch-org org-avatar-data org-avatar-edit-save-cb))
+
 (defn org-change [data org-data]
   (let [change-data (:data data)
         container-id (:container-id change-data)

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -389,10 +389,10 @@
 
 (def user-profile-keys [:first-name :last-name :password :avatar-url :timezone :digest-frequency :digest-medium])
 
-(defn patch-user-profile [old-user-data new-user-data cb]
-  (when (and (:links old-user-data)
+(defn patch-user-profile [user-update-link new-user-data cb]
+  (when (and user-update-link
              (map? new-user-data))
-    (let [user-update-link (utils/link-for (:links old-user-data) "partial-update" "PATCH")
+    (let [user-update-link user-update-link
           without-email (dissoc new-user-data :email)
           safe-new-user-data (select-keys without-email user-profile-keys)]
       (auth-http (method-for-link user-update-link) (relative-href user-update-link)

--- a/src/oc/web/components/ui/org_avatar.cljs
+++ b/src/oc/web/components/ui/org_avatar.cljs
@@ -18,9 +18,9 @@
     (when show-org-avatar?
       [:img.org-avatar-img
         {:src (:logo-url org-data)
-         :style #js {:height (str (:logo-height org-data) "px")
-                     :marginTop (when (< (:logo-height org-data) default-max-logo-height)
-                                 (str (/ (- default-max-logo-height (:logo-height org-data)) 2) "px"))}
+         ; :style #js {:height (str (:logo-height org-data) "px")
+         ;             :marginTop (when (< (:logo-height org-data) default-max-logo-height)
+         ;                         (str (/ (- default-max-logo-height (:logo-height org-data)) 2) "px"))}
          :on-error #(reset! (::img-load-failed s) true)}])
     (when show-org-name?
       [:span.org-name

--- a/src/oc/web/components/ui/org_avatar.cljs
+++ b/src/oc/web/components/ui/org_avatar.cljs
@@ -18,9 +18,6 @@
     (when show-org-avatar?
       [:img.org-avatar-img
         {:src (:logo-url org-data)
-         ; :style #js {:height (str (:logo-height org-data) "px")
-         ;             :marginTop (when (< (:logo-height org-data) default-max-logo-height)
-         ;                         (str (/ (- default-max-logo-height (:logo-height org-data)) 2) "px"))}
          :on-error #(reset! (::img-load-failed s) true)}])
     (when show-org-name?
       [:span.org-name

--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -72,10 +72,7 @@
   [res]
   (let [url    (googobj/get res "url")]
     (if-not url
-      (notification-actions/show-notification
-        {:title "Image upload error"
-         :description "An error occurred while processing the image URL. Please try again."
-         :expire 5})
+      (error-cb nil nil)
       (do
         (dis/dispatch! [:input [:edit-user-profile-avatar] url])
         (user-actions/user-avatar-save url)))))

--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -67,6 +67,13 @@
       (alert-modal/show-alert alert-data))
     (real-close-cb current-user-data)))
 
+(defn error-cb [res error]
+  (notification-actions/show-notification
+    {:title "Image upload error"
+     :description "An error occurred while processing your image. Please retry."
+     :expire 5
+     :dismiss true}))
+
 (defn success-cb
   [res]
   (let [url    (googobj/get res "url")
@@ -77,19 +84,13 @@
          :description "An error occurred while processing the image URL. Please try again."
          :expire 5})
       (do
+        (set! (.-onerror node) #(error-cb nil nil))
         (set! (.-onload node) #(img-on-load url node))
         (set! (.-className node) "hidden")
         (gdom/append (.-body js/document) node)
         (set! (.-src node) url)))))
 
 (defn progress-cb [res progress])
-
-(defn error-cb [res error]
-  (notification-actions/show-notification
-    {:title "Image upload error"
-     :description "An error occurred while processing your image. Please retry."
-     :expire 5
-     :dismiss true}))
 
 (defn upload-user-profile-pictuer-clicked []
   (iu/upload! user-utils/user-avatar-filestack-config success-cb progress-cb error-cb))

--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -34,8 +34,8 @@
   (utils/after 100
    #(let [header-avatar (rum/ref-node s "user-profile-header-avatar")
           $header-avatar (js/$ header-avatar)
-          current-user-data (:user-data @(drv/get-ref s :edit-user-profile))
-          title (if (empty? (:avatar-url current-user-data))
+          edit-user-profile-avatar @(drv/get-ref s :edit-user-profile-avatar)
+          title (if (empty? edit-user-profile-avatar)
                   "Add a photo"
                   "Change photo")
           profile-tab? (.hasClass $header-avatar "profile-tab")]
@@ -47,9 +47,9 @@
         (.tooltip $header-avatar "destroy")))))
 
 (defn- img-on-load [url img]
-  (dis/dispatch! [:input [:edit-user-profile :avatar-url] url])
-  (dis/dispatch! [:input [:edit-user-profile :has-changes] true])
-  (gdom/removeNode img))
+  (dis/dispatch! [:input [:edit-user-profile-avatar] url])
+  (gdom/removeNode img)
+  (user-actions/user-avatar-save url))
 
 (defn close-cb [current-user-data]
   (dis/dispatch! [:input [:latest-entry-point] 0])
@@ -100,6 +100,7 @@
                           (drv/drv :alert-modal)
                           (drv/drv :edit-user-profile)
                           (drv/drv :user-settings)
+                          (drv/drv :edit-user-profile-avatar)
                           ;; Mixins
                           no-scroll-mixin
                           {:will-mount (fn [s]
@@ -118,7 +119,9 @@
   (let [user-profile-data (drv/react s :edit-user-profile)
         current-user-data (:user-data user-profile-data)
         tab (drv/react s :user-settings)
-        org-data (drv/react s :org-data)]
+        org-data (drv/react s :org-data)
+        edit-user-profile-avatar (drv/react s :edit-user-profile-avatar)
+        user-for-avatar (merge current-user-data {:avatar-url edit-user-profile-avatar})]
     [:div.user-profile.fullscreen-page
       [:div.user-profile-inner
         [:button.mlb-reset.settings-modal-close
@@ -128,7 +131,7 @@
             {:ref "user-profile-header-avatar"
              :class (utils/class-set {:profile-tab (= tab :profile)})
              :on-click #(upload-user-profile-pictuer-clicked)}
-            (user-avatar-image current-user-data)]
+            (user-avatar-image user-for-avatar)]
           [:div.user-profile-header-name
             (clojure.string/trim
              (str (:first-name current-user-data) " " (:last-name current-user-data)))]

--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -1,6 +1,5 @@
 (ns oc.web.components.user-profile
   (:require [rum.core :as rum]
-            [goog.dom :as gdom]
             [goog.object :as googobj]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.dispatcher :as dis]
@@ -46,11 +45,6 @@
                                       :container "body"})
         (.tooltip $header-avatar "destroy")))))
 
-(defn- img-on-load [url img]
-  (dis/dispatch! [:input [:edit-user-profile-avatar] url])
-  (gdom/removeNode img)
-  (user-actions/user-avatar-save url))
-
 (defn close-cb [current-user-data]
   (dis/dispatch! [:input [:latest-entry-point] 0])
   (if (:has-changes current-user-data)
@@ -76,19 +70,15 @@
 
 (defn success-cb
   [res]
-  (let [url    (googobj/get res "url")
-        node   (gdom/createDom "img")]
+  (let [url    (googobj/get res "url")]
     (if-not url
       (notification-actions/show-notification
         {:title "Image upload error"
          :description "An error occurred while processing the image URL. Please try again."
          :expire 5})
       (do
-        (set! (.-onerror node) #(error-cb nil nil))
-        (set! (.-onload node) #(img-on-load url node))
-        (set! (.-className node) "hidden")
-        (gdom/append (.-body js/document) node)
-        (set! (.-src node) url)))))
+        (dis/dispatch! [:input [:edit-user-profile-avatar] url])
+        (user-actions/user-avatar-save url)))))
 
 (defn progress-cb [res progress])
 

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -243,6 +243,8 @@
    :org-editing         [[:base]
                           (fn [base]
                             (:org-editing base))]
+   :org-avatar-editing  [[:base]
+                          (fn [base] (:org-avatar-editing base))]
    :alert-modal         [[:base]
                           (fn [base]
                             (:alert-modal base))]

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -224,6 +224,7 @@
                           (fn [base]
                             {:user-data (:edit-user-profile base)
                              :error (:edit-user-profile-failed base)})]
+   :edit-user-profile-avatar [[:base] (fn [base] (:edit-user-profile-avatar base))]
    :entry-editing       [[:base]
                           (fn [base]
                             (:entry-editing base))]

--- a/src/oc/web/stores/org.cljs
+++ b/src/oc/web/stores/org.cljs
@@ -25,15 +25,22 @@
         next-boards (into {} (filter filter-board old-boards))
         section-names (:default-board-names org-data)
         selected-sections (map :name (:boards org-data))
-        sections (vec (map #(hash-map :name % :selected (utils/in? selected-sections %)) section-names))]
+        sections (vec (map #(hash-map :name % :selected (utils/in? selected-sections %)) section-names))
+        fixed-org-data (fix-org org-data)]
     (-> db
-      (assoc-in (dispatcher/org-data-key (:slug org-data)) (fix-org org-data))
+      (assoc-in (dispatcher/org-data-key (:slug org-data)) fixed-org-data)
       (assoc :org-editing (-> org-data
                               (assoc :saved saved?)
                               (assoc :email-domain email-domain)
                               (dissoc :has-changes)))
+      (assoc :org-avatar-editing (select-keys fixed-org-data [:logo-url :logo-width :logo-height]))
       (assoc :sections-setup sections)
       (assoc-in boards-key next-boards))))
+
+(defmethod dispatcher/action :org-avatar-update/failed
+  [db [_]]
+  (let [org-data (dispatcher/org-data db)]
+    (assoc db :org-avatar-editing (select-keys org-data [:logo-url :logo-width :logo-height]))))
 
 (defmethod dispatcher/action :org-create
   [db [_]]

--- a/src/oc/web/stores/user.cljs
+++ b/src/oc/web/stores/user.cljs
@@ -85,7 +85,12 @@
     (-> db
         (assoc :current-user-data fixed-user-data)
         (assoc :edit-user-profile (fix-user-values fixed-user-data))
+        (assoc :edit-user-profile-avatar (:avatar-url fixed-user-data))
         (dissoc :edit-user-profile-failed))))
+
+(defmethod dispatcher/action :user-profile-avatar-update/failed
+  [db [_]]
+  (assoc db :edit-user-profile-avatar (:avatar-url (:current-user-data db))))
 
 (defmethod dispatcher/action :user-data
   [db [_ user-data]]


### PR DESCRIPTION
Card: https://trello.com/c/xDtmKXCC

From: https://paper.dropbox.com/doc/Misc-UX--ANGz0bS9GxPlXU0OdvuNQNMdAg-zmqEXqPjOZGPJJSxUfPxC

Item:
> Once you've chosen a new user avatar you shouldn't have to hit the Save button; consider it already saved.

This was initially thought for mobile user avatar change only. I extended it to both mobile and desktop and to both user and org avatar since both have the same UI where the save button is down below other fields and the avatars feel disconnected from it.

To test:
- go to org settings
- change the org avatar
- [x] do you see a notification when the upload finishes? Good
- [x] did the avatar changed in the navigation bar too? Good
- [x] can you edit data inside the 3 settings tabs w/o problems? Good
- now stop storage service and try to change the avatar again
- [x] do you get a notification about the error? Good
- [x] do you get the old avatar back in the view? Good
- switch to mobile
- restart storage service
- go to user profile from the menu
- change your avatar
- [x] do you see a notification when the upload finishes? Good
- [x] did your avatar changed in the top right menu too? Good
- [x] can you change your first or last name or other data inside the profile panel w/o problems? Good
- [x] can you change data inside the notifications panel w/o problems? Good
- now stop auth service and try to change the avatar again
- [x] do you get a notification about the error? Good
- [x] do you get your old avatar back in the view? Good