### PR TITLE
Fix slack orgs icon

### DIFF
--- a/scss/partials/_onboard_wrapper.scss
+++ b/scss/partials/_onboard_wrapper.scss
@@ -3,6 +3,7 @@ div.onboard-wrapper-container {
   div.oc-loading {
     width: 100vw;
     height: 100vh;
+    position: fixed;
   }
 
   div.onboard-wrapper {

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -158,11 +158,21 @@
              (seq teams-data))
       (let [first-team (select-keys
                         (first teams-data)
-                        [:name])]
-        (dis/dispatch!
-         [:update
-          [:org-editing]
-          #(merge % first-team)])))))
+                        [:name :logo-url])]
+        (dis/dispatch! [:update [:org-editing] #(merge % first-team)])
+        (when (seq (:logo-url first-team))
+          (let [img (gdom/createDom "img")]
+            (set! (.-onload img)
+             (fn []
+               (dis/dispatch! [:update [:org-editing] #(merge % {:logo-width (.-width img)
+                                                                 :logo-height (.-height img)})])
+               (gdom/removeNode img)))
+            (set! (.-onerror img)
+             (fn []
+               (dis/dispatch! [:update [:org-editing] #(dissoc % :logo-url)])
+               (gdom/removeNode img)))
+            (gdom/append (.-body js/document) img)
+            (set! (.-src img) (:logo-url first-team))))))))
 
 (rum/defcs lander-profile < rum/reactive
                                   (drv/drv :edit-user-profile)


### PR DESCRIPTION
Card: https://trello.com/c/o11kXX7K

Get the logo-url from the team and pass it to the org creation. Also load width and height to set them in the org data.

To test:
- signup with a new Slack team
- [x] do you see the logo when you finish onboard? Good
- signup with email
- [x] do you NOT get errors on the first/last name and org name step? Good
- [x] do you NOT get a logo when onboard finishes? Good