### PR TITLE
Cancel signup by logging out the user.

### DIFF
--- a/scss/partials/_onboard_wrapper.scss
+++ b/scss/partials/_onboard_wrapper.scss
@@ -773,6 +773,22 @@ div.onboard-lander {
         margin-bottom: 24px;
       }
     }
+
+    div.logout-cancel {
+      text-align: center;
+      @include avenir_R();
+      font-size: 14px;
+      color: $deep_navy;
+
+      button.logout-cancel {
+        display: inline-block;
+        @include avenir_H();
+        font-size: 14px;
+        color: $carrot_green;
+        margin: 24px auto 0px;
+        padding: 0;
+      }
+    }
   }
 
 

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -21,7 +21,7 @@
 
 (defn logout
   ([]
-     (logout "/"))
+     (logout oc-urls/home))
   ([location]
      (cook/remove-cookie! :jwt)
      (router/redirect! location)

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -19,10 +19,13 @@
 
 ;; Logout
 
-(defn logout []
-  (cook/remove-cookie! :jwt)
-  (router/redirect! "/")
-  (dis/dispatch! [:logout]))
+(defn logout
+  ([]
+     (logout "/"))
+  ([location]
+     (cook/remove-cookie! :jwt)
+     (router/redirect! location)
+     (dis/dispatch! [:logout])))
 
 ;; JWT
 

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -398,11 +398,15 @@
                                                                                         (not (utils/valid-domain? domain)))]))
                  :placeholder "Domain, e.g. acme.com"}]]
             [:div.field-label.info "Anyone with this email domain can automatically join your team."]]
-          [:button.continue
-            {:class (when continue-disabled "disabled")
-             :on-touch-start identity
-             :on-click continue-fn}
-            "Continue"]]]]))
+         [:button.continue
+           {:class (when continue-disabled "disabled")
+            :on-touch-start identity
+            :on-click continue-fn}
+           "Continue"]
+         [:div.logout-cancel
+          [:button.mlb-reset.logout-cancel
+           {:on-click #(user-actions/logout)}
+              "Cancel sign up"]]]]]))
 
 (rum/defcs lander-sections < rum/reactive
                              (drv/drv :org-data)

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -405,7 +405,7 @@
            "Continue"]
          [:div.logout-cancel
           [:button.mlb-reset.logout-cancel
-           {:on-click #(user-actions/logout "/sign-up")}
+           {:on-click #(user-actions/logout oc-urls/sign-up)}
               "Cancel sign up"]]]]]))
 
 (rum/defcs lander-sections < rum/reactive

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -405,7 +405,7 @@
            "Continue"]
          [:div.logout-cancel
           [:button.mlb-reset.logout-cancel
-           {:on-click #(user-actions/logout)}
+           {:on-click #(user-actions/logout "/sign-up")}
               "Cancel sign up"]]]]]))
 
 (rum/defcs lander-sections < rum/reactive


### PR DESCRIPTION
In the case mentioned in the Trello card https://trello.com/c/zGuY4RWh/1277-stuck-clicking-back-on-slack-signup 
A user wanted to pick a different slack org but was unable to do so since we keep the user logged in. This change adds a cancel button so the user can logout and then pick a different slack org.

To test
- Sign up with a slack user
- pick the default org
- Click the cancel button
- [x] Are you brought back sign up?
- Sign up again and chose a different slack org
- [x] are you able to sign up?