### PR TITLE
Remove double border on org logo.

### DIFF
--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -76,12 +76,6 @@ div.org-settings {
           background-repeat: no-repeat;
         }
 
-        div.org-avatar:not(.missing-logo) {
-          border: 1px solid #D8DBDF;
-          border-radius: 4px;
-          padding: 4px;
-        }
-
         @include org-avatar(48);
 
         div.org-avatar-container img.org-avatar-img {


### PR DESCRIPTION
BUG: in settings panel if you have a logo set for the company you see it inside 2 borders, not one.

To test:
- signup with email so you have an org w/o a logo
- go to settings
- [x] do you see the green + with one dashed border as placeholder of the logo? Good
- add a logo
- [x] do you see only one border around the logo? Good
- [x] do you see the border turn green when you hover the logo? Good
- change the logo
- [x] did it work? Good