### PR TITLE
Do not resize the center navbar item on mobile when search is active.

### DIFF
--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -129,6 +129,11 @@ nav.oc-navbar {
           height: 32px;
           margin-left: -40px;
           transition: margin-left 0ms ease-in, width 0ms ease-in;
+
+          &.search-active {
+            width: 80px;
+            margin-left: -40px;
+          }
         }
 
         button.orgs-dropdown div.org-avatar {


### PR DESCRIPTION
Card: https://trello.com/c/fANGeo0Y
Item:
> *When in mobile search, clicking on any other nav items should close you out of search (currently the only way out is clicking the “X”)

To test:
- open mobile app
- click on search
- do a search
- tap on the AP icon
- [ ] did it dismiss the search? good
- repeat search
- tap on notification bell
- [ ] did  it dismiss the search? Good
- repeat search
- tap on user menu (far right user icon)
- [ ] did  it dismiss the search? Good
- open desktop app
- try search
- [ ] does it work? Good
- merge