### PR TITLE
Fix cmail scroll on iOS

### DIFF
--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -538,7 +538,7 @@ div.cmail-outer {
             }
 
             @include tablet() {
-              min-height: 50vh;
+              min-height: 20vh;
               max-height: initial;
               @include activity-body(18, 24, 24, $deep_navy);
               font-size: 18px;


### PR DESCRIPTION
Card: https://trello.com/c/fANGeo0Y
Item:
> When focus on body it scrolls too much i don’t see anything anymore

To test:
- on iOS focus open Cmail
- click on the body
- [x] can you still see at least the headline and the body fields with the cursor blinking? Good