### PR TITLE
Fix Start using Button rage click

### DIFF
--- a/scss/partials/_onboard_wrapper.scss
+++ b/scss/partials/_onboard_wrapper.scss
@@ -1,5 +1,10 @@
 div.onboard-wrapper-container {
 
+  div.oc-loading {
+    width: 100vw;
+    height: 100vh;
+  }
+
   div.onboard-wrapper {
     position: absolute;
     top: 0;

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -246,6 +246,7 @@
               (router/nav! (oc-urls/all-posts (:slug org-data))))))))))
 
 (defn update-org-sections [org-slug all-sections]
+  (dis/dispatch! [:input [:ap-loading] true])
   (let [selected-sections (vec (map :name (filterv :selected all-sections)))
         patch-payload {:boards (conj selected-sections "General")
                        :samples true}]

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -19,6 +19,7 @@
             [oc.web.actions.team :as team-actions]
             [oc.web.actions.user :as user-actions]
             [oc.web.lib.responsive :as responsive]
+            [oc.web.components.ui.loading :refer (loading)]
             [oc.web.components.ui.small-loading :refer (small-loading)]
             [oc.web.components.ui.org-avatar :refer (org-avatar)]
             [oc.web.components.ui.user-avatar :refer (user-avatar-image)]
@@ -406,11 +407,14 @@
 (rum/defcs lander-sections < rum/reactive
                              (drv/drv :org-data)
                              (drv/drv :sections-setup)
+                             (rum/local false ::patching-sections)
   [s]
   (let [sections-list (drv/react s :sections-setup)
         org-data (drv/react s :org-data)
+        disabled @(::patching-sections s)
         continue-fn (fn []
-                     (org-actions/update-org-sections (:slug org-data) sections-list))]
+                      (reset! (::patching-sections s) true)
+                      (org-actions/update-org-sections (:slug org-data) sections-list))]
     [:div.onboard-lander.lander-sections
       [:div.main-cta
         [:div.mobile-header.mobile-only
@@ -418,6 +422,7 @@
           [:button.mlb-reset.top-continue
             {:on-touch-start identity
              :on-click continue-fn
+             :disabled disabled
              :aria-label "Start using Carrot"}
            "Start"]]
         [:div.title
@@ -437,7 +442,8 @@
             (small-loading))]
         [:button.continue.start-using-carrot
           {:on-touch-start identity
-           :on-click continue-fn}
+           :on-click continue-fn
+           :disabled disabled}
           "✨ Start using Carrot ✨"]]]))
 
 (def default-invite-row
@@ -891,9 +897,11 @@
     :password-reset-lander (password-reset-lander)
     [:div]))
 
-(rum/defc onboard-wrapper < rum/static
-  [component]
+(rum/defcs onboard-wrapper < rum/reactive
+                             (drv/drv :ap-loading)
+  [s component]
   [:div.onboard-wrapper-container
+    (loading {:loading (drv/react s :ap-loading)})
     [:div.onboard-wrapper
       {:class (str "onboard-" (name component))}
       [:div.onboard-wrapper-left

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -137,6 +137,7 @@
    :site-menu-open      [[:base] (fn [base] (:site-menu-open base))]
    :mobile-menu-open    [[:base] (fn [base] (:mobile-menu-open base))]
    :sections-setup      [[:base] (fn [base] (:sections-setup base))]
+   :ap-loading          [[:base] (fn [base] (:ap-loading base))]
    :org-data            [[:base :org-slug]
                           (fn [base org-slug]
                             (when org-slug


### PR DESCRIPTION
BUG: if section patch is taking more then expected user can click multiple times on the Start using Carrot button.

To fix disable the button once the user clicks on it and show the loading screen with the shaky Carrot until AP is loaded to give the impression we are preparing something.

To test:
- signup with email
- pick sections
- open dev tools to Network tab and check keep logs to make sure you don't lose them
- now click multiple times as fast as you can on the Start using Carrot button
- [ ] do you see only one PATCH request in the Network tab? Good
- [ ] does it contains the sections you selected plus General? Good
- [ ] did you see the shaky Carrot after you clicked the button and util AP is loaded? Good
- merge