### PR TITLE
Mobile video width

### DIFF
--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -151,7 +151,7 @@ div.stream-item {
       @include tablet(){
         margin-top: 16px;
         float: unset;
-        width: auto;
+        width: calc(100vw + 32px);
         height: auto;
         margin-left: -16px;
 


### PR DESCRIPTION
Don't use width auto on tablet and mobile devices for the ziggeo player, use the needed width.

To test:
- make sure you have some videos in AP
- open AP on your mobile device
- click on the cover
- [x] do you see the video taking the whole screen width? No white bar on the right of the video? Good