### PR TITLE
Autosave race condition

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -279,7 +279,7 @@
                      (dis/dispatch! [:entry-save-with-board/finish (router/current-org-slug) board-data]))
                    ;; add or update the entry in the app-state list of posts
                    ;; also move the updated data to the entry editing
-                   (dis/dispatch! [:entry-auto-save/finish (merge entry-data-saved entry-saved) edit-key])))))
+                   (dis/dispatch! [:entry-auto-save/finish entry-saved edit-key entry-map])))))
            (dis/dispatch! [:entry-toggle-save-on-exit false])))))))
 
 (defn entry-toggle-save-on-exit


### PR DESCRIPTION
During autosave somethings could change in the post on server side: board-slug and board-uuid in case we are creating a new board, and video-error and video-processing when we added a video and ziggeo callback came back.

In these cases we need to keep the server version of these values but only if they didn’t change on the client from the moment the autosave request started.

If you can think of other keys that can change server side and client side during autosave please let me know.

This is a bit hard to test since it's a race condition, Stuart's said video is broken right now and i think it's due to this so try to add a video post and checks that the video is ready for playing on the draft board below cmail and also in cmail.

- go to draft
- remove all drafts
- add a new post
- add a video
- record video and select cover
- [ ] do you see the video being saved and show up in the drafts board below cmail? Good
- [ ] do you see the video being available inside cmail? Good
- merge
