### PR TITLE
Remove Blog link from the header and mobile site menu.

### DIFF
--- a/scss/partials/_site_mobile_menu.scss
+++ b/scss/partials/_site_mobile_menu.scss
@@ -22,9 +22,10 @@ div.site-mobile-menu {
 
   div.site-mobile-menu-container {
     margin: 64px 0 0;
+    min-height: calc(100vh - 366px);
 
     @media screen and (max-height: 610px) {
-      margin: 40px 0 0;      
+      margin: 40px 0 0;
     }
 
     div.site-mobile-menu-item {

--- a/site/oc/core.clj
+++ b/site/oc/core.clj
@@ -70,12 +70,7 @@
         [:a
           {:href "/about"
            :class (when (= active-page "about") "active")}
-          "About"]]
-      [:div.site-mobile-menu-item
-        [:a
-          {:href "http://blog.carrot.io"
-           :target "_blank"}
-          "Blog"]]]
+          "About"]]]
     [:div.site-mobile-menu-footer
       [:button.mlb-reset.login-btn
         {:id "site-mobile-menu-login"}
@@ -116,11 +111,7 @@
           [:a
             {:href "/pricing"
              :class (when (= active-page "pricing") "active")}
-            "Pricing"]
-          [:a
-            {:href "https://blog.carrot.io"
-             :target "_blank"}
-            "Blog"]]
+            "Pricing"]]
         [:div.site-navbar-right.big-web-only
           [:a.login
             {:id "site-header-login-item"

--- a/src/oc/web/components/ui/site_header.cljs
+++ b/src/oc/web/components/ui/site_header.cljs
@@ -69,10 +69,11 @@
             {:href oc-urls/pricing
              :on-click (partial nav! oc-urls/pricing)}
             "Pricing"]
-          [:a
-            {:href oc-urls/blog
-             :target "_blank"}
-            "Blog"]]
+          ; [:a
+          ;   {:href oc-urls/blog
+          ;    :target "_blank"}
+          ;   "Blog"]
+            ]
         [:div.site-navbar-right.big-web-only
           (when-not logged-in
             [:a.login

--- a/src/oc/web/components/ui/site_mobile_menu.cljs
+++ b/src/oc/web/components/ui/site_mobile_menu.cljs
@@ -70,12 +70,7 @@
                         (user/show-login nil)
                         (site-menu-toggle true)
                         (router/nav! oc-urls/about))}
-            "About"]]
-        [:div.site-mobile-menu-item
-          [:a
-            {:href oc-urls/blog
-             :target "_blank"}
-            "Blog"]]]
+            "About"]]]
       [:div.site-mobile-menu-footer
         (when-not (jwt/jwt)
           [:button.mlb-reset.login-btn


### PR DESCRIPTION
Remove the blog link from the marketing site header and the marketing site mobile menu.

To test:
- load marketing site on desktop
- [x] do you NOT see blog at the top? Good
- load /login, dismiss login
- [x] do you NOT see blog at the top? Good
- load marketing site on mobile
- click ham menu (top left corner)
- [x] do you NOT see blog below About? Good