### PR TITLE
Remove Must See toggle from contextual menu

### DIFF
--- a/src/oc/web/components/ui/more_menu.cljs
+++ b/src/oc/web/components/ui/more_menu.cljs
@@ -141,18 +141,7 @@
                               (when (fn? will-close)
                                 (will-close))
                               (activity-actions/activity-share-show activity-data share-container-id))}
-                "Share"])
-            (when edit-link
-              [:li
-               {:class (utils/class-set
-                         {:must-see (not (:must-see activity-data))
-                          :must-see-on (:must-see activity-data)})
-                :on-click #(do
-                             (utils/event-stop %)
-                             (activity-actions/toggle-must-see activity-data))}
-               (if (:must-see activity-data)
-                 "Unmark"
-                 "Must see")])])
+                "Share"])])
         (when (and external-share
                    share-link
                    (not (responsive/is-tablet-or-mobile?)))


### PR DESCRIPTION
Card: https://trello.com/c/fANGeo0Y
Item:
> *Remove Must see from the ... menu (can also be removed from the dropdown menu on desktop)

To test:
- open desktop
- [x] make sure the post contextual menu has no must see toggle
- open  mobile
- [x] make sure the post contextual menu has no must see toggle
- [x] make sure it has Share though (on desktop is out of the menu)