### PR TITLE
Org name length ui

### DIFF
--- a/scss/mixins/_org.scss
+++ b/scss/mixins/_org.scss
@@ -75,6 +75,7 @@
       text-overflow: ellipsis;
       overflow: hidden;
       width: 100%;
+      max-width: 250px;
 
       @include mobile() {
         display: none;

--- a/scss/partials/_menu.scss
+++ b/scss/partials/_menu.scss
@@ -119,22 +119,24 @@ div.menu {
       @include avenir_H();
       font-size: 15px;
       color: $deep_navy;
-      width: calc(100% - 48px);
+      width: 100%;
       line-height: 18px;
       height: 18px;
       overflow: hidden;
       text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     div.org-url {
       @include avenir_R();
       font-size: 13px;
-      width: calc(100% - 48px);
+      width: 100%;
       height: 15px;
       color: $light_ui_grey;
       overflow: hidden;
       text-overflow: ellipsis;
       line-height: 15px;
+      white-space: nowrap;
     }
   }
 

--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -108,6 +108,10 @@ div.org-settings {
         font-size: 22px;
         color: $deep_navy;
         line-height: 32px;
+        text-overflow: ellipsis;
+        width: calc(100% - 70px);
+        overflow: hidden;
+        white-space: nowrap;
       }
 
       div.org-url {
@@ -115,6 +119,10 @@ div.org-settings {
         @include avenir_R();
         font-size: 18px;
         color: $light_ui_grey;
+        text-overflow: ellipsis;
+        width: calc(100% - 70px);
+        overflow: hidden;
+        white-space: nowrap;
       }
     }
 

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -256,6 +256,7 @@
                :ref "org-name"
                :placeholder "e.g., Acme, or Acme Design"
                :class (when (:error org-editing) "error")
+               :max-length org-utils/org-name-max-length
                :value (:name org-editing)
                :on-change #(dis/dispatch! [:input [:org-editing]
                  (merge org-editing {:error nil :name (.. % -target -value)})])}])

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -236,6 +236,7 @@
             {:type "text"
              :ref "first-name"
              :placeholder "First name"
+             :max-length user-utils/user-name-max-lenth
              :value (or (:first-name user-data) "")
              :on-change #(dis/dispatch! [:input [:edit-user-profile :first-name] (.. % -target -value)])}]
           [:div.field-label
@@ -244,6 +245,7 @@
             {:type "text"
              :placeholder "Last name"
              :value (or (:last-name user-data) "")
+             :max-length user-utils/user-name-max-lenth
              :on-change #(dis/dispatch! [:input [:edit-user-profile :last-name] (.. % -target -value)])}]
           (when-not has-org?
             [:div.field-label
@@ -740,12 +742,14 @@
             {:type "text"
              :ref "first-name"
              :value (:first-name user-data)
+             :max-length user-utils/user-name-max-lenth
              :on-change #(dis/dispatch! [:input [:edit-user-profile :first-name] (.. % -target -value)])}]
           [:div.field-label
             "Last name"]
           [:input.field.fs-hide
             {:type "text"
              :value (:last-name user-data)
+             :max-length user-utils/user-name-max-lenth
              :on-change #(dis/dispatch! [:input [:edit-user-profile :last-name] (.. % -target -value)])}]
           [:button.continue.start-using-carrot
             {:disabled (and (empty? (:first-name user-data))

--- a/src/oc/web/components/ui/org_settings_main_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_main_panel.cljs
@@ -7,6 +7,7 @@
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
+            [oc.web.utils.org :as org-utils]
             [oc.web.actions.org :as org-actions]
             [oc.web.actions.team :as team-actions]
             [oc.web.components.ui.alert-modal :as alert-modal]
@@ -71,6 +72,7 @@
             [:input
               {:type "text"
                :value (:name org-editing)
+               :max-length org-utils/org-name-max-length
                :on-change (fn [e]
                             (dis/dispatch! [:input [:org-editing] (merge org-editing {:name (.. e -target -value)
                                                                                       :has-changes true})]))}]]]

--- a/src/oc/web/components/user_profile_personal_tab.cljs
+++ b/src/oc/web/components/user_profile_personal_tab.cljs
@@ -8,6 +8,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
+            [oc.web.utils.user :as user-utils]
             [oc.web.stores.user :as user-stores]
             [oc.web.actions.user :as user-actions]
             [oc.web.mixins.ui :refer (no-scroll-mixin)]
@@ -101,6 +102,7 @@
               [:input
                 {:type "text"
                  :tab-index 1
+                 :max-length user-utils/user-name-max-lenth
                  :on-change #(change! s :first-name (.. % -target -value))
                  :value (:first-name current-user-data)}]]]
           ;; Mobile last name
@@ -111,6 +113,7 @@
               [:input
                 {:type "text"
                  :tab-index 2
+                 :max-length user-utils/user-name-max-lenth
                  :on-change #(change! s :last-name (.. % -target -value))
                  :value (:last-name current-user-data)}]]]
           ; Email

--- a/src/oc/web/utils/org.cljs
+++ b/src/oc/web/utils/org.cljs
@@ -3,3 +3,5 @@
 (def org-avatar-filestack-config
   {:accept "image/*"
    :fromSources ["local_file_system"]})
+
+(def org-name-max-length 126)

--- a/src/oc/web/utils/org.cljs
+++ b/src/oc/web/utils/org.cljs
@@ -4,4 +4,4 @@
   {:accept "image/*"
    :fromSources ["local_file_system"]})
 
-(def org-name-max-length 126)
+(def org-name-max-length 64)

--- a/src/oc/web/utils/user.cljs
+++ b/src/oc/web/utils/user.cljs
@@ -46,3 +46,5 @@
    (remove nil?
     (map fix-notification
      notifications))))
+
+(def user-name-max-lenth 64)


### PR DESCRIPTION
Set maximum length for the org name fields to 64 characters.
Also make sure the UI doesn't break if the org name is very long.

To test:
- signup
- insert the longest possible org name
- [x] is that 64 chars? Good
- finish onboard
- [x] check the navbar, org name is truncated and doesn't go in front of the search field? Good
- [x] check the user menu, org name and slug are truncated? Good
- [x] check the org settings panel, org name and slug are truncated? Good
- change the org name
- [x] can you NOT add an org name longer then 64 chars from settings panel? Good
- [x] save did work? Good