### PR TITLE
Fix click out on iOS

### DIFF
--- a/src/oc/web/components/reactions.cljs
+++ b/src/oc/web/components/reactions.cljs
@@ -34,7 +34,7 @@
                          (reset!
                           (::window-click s)
                           (events/listen
-                           js/window
+                           (.getElementById js/document "app")
                            EventType/CLICK
                            #(when-not (utils/event-inside? % (rum/dom-node s))
                               (reset! (::show-picker s) false))))

--- a/src/oc/web/components/search.cljs
+++ b/src/oc/web/components/search.cljs
@@ -122,7 +122,7 @@
                             (search/inactive))
                           (reset! (::window-click s)
                             (events/listen
-                             js/window
+                             (.getElementById js/document "app")
                              EventType/CLICK
                              (fn [e]
                                (when (and (not (responsive/is-tablet-or-mobile?))

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -90,7 +90,7 @@
                              (mention-mixins/oc-mentions-hover)
                              {:will-mount (fn [s]
                                (reset! (::click-listener s)
-                                 (events/listen js/window EventType/CLICK
+                                 (events/listen (.getElementById js/document "app") EventType/CLICK
                                   #(when (and @(::showing-menu s)
                                               (not (utils/event-inside? %
                                                     (rum/ref-node s (str "comment-more-menu-" @(::showing-menu s))))))

--- a/src/oc/web/components/ui/activity_move.cljs
+++ b/src/oc/web/components/ui/activity_move.cljs
@@ -28,7 +28,7 @@
                                         (let [opts (first (:rum/args s))
                                               dismiss-cb (:dismiss-cb opts)]
                                           (reset! (::window-click s)
-                                           (events/listen js/window EventType/CLICK
+                                           (events/listen (.getElementById js/document "app") EventType/CLICK
                                             #(when (and (not (utils/event-inside? % (rum/dom-node s)))
                                                         (fn? dismiss-cb))
                                                 (dismiss-cb)))))

--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -75,7 +75,7 @@
                                           (has-bot? org-data))
                                  (dis/dispatch! [:input [:activity-share-medium] :slack])))
                               (reset! (::window-click-listener s)
-                               (events/listen js/window EventType/CLICK
+                               (events/listen (.getElementById js/document "app") EventType/CLICK
                                 #(when-not (utils/event-inside? % (rum/dom-node s))
                                    (close-clicked s))))
                              s)

--- a/src/oc/web/components/ui/dropdown_list.cljs
+++ b/src/oc/web/components/ui/dropdown_list.cljs
@@ -21,7 +21,7 @@
     (rum/local nil ::window-click-listener)
     {:will-mount (fn [s]
                    (reset! (::window-click-listener s)
-                    (events/listen js/window EventType/CLICK
+                    (events/listen (.getElementById js/document "app") EventType/CLICK
                      #(when-not (utils/event-inside? % (sel1 :div.dropdown-list-container))
                         (let [on-blur (:on-blur (first (:rum/args s)))]
                           (when (fn? on-blur)

--- a/src/oc/web/components/ui/emoji_picker.cljs
+++ b/src/oc/web/components/ui/emoji_picker.cljs
@@ -69,7 +69,7 @@
    :will-mount (fn [s]
                  (check-focus s nil)
                  (let [click-listener (events/listen
-                                       js/window
+                                       (.getElementById js/document "app")
                                        EventType/CLICK
                                        (partial on-click-out s))
                        focusin (events/listen

--- a/src/oc/web/components/ui/more_menu.cljs
+++ b/src/oc/web/components/ui/more_menu.cljs
@@ -58,14 +58,16 @@
                        (drv/drv :editable-boards)
                        {:will-mount (fn [s]
                          (reset! (::click-listener s)
-                           (events/listen js/window EventType/CLICK
-                            #(when-not (utils/event-inside? % (rum/ref-node s "more-menu"))
-                               (when-let* [args (into [] (:rum/args s))
-                                           opts (get args 2)
-                                           will-close (:will-close opts)]
-                                 (when (fn? will-close)
-                                   (will-close)))
-                               (reset! (::showing-menu s) false))))
+                           (events/listen (.getElementById js/document "app") EventType/CLICK
+                            #(do
+                               (js/console.log "XXX click!")
+                               (when-not (utils/event-inside? % (rum/ref-node s "more-menu"))
+                                 (when-let* [args (into [] (:rum/args s))
+                                             opts (get args 2)
+                                             will-close (:will-close opts)]
+                                   (when (fn? will-close)
+                                     (will-close)))
+                                 (reset! (::showing-menu s) false)))))
                          s)
                         :did-mount (fn [s]
                          (.tooltip (js/$ "[data-toggle=\"tooltip\"]"))

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -26,7 +26,7 @@
                     (rum/local nil ::window-click)
                     {:will-mount (fn [s]
                       (reset! (::window-click s)
-                       (events/listen js/window EventType/CLICK
+                       (events/listen (.getElementById js/document "app") EventType/CLICK
                         #(when-not (utils/event-inside? % (rum/ref-node s "user-menu"))
                            (reset! (::expanded-user-menu s) false))))
                       s)

--- a/src/oc/web/components/ui/orgs_dropdown.cljs
+++ b/src/oc/web/components/ui/orgs_dropdown.cljs
@@ -28,7 +28,7 @@
                            (drv/drv :orgs-dropdown-visible)
                            {:will-mount (fn [s]
                              (reset! (::window-click-listener s)
-                              (events/listen js/window EventType/CLICK
+                              (events/listen (.getElementById js/document "app") EventType/CLICK
                                #(when-not (utils/event-inside? % (rum/dom-node s))
                                   (dis/dispatch! [:input [:orgs-dropdown-visible] false]))))
                              s)

--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -127,7 +127,7 @@
                                 (reset! (::slack-enabled s)
                                  (not (empty? (:channel-id (:slack-mirror fixed-section-data))))))
                               (reset! (::click-listener s)
-                               (events/listen js/window EventType/CLICK
+                               (events/listen (.getElementById js/document "app") EventType/CLICK
                                 #(when-not (utils/event-inside? % (rum/dom-node s))
                                    (dismiss))))
                               s)

--- a/src/oc/web/components/ui/sections_picker.cljs
+++ b/src/oc/web/components/ui/sections_picker.cljs
@@ -31,7 +31,7 @@
                              ;; Local mixins
                              {:will-mount (fn [s]
                                (reset! (::click-listener s)
-                                (events/listen js/window EventType/CLICK
+                                (events/listen (.getElementById js/document "app") EventType/CLICK
                                  #(when-not (utils/event-inside? % (rum/dom-node s))
                                     (dis/dispatch! [:input [:show-sections-picker] false]))))
                                s)

--- a/src/oc/web/components/ui/slack_channels_dropdown.cljs
+++ b/src/oc/web/components/ui/slack_channels_dropdown.cljs
@@ -32,7 +32,7 @@
                                            (reset! (::team-channels-requested s) true)
                                            (dis/dispatch! [:channels-enumerate (:team-id team-data)])))
                                        (reset! (::window-click s)
-                                        (events/listen js/window EventType/CLICK
+                                        (events/listen (.getElementById js/document "app") EventType/CLICK
                                           #(when (and @(::show-channels-dropdown s)
                                                       (not
                                                        (utils/event-inside?

--- a/src/oc/web/components/ui/slack_users_dropdown.cljs
+++ b/src/oc/web/components/ui/slack_users_dropdown.cljs
@@ -57,7 +57,7 @@
                                          (reset! (::slack-user s) (or initial-value "")))
                                        (setup-sorted-users s)
                                        (reset! (::window-click s)
-                                        (events/listen js/window EventType/CLICK
+                                        (events/listen (.getElementById js/document "app") EventType/CLICK
                                           #(when (and @(::show-users-dropdown s)
                                                       ; (not
                                                       ;  (utils/event-inside?

--- a/src/oc/web/components/user_notifications.cljs
+++ b/src/oc/web/components/user_notifications.cljs
@@ -24,7 +24,7 @@
 
                                 {:will-mount (fn [s]
                                   (reset! (::click-out-listener s)
-                                   (events/listen js/window EventType/CLICK
+                                   (events/listen (.getElementById js/document "app") EventType/CLICK
                                     #(when-not (utils/event-inside? % (rum/dom-node s))
                                        (close-tray s))))
                                   s)


### PR DESCRIPTION
Card: 
Item:
> *When I tap the “•••” menu, and click somewhere else, it should close

iOS doesn't like window click listeners, they are never fired. I changed all those listeners to listen on `div#app` selector since it's a main div wrapping the whole app.

To test:
- check on desktop some click out (dismiss notifications, dismiss emoji picker, dismiss post contextual menu etc...)
- check on mobile dismiss of the post contextual menu