### PR TITLE
Zindex fixes

### DIFF
--- a/scss/partials/_activity_move.scss
+++ b/scss/partials/_activity_move.scss
@@ -1,7 +1,7 @@
 div.activity-move {
   width: 310px;
   height: 166px;
-  z-index: 1000;
+  z-index: 110;
 
   div.move-post-inner {
     background-color: white;
@@ -57,7 +57,7 @@ div.activity-move {
       border: 1px solid $carrot_light_gray_1;
       border-radius: 4px;
       background-color: white;
-      z-index: 1002;
+      z-index: 112;
 
       div.board-item {
         height: 40px;

--- a/scss/partials/_activity_share.scss
+++ b/scss/partials/_activity_share.scss
@@ -7,7 +7,7 @@ div.activity-share-modal-container {
   top: 0px;
   right: 16px;
   background-color: $carrot_modal_bg;
-  z-index: 103;
+  z-index: 110;
   transition: opacity 180ms ease-in;
   width: 360px;
   background-color: white;

--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -165,7 +165,7 @@ div.cmail-outer {
           border-top-left-radius: 0;
           border-top-right-radius: 0;
           padding: 16px 14px;
-          z-index: 100;
+          z-index: #{$navbar_zindex + 126};
         }
 
         div.cmail-header-title {
@@ -394,7 +394,7 @@ div.cmail-outer {
           position: absolute;
           top: 36px;
           left: 16px;
-          z-index: 1000;
+          z-index: #{$navbar_zindex + 156};
           max-height: 370px;
           overflow: auto;
         }

--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -3,22 +3,6 @@ div.dashboard-layout {
   width: 100%;
   overflow: visible;
 
-  div.section-add {
-
-    &.has-drafts {
-      div.section-editor {
-        top: 250px;
-      }
-    }
-
-    div.section-editor {
-      position: absolute;
-      top: 214px;
-      left: 180px;
-      z-index: 1000;
-    }
-  }
-
   @include mobile() {
     &.sticky-board-name {
       padding-top: 48px;
@@ -801,12 +785,6 @@ div.dashboard-layout {
               }
             }
           }
-
-          div.dropdown-list-container {
-            top: 46px;
-            width: 200px;
-            left: -26px;
-          }
         }
       }
     }
@@ -817,7 +795,6 @@ div.dashboard-layout {
       position: fixed;
       bottom: 24px;
       right: 24px;
-      z-index: 1000;
 
       button.add-to-board-floating-button {
         width: 56px;
@@ -846,22 +823,6 @@ div.dashboard-layout {
           background-repeat: no-repeat;
           width: 56px;
           height: 56px;
-        }
-      }
-
-      div.dropdown-list-container {
-        top: unset;
-        bottom: 0px;
-        width: 200px;
-        left: -220px;
-        z-index: 100;
-
-        div.triangle {
-          transform: rotate(135deg);
-          top: unset;
-          bottom: 20px;
-          left: unset;
-          right: -10px;
         }
       }
     }

--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -9,7 +9,7 @@ div.org-settings {
   position: fixed;
   top: 0px;
   left: 0px;
-  z-index: 1000;
+  z-index: #{$navbar_zindex + 156};
   overflow-x: hidden;
   overflow-y: auto;
   height: 100vh;

--- a/scss/partials/_section_editor.scss
+++ b/scss/partials/_section_editor.scss
@@ -2,7 +2,7 @@ div.section-editor-container {
   background-color: $carrot_modal_bg;
   width: 100vw;
   height: 100vh;
-  z-index: #{$navbar_zindex + 186};
+  z-index: #{$navbar_zindex + 136};
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
Bug: it's impossible to remove a user from a team right now since the confirmation dialog is hidden behind the settings panel.

I took this to fix also some other z-index rules that were arbitrary set and transformed them in relatively set. The base z-index is the navbar z-index (it was the first and most important we had at the beginning)

To test:
- move an activity (from the contextual menu, not cmail)
- share an activity
- edit an activity
- change the board of a post inside cmail
- add and remove a user from the team
- add and remove a user from a private section
- change a section settings: change slack channel, change name, save and close without saving
- repeat the editing ones on mobile