### PR TITLE
Fix mobile thumbnails

### DIFF
--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -171,6 +171,10 @@ div.stream-item {
           width: calc(100vw + 32px);
           height: auto;
           margin-left: -16px;
+          position: initial;
+          top: unset;
+          right: unset;
+          transform: translateY(0%);
 
           video {
             max-height: calc(100vw * 0.75);
@@ -221,15 +225,29 @@ div.stream-item {
       position: relative;
       margin-top: 8px;
 
-      &.has-thumbnail {
+      &.has-thumbnail, &.has-video {
         float: left;
         width: 400px;
         min-height: 98px;
       }
 
-      @include mobile() {
+      @include tablet() {
         width: 100%;
         margin: 8px 0px 0px;
+      }
+
+      &.has-thumbnail {
+        @include tablet() {
+          width: calc(100% - 136px - 16px);
+        }
+      }
+
+      &.has-video {
+        @include tablet() {
+          float: unset;
+          width: 100%;
+          min-height: initial;
+        }
       }
 
       div.stream-item-headline {

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -195,7 +195,8 @@
                  :data-image (:thumbnail (:body-thumbnail activity-data))
                  :style {:background-image (str "url(\"" (:thumbnail (:body-thumbnail activity-data)) "\")")}}]))
           [:div.stream-body-left.group.fs-hide
-            {:class (when (and (:has-thumbnail activity-data) (not expanded?)) "has-thumbnail")}
+            {:class (utils/class-set {:has-thumbnail (and (:has-thumbnail activity-data) (not expanded?))
+                                      :has-video (:fixed-video-id activity-data)})}
             [:div.stream-item-headline.ap-seen-item-headline
               {:ref "activity-headline"
                :data-itemuuid (:uuid activity-data)

--- a/src/oc/web/utils/activity.cljs
+++ b/src/oc/web/utils/activity.cljs
@@ -164,8 +164,7 @@
         [has-images stream-view-body] (body-for-stream-view (:body entry-data))
         is-uploading-video? (dis/uploading-video-data (:video-id entry-data))
         fixed-video-id (:video-id entry-data)
-        body-thumbnail (get-first-body-thumbnail (:body entry-data))
-        has-thumbnail (or (seq fixed-video-id) body-thumbnail)]
+        body-thumbnail (get-first-body-thumbnail (:body entry-data))]
     (-> entry-data
       (assoc :content-type "entry")
       (assoc :new (post-new? (assoc entry-data :board-uuid fixed-board-uuid) changes))
@@ -178,7 +177,7 @@
       (assoc :stream-view-body stream-view-body)
       (assoc :body-has-images has-images)
       (assoc :fixed-video-id fixed-video-id)
-      (assoc :has-thumbnail has-thumbnail)
+      (assoc :has-thumbnail body-thumbnail)
       (assoc :body-thumbnail body-thumbnail))))
 
 (defn fix-board


### PR DESCRIPTION
BUG: thumbnails broke the mobile experience

![](https://files.slack.com/files-pri/T06SBMH60-FDJJH9AV8/img-20181019-wa0000.jpg)

Fix is complicated by the ziggeo videos that are showing the same size thumbnail on big web but they are shown full size on mobile.

To test:
- on mobile, check a stream of posts with:
- [ ] only headline and body
- [ ]  ziggeo video: should be shown full width and needed height
- [ ] body with at least one image and some text
- [ ] body with at a youtube or vimeo video and some text
- on desktop, check a stream of posts with:
- [ ] only headline and body
- [ ]  ziggeo video: should be shown as thumbnail and playable inline
- [ ] body with at least one image and some text
- [ ] body with at a youtube or vimeo video and some text