### PR TITLE
Fix video playback

### DIFF
--- a/scss/partials/_secure_activity.scss
+++ b/scss/partials/_secure_activity.scss
@@ -159,6 +159,9 @@ div.secure-activity-container {
 
       div.ziggeo-player {
         margin-top: 16px;
+        video {
+          max-height: 480px;
+        }
         @include tablet(){
           margin-left: -24px;
         }

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -127,6 +127,10 @@ div.stream-item {
         width: 638px;
         height: 480px;
 
+        video {
+          max-height: 480px;
+        }
+
         @include tablet(){
           width: auto;
           height: auto;

--- a/src/oc/web/components/secure_activity.cljs
+++ b/src/oc/web/components/secure_activity.cljs
@@ -57,7 +57,7 @@
                       {:width (win-width)
                        :height @(::mobile-video-height s)}
                       {:width 640
-                       :height (utils/calc-video-height 480)}))
+                       :height (utils/calc-video-height 640)}))
         video-id (:fixed-video-id activity-data)]
     [:div.secure-activity-container
       {:style {:min-height (when is-mobile?

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -618,4 +618,4 @@
 (def section-name-exists-error "Section name already exists or isn't allowed")
 
 (defn calc-video-height [width]
-  (* width (/ 3 4)))
+  (int (* width (/ 3 4))))


### PR DESCRIPTION
BUG: When recording a video from mobile in portrait mode the player look like this on desktop:
![screen shot 2018-09-24 at 2 57 09 pm](https://user-images.githubusercontent.com/642704/46105624-d1186880-c1d6-11e8-9dd2-e81e09061fa2.png)

Fix: apply a `max-height` rule to the video tag to avoid overflowing.

To test:
- check on staging if the post you see in the screenshot is still overflowing when you expand it
- also visit that same post via this link https://staging.carrot.io/carrot/apseen2/post/fcb4-473f-9e46
- and this https://staging.carrot.io/carrot/post/0f84-48da-a44b