### PR TITLE
Drift users data

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -166,6 +166,7 @@ Headway.show = function(){};
 var drift = function(){};
 drift.api = {};
 drift.api.startInteraction = function(){};
+drift.identify = function(){};
 // Homepage animation
 var OCStaticShowAnimationLightbox = function(){};
 var OCStaticHideAnimationLightbox = function(){};

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -37,7 +37,13 @@
              (not= (cook/get-cookie :show-login-overlay) "collect-name-password")
              (not= (cook/get-cookie :show-login-overlay) "collect-password"))
     (cook/remove-cookie! :show-login-overlay))
-  (utils/after 1 #(dis/dispatch! [:jwt (jwt/get-contents)])))
+  (let [jwt-contents (jwt/get-contents)
+        email (:email jwt-contents)]
+    (utils/after 1 #(dis/dispatch! [:jwt jwt-contents]))
+    (when email
+      (utils/after 1 #(.identify js/drift (:user-id jwt-contents)
+                        (clj->js {:nickname (:name jwt-contents)
+                                  :email email}))))))
 
 (defn update-jwt [jbody]
   (timbre/info jbody)


### PR DESCRIPTION
Identify user for drift when settings the JWT.

To test:
- logout
- signup with email or Slack (whatever but make sure the user is new)
- open Drift support chant once in app
- [x] do you see user name and email? Good
- refresh the page
- open Drift support chat once in app
- [x] do you see user name and email? Good
- logout
- login with the previous created account
- open Drift support chat once in app
- [x] do you see user name and email? Good