### PR TITLE
Do not show covershot selection on mobile, only on desktop.

### DIFF
--- a/src/oc/web/components/ui/ziggeo.cljs
+++ b/src/oc/web/components/ui/ziggeo.cljs
@@ -3,6 +3,7 @@
             [taoensso.timbre :as timbre]
             [oc.web.local-settings :as ls]
             [oc.web.actions.notifications :as na]
+            [oc.web.lib.responsive :as responsive]
             [clojure.contrib.humanize :refer (filesize)]))
 
 (rum/defcs ziggeo-player < (rum/local nil ::player-instance)
@@ -72,7 +73,8 @@
                                               :theme "carrot"
                                               :themecolor "white"
                                               :localplayback true
-                                              :meta-profile ls/oc-ziggeo-profiles}
+                                              :meta-profile ls/oc-ziggeo-profiles
+                                              :picksnapshots (not (responsive/is-tablet-or-mobile?))}
                                        config {:element recorder-el
                                                :attrs attrs}
                                        Recorder (.. js/ZiggeoApi -V2 -Recorder)


### PR DESCRIPTION
Card: https://trello.com/c/fANGeo0Y
Item:
> Should not have to pick a cover shot on mobile. It's weird to double tap, it's stretched, and no one is used to picking a cover shot when making a mobile video. They're meant to be fast and casual.

To test:
- deploy to staging
- visit from desktop
- create new post
- add a video of at least 12 seconds
- [x] do you get the covershot selection? Good
- now visit from mobile
- create a new post
- add a video of at least 12 seconds
- [x] do you NOT get the covershot selection step? Good
- merge