### PR TITLE
Enable video for mobile

### DIFF
--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -415,8 +415,6 @@ div.cmail-outer {
               width: 24px;
               height: 24px;
               display: block;
-              // FIXME: disable video on mobile for now
-              display: none;
 
               &.remove-video-bt {
                 &:before {

--- a/scss/partials/_ziggeo.scss
+++ b/scss/partials/_ziggeo.scss
@@ -1,5 +1,6 @@
 div.ziggeo-player {
   position: relative;
+  background-color: black;
 
   div.ziggeo-player-not-processed {
     width: 100%;
@@ -43,6 +44,7 @@ div.ziggeo-player {
 
 div.ziggeo-recorder {
   position: relative;
+  background-color: black;
 
  button.remove-recorder-bt {
     width: 40px;

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -473,32 +473,28 @@
                        show-edit-tooltip)
               (edit-tooltip s))
             ;; Video elements
-            ;; FIXME: disable video on mobile for now
-            (when-not is-mobile?
-              (when (and (:fixed-video-id cmail-data)
-                         (not @(::record-video s)))
-                (ziggeo-player {:video-id (:fixed-video-id cmail-data)
-                                :remove-video-cb #(activity-actions/prompt-remove-video :cmail-data cmail-data)
+            (when (and (:fixed-video-id cmail-data)
+                       (not @(::record-video s)))
+              (ziggeo-player {:video-id (:fixed-video-id cmail-data)
+                              :remove-video-cb #(activity-actions/prompt-remove-video :cmail-data cmail-data)
+                              :width (:width video-size)
+                              :height (:height video-size)
+                              :video-processed (:video-processed cmail-data)}))
+            (when @(::record-video s)
+              (ziggeo-recorder {:start-cb (partial activity-actions/video-started-recording-cb :cmail-data)
+                                :upload-started-cb #(do
+                                                      (activity-actions/uploading-video % :cmail-data)
+                                                      (reset! (::video-picking-cover s) false)
+                                                      (reset! (::video-uploading s) true))
+                                :pick-cover-start-cb #(reset! (::video-picking-cover s) true)
+                                :pick-cover-end-cb #(reset! (::video-picking-cover s) false)
+                                :submit-cb (partial activity-actions/video-processed-cb :cmail-data)
                                 :width (:width video-size)
                                 :height (:height video-size)
-                                :video-processed (:video-processed cmail-data)})))
-            ;; FIXME: disable video on mobile for now
-            (when-not is-mobile?
-              (when @(::record-video s)
-                (ziggeo-recorder {:start-cb (partial activity-actions/video-started-recording-cb :cmail-data)
-                                  :upload-started-cb #(do
-                                                        (activity-actions/uploading-video % :cmail-data)
-                                                        (reset! (::video-picking-cover s) false)
-                                                        (reset! (::video-uploading s) true))
-                                  :pick-cover-start-cb #(reset! (::video-picking-cover s) true)
-                                  :pick-cover-end-cb #(reset! (::video-picking-cover s) false)
-                                  :submit-cb (partial activity-actions/video-processed-cb :cmail-data)
-                                  :width (:width video-size)
-                                  :height (:height video-size)
-                                  :remove-recorder-cb (fn []
-                                    (when (:video-id cmail-data)
-                                      (activity-actions/remove-video :cmail-data cmail-data))
-                                    (reset! (::record-video s) false))})))
+                                :remove-recorder-cb (fn []
+                                  (when (:video-id cmail-data)
+                                    (activity-actions/remove-video :cmail-data cmail-data))
+                                  (reset! (::record-video s) false))}))
             ; Headline element
             [:div.cmail-content-headline.emoji-autocomplete.emojiable.group.fs-hide
               {:content-editable true

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -460,10 +460,7 @@
                                         :invite-note note})]))))])
             [:div.cmail-section-right
               [:button.mlb-reset.video-record-bt
-                {:on-click #(do
-                              (when is-mobile?
-                                (js/alert (str "Video size is:" (:width video-size) "x" (:height video-size) ". Screen width is:" (win-width))))
-                              (video-record-clicked s))
+                {:on-click #(video-record-clicked s)
                  :class (when (or (:fixed-video-id cmail-data)
                                   @(::record-video s))
                           "remove-video-bt")}]]]


### PR DESCRIPTION
Card: https://trello.com/c/w4QMz7Xs

Enable video recording on mobile and also add black bands on the sides of those videos that doesn't take the whole player area.

### Review after #672 

To test:
- record a video from a real device (on staging, locally will be a pain)
- [ ] see the cover shot? Good
- [ ] do you see black bands besides the cover shot? Good
- play the video
- [ ] does it still have the black bands while playing? Good
- play it on desktop in expanded and not expanded mode
- [ ] looking good? Good
- now record a video from desktop
- play it on desktop
- [ ] looking good? Good
- play it on mobile
- [ ] looking good? Good