### PR TITLE
Fix for blank screen after clicking search result (mobile)

### DIFF
--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -136,7 +136,7 @@
         is-loading (and (not show-activity-not-found)
                         (not show-activity-removed)
                         loading?)
-        is-showing-mobile-search (and is-mobile? search-active? (not (router/current-activity-id)))]
+        is-showing-mobile-search (and is-mobile? search-active?)]
     ;; Show loading if
     (if is-loading
       [:div.org-dashboard

--- a/src/oc/web/stores/search.cljs
+++ b/src/oc/web/stores/search.cljs
@@ -63,7 +63,7 @@
 (defmethod dispatcher/action :search-result-clicked
   [db [_]]
   (reset! savedsearch @lastsearch)
-  db)
+  (assoc db search-active? false))
 
 (defmethod dispatcher/action :search-focus
   [db [_]]


### PR DESCRIPTION
This change should show the single post and correctly show the search page on the single post display.

To test:

On mobile
- click the spyglass
- type in a search
- click the result
- [ ] is the result displayed?
- click the spy glass
- [ ] does the search page display?

- merge