### PR TITLE
FS url into drift user

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -137,6 +137,7 @@ CarrotGA.NULL_VALUE = {};
 CarrotGA.clientid = '';
 var init_fullstory = function(){};
 var FS = function(){};
+FS.getCurrentSessionURL = function(){};
 // TCMention
 var CustomizedTagComponent = function(){};
 var TCMention = function(){};

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -44,7 +44,7 @@
       (utils/after 1 #(.identify js/drift (:user-id jwt-contents)
                         (clj->js {:nickname (:name jwt-contents)
                                   :email email
-                                  :fsUrl (when (and js/FS (.-getCurrentSessionURL js/FS))
+                                  :fsUrl (when (and (.-FS js/window) (.-getCurrentSessionURL js/FS))
                                            (.getCurrentSessionURL js/FS))
                                   }))))))
 

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -43,7 +43,9 @@
     (when email
       (utils/after 1 #(.identify js/drift (:user-id jwt-contents)
                         (clj->js {:nickname (:name jwt-contents)
-                                  :email email}))))))
+                                  :email email
+                                  :fsUrl (.getCurrentSessionURL js/FS)
+                                  }))))))
 
 (defn update-jwt [jbody]
   (timbre/info jbody)

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -44,7 +44,8 @@
       (utils/after 1 #(.identify js/drift (:user-id jwt-contents)
                         (clj->js {:nickname (:name jwt-contents)
                                   :email email
-                                  :fsUrl (.getCurrentSessionURL js/FS)
+                                  :fsUrl (when (and js/FS (.-getCurrentSessionURL js/FS))
+                                           (.getCurrentSessionURL js/FS))
                                   }))))))
 
 (defn update-jwt [jbody]


### PR DESCRIPTION
Until FS is out of data this won't work, also this may never work but won't give us any error.

To see the FS url you probably need to click on the user name on the right while in the Drift chat, then on the left sidebar click on See all attributes and look for `fsUrl` attr.