### PR TITLE
Gather slack channel data even if you aren't an admin.

### DIFF
--- a/src/oc/web/actions/team.cljs
+++ b/src/oc/web/actions/team.cljs
@@ -53,8 +53,8 @@
 (defn enumerate-channels [team-data]
   (let [org-data (dis/org-data)
         team-id (:team-id team-data)]
-    (when (= (:team-id org-data) team-id)
-      (api/enumerate-channels team-id (partial enumerate-channels-cb team-id))
+    (when team-id
+      (api/enumerate-channels team-data (partial enumerate-channels-cb team-id))
       (dis/dispatch! [:channels-enumerate team-id]))))
 
 (defn team-get [team-link]
@@ -76,10 +76,12 @@
 (defn read-teams [teams]
   (doseq [team teams
           :let [team-link (utils/link-for (:links team) "item")
+                channels-link (utils/link-for (:links team) "channels")
                 roster-link (utils/link-for (:links team) "roster")]]
     ; team link may not be present for non-admins, if so they can still get team users from the roster
-    (when team-link
-      (team-get team-link))
+    (if team-link
+      (team-get team-link)
+      (when channels-link (enumerate-channels team)))
     (when roster-link
       (roster-get roster-link))))
 

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -336,14 +336,14 @@
       {:headers (headers-for-link team-link)}
       callback)))
 
-(defn enumerate-channels [team-id callback]
-  (when team-id
-    (let [team-data (dispatcher/team-data team-id)
-          enumerate-link (utils/link-for (:links team-data) "channels" "GET")]
-      (when enumerate-link
-        (auth-http (method-for-link enumerate-link) (relative-href enumerate-link)
-          {:headers (headers-for-link enumerate-link)}
-          callback)))))
+(defn enumerate-channels [team-data callback]
+  (let [team-id (:team-id team-data)]
+    (when team-id
+      (let [enumerate-link (utils/link-for (:links team-data) "channels" "GET")]
+        (when enumerate-link
+          (auth-http (method-for-link enumerate-link) (relative-href enumerate-link)
+                     {:headers (headers-for-link enumerate-link)}
+                     callback))))))
 
 (defn user-action [action-link payload callback]
   (when action-link


### PR DESCRIPTION
This change gathers slack channel info even if the team link isn't present. 

To test:
- sign up with slack as user 1
- add the slack bot as user 1
- sign up with same slack org as user 2
- [x] when sharing a post do you see the slack channels? 