### PR TITLE
Fix for missing search result.

### DIFF
--- a/src/oc/web/stores/org.cljs
+++ b/src/oc/web/stores/org.cljs
@@ -26,8 +26,11 @@
         section-names (:default-board-names org-data)
         selected-sections (map :name (:boards org-data))
         sections (vec (map #(hash-map :name % :selected (utils/in? selected-sections %)) section-names))
-        fixed-org-data (fix-org org-data)]
+        fixed-org-data (fix-org org-data)
+        current-orgs (dispatcher/orgs-data)
+        new-orgs (distinct (conj current-orgs org-data))]
     (-> db
+      (assoc dispatcher/orgs-key new-orgs)
       (assoc-in (dispatcher/org-data-key (:slug org-data)) fixed-org-data)
       (assoc :org-editing (-> org-data
                               (assoc :saved saved?)


### PR DESCRIPTION
Only after finishing the NUX and searching for a post will this occur.  The issue is that the app state doesn't have any org information in the `:orgs` key.  This would cause the org dashboard component to say the post was missing because it thought the org was missing.


To test -

- finish the nux
- search for sample data
- click on the result
- [ ] without this change it will say the post is missing
- [ ] with this change the post will be displayed

- test that all other org related things are functioning

