### PR TITLE
Truncate org name

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -183,6 +183,13 @@
       (update-email-domains email-domain org-data))
     (org-create-check-errors status)))
 
+(defn- trunc
+  "
+  Truncate a string based on length
+  "
+  [s n]
+  (subs s 0 (min (count s) n)))
+
 (defn create-or-update-org [org-data]
   (dis/dispatch! [:input [:org-editing :error] false])
   (let [email-domain (:email-domain org-data)
@@ -190,9 +197,12 @@
                              (subs email-domain 1)
                              email-domain)
         existing-org (dis/org-data)
-        clean-org-data (if (seq (:logo-url org-data))
+        logo-org-data (if (seq (:logo-url org-data))
                           org-data
-                          (dissoc org-data :logo-url :logo-width :logo-height))]
+                          (dissoc org-data :logo-url :logo-width :logo-height))
+        clean-org-data (assoc logo-org-data
+                              :name
+                              (trunc (:name logo-org-data) 127))]
     (if (seq (:slug existing-org))
       (api/patch-org clean-org-data (partial org-update-cb fixed-email-domain))
       (api/create-org clean-org-data (partial org-create-cb fixed-email-domain)))))


### PR DESCRIPTION
This change truncates the org name to 127 chars.  The server side also truncates but this code prevents sending a long name to the server.

To test:

- sign up and create an org with a name longer than 127 chars
- [x] is the org created with a truncated name?