### PR TITLE
Fix empty avatar

### DIFF
--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -56,37 +56,31 @@ div.org-settings {
 
       div.org-settings-header-avatar {
         float: left;
-        border: 1px solid #D8DBDF;
-        border-radius: 4px;
         width: 48px;
         height: 48px;
-        padding: 3px;
+        // padding: 3px;
 
         &.main-panel {
           cursor: pointer;
         }
 
-        &.missing-logo {
-          &:hover {
-            background-color: $carrot_green;
+        div.org-avatar.missing-logo {
+          position: relative;
+          width: 48px;
+          height: 48px;
+          background-color: #F8FCFA;
+          border: 1px dashed $carrot_green;
+          border-radius: 8px;
+          background-image: cdnUrl("/img/ML/company_avatar_green_plus.svg");
+          background-size: 16px 16px;
+          background-position: center;
+          background-repeat: no-repeat;
+        }
 
-            @include preload_image(cdnUrl("/img/ML/upload_avatar_placeholder.svg"));
-            @include preload_image(cdnUrl("/img/ML/upload_avatar_placeholder_hover.svg"));
-
-            div.org-avatar-img-empty {
-              background-image: cdnUrl("/img/ML/upload_avatar_placeholder_hover.svg");
-            }
-          }
-
-          div.org-avatar-img-empty {
-            width: 22px;
-            height: 19px;
-            margin: 14px auto;
-            background-image: cdnUrl("/img/ML/upload_avatar_placeholder.svg");
-            background-size: 22px 19px;
-            background-position: center;
-            background-repeat: no-repeat;
-          }
+        div.org-avatar:not(.missing-logo) {
+          border: 1px solid #D8DBDF;
+          border-radius: 4px;
+          padding: 4px;
         }
 
         @include org-avatar(40);
@@ -102,10 +96,6 @@ div.org-settings {
 
         div.org-avatar * {
           border-radius: 4px;
-        }
-
-        &.main-panel:hover {
-          border: 1px solid $carrot_green;
         }
       }
 

--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -58,7 +58,6 @@ div.org-settings {
         float: left;
         width: 48px;
         height: 48px;
-        // padding: 3px;
 
         &.main-panel {
           cursor: pointer;

--- a/scss/partials/_user_profile.scss
+++ b/scss/partials/_user_profile.scss
@@ -58,6 +58,18 @@ div.user-profile {
         }
 
         @include user-profile(48);
+
+        div.empty-user-avatar-placeholder {
+          width: 48px;
+          height: 48px;
+          border-radius: 50%;
+          background-color: #F8FCFA;
+          border: 1px dashed $carrot_green;
+          background-image: cdnUrl("/img/ML/company_avatar_green_plus.svg");
+          background-size: 16px 16px;
+          background-position: center;
+          background-repeat: no-repeat;
+        }
       }
 
       div.user-profile-header-name {

--- a/src/oc/web/components/org_settings.cljs
+++ b/src/oc/web/components/org_settings.cljs
@@ -172,9 +172,7 @@
                :class (utils/class-set {:missing-logo (empty? (:logo-url org-avatar-editing))
                                         :main-panel main-tab?})
                :on-click logo-on-click}
-              (if (empty? (:logo-url org-avatar-editing))
-                [:div.org-avatar-img-empty]
-                (org-avatar org-data-for-avatar false false true))]
+              (org-avatar org-data-for-avatar false :never)]
             [:div.org-name (:name org-data)]
             [:div.org-url (str ls/web-server "/" (:slug org-data))]]
           (org-settings-tabs org-data settings-tab)

--- a/src/oc/web/components/user_profile.cljs
+++ b/src/oc/web/components/user_profile.cljs
@@ -89,10 +89,14 @@
                           (drv/drv :edit-user-profile)
                           (drv/drv :user-settings)
                           (drv/drv :edit-user-profile-avatar)
+                          ;; Locals
+                          (rum/local nil ::temp-user-avatar)
                           ;; Mixins
                           no-scroll-mixin
                           {:will-mount (fn [s]
                             (user-actions/user-profile-reset)
+                            (let [avatar-with-cdn (:avatar-url (:user-data @(drv/get-ref s :edit-user-profile)))]
+                              (reset! (::temp-user-avatar s) avatar-with-cdn))
                             s)
                            :did-remount (fn [_ s]
                             (update-tooltip s)
@@ -109,7 +113,9 @@
         tab (drv/react s :user-settings)
         org-data (drv/react s :org-data)
         edit-user-profile-avatar (drv/react s :edit-user-profile-avatar)
-        user-for-avatar (merge current-user-data {:avatar-url edit-user-profile-avatar})]
+        user-for-avatar (merge current-user-data {:avatar-url edit-user-profile-avatar})
+        temp-user-avatar @(::temp-user-avatar s)
+        is-jelly-head-avatar (= (:avatar-url user-for-avatar) temp-user-avatar)]
     [:div.user-profile.fullscreen-page
       [:div.user-profile-inner
         [:button.mlb-reset.settings-modal-close
@@ -119,7 +125,9 @@
             {:ref "user-profile-header-avatar"
              :class (utils/class-set {:profile-tab (= tab :profile)})
              :on-click #(upload-user-profile-pictuer-clicked)}
-            (user-avatar-image user-for-avatar)]
+            (if is-jelly-head-avatar
+              [:div.empty-user-avatar-placeholder]
+              (user-avatar-image user-for-avatar))]
           [:div.user-profile-header-name
             (clojure.string/trim
              (str (:first-name current-user-data) " " (:last-name current-user-data)))]


### PR DESCRIPTION
From:

Items:
> For users that don’t upload a workplace icon, please use this design so that they’re prompted to add one
> Both in the settings drop down and settings modal

To test:
- use a user w/o logo in an org w/o logo
- go to user profile
- [ ] do you see the green circle instead of the jelly face? Good
- upload a profile logo
- [ ] do you see the profile logo? Good
- go to org settings
- [ ] do you see the green square with a plus in the middle? Good
- upload a logo
- [ ] do you see the logo? Good