### PR TITLE
Don't add drafts to must see data in app state.

### DIFF
--- a/src/oc/web/stores/activity.cljs
+++ b/src/oc/web/stores/activity.cljs
@@ -213,7 +213,8 @@
 
 (defn add-remove-item-from-must-see [db org-slug activity-data]
   (let [;; Add/remove item from MS
-        is-ms? (:must-see activity-data)
+        is-ms? (and (:must-see activity-data)
+                    (not= (:status activity-data) "draft"))
         ms-key (dispatcher/container-key org-slug :must-see)
         old-ms-data (get-in db ms-key)
         old-ms-data-posts (get old-ms-data :posts-list)


### PR DESCRIPTION
This change fixes the issue where a draft will show up when viewing the must see section.

To test:

- navigate to must see
- click new
- type a headline, body , and make sure it is toggled as must see
- [x] Does the draft show up in the list of must see posts?  If not , all is good. You can revert the change to test that it does show up.

