### PR TITLE
Show the empty notifications message on mobile.

### DIFF
--- a/scss/partials/_user_notifications.scss
+++ b/scss/partials/_user_notifications.scss
@@ -104,7 +104,12 @@ div.user-notifications {
       overflow-x: hidden;
 
       div.user-notifications-tray-empty {
-
+        @include mobile() {
+          div.all-caught-up {
+            display: block !important;
+            margin-top: 100px;
+          }
+        }
       }
 
       div.user-notification {


### PR DESCRIPTION
Card: https://trello.com/c/fANGeo0Y
Item:
> Missing the empty state for Notifications on mobile

To test:
- stop notify service
- on mobile open our app
- click on the bell in the header
- [x] do you see something instead of a white body? Good
- open it on desktop
- click the bell again
- [x] do you see the message here too? Good
- merge