### PR TITLE
Fix multiple drafts while autosaving.

### DIFF
--- a/src/oc/web/stores/activity.cljs
+++ b/src/oc/web/stores/activity.cljs
@@ -374,11 +374,15 @@
         board-slug (:board-slug activity-data)
         activity-key (dispatcher/activity-key org-slug (:uuid activity-data))
         activity-board-data (dispatcher/board-data db org-slug board-slug)
-        fixed-activity-data (au/fix-entry activity-data activity-board-data (dispatcher/change-data db))]
+        fixed-activity-data (au/fix-entry activity-data activity-board-data (dispatcher/change-data db))
+        ;; these are the data we need to move from the saved post to the editing map
+        ;; we don't have to override the keys that the user could have changed during the PATCH/POST request
+        keys-for-edit [:uuid :board-name :board-slug :board-uuid :links :revision-id :secure-uuid :status]
+        map-for-edit (assoc (select-keys activity-data keys-for-edit) :auto-saving false)]
     (-> db
       (assoc-in activity-key fixed-activity-data)
       (dissoc :entry-toggle-save-on-exit)
-      (assoc-in [edit-key :auto-saving] false))))
+      (update-in [edit-key] merge map-for-edit))))
 
 (defmethod dispatcher/action :entry-revert/finish
   [db [_ activity-data]]


### PR DESCRIPTION
BUG:  if you edit a new post each autosave creates a new draft post right now. That's due to a change i did yesterday.
To avoid overriding user's edits while autosaving i didn't copy the anything from the saved post to the editing entry map, this way we lost the uuid and the links of the post so autosave thinks it's always a new post.

To test:
- go to draft
- clean all drafts so you can see how many drafts are created
- click New
- edit it
- [x] auto save happened? Good
- [x] do you see a new draft? Good
- edit again
- [x] auto save happened? Good
- [x] do you NOT see a new draft? Good
- keep writing the headline while the client autosaves and see if the finish of the autosave request override your last edits
- [x] do you see all you edits preserved across autosaving requests? Good