### PR TITLE
Add an argument to the redirect url to indicate a slack team is being added.

### DIFF
--- a/src/oc/web/actions/team.cljs
+++ b/src/oc/web/actions/team.cljs
@@ -295,7 +295,7 @@
                                    (:href add-slack-team-link)
                                    (:user-id current-user-data)
                                    team-id
-                                   redirect)]
+                                   (str redirect "%26add=team"))]
     (when fixed-add-slack-team-link
       (router/redirect! fixed-add-slack-team-link))))
 


### PR DESCRIPTION
Needs: https://github.com/open-company/open-company-auth/pull/58

Test steps are in the trello card https://trello.com/c/hsZ6WtmG/1412-auth-bug-slack-exception-adding-bot

With this fix an exception is no longer thrown and the user is redirected back to the settings page.