### PR TITLE
Prod video qa

### DIFF
--- a/resources/public/lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorMediaPicker/MediaPicker.js
@@ -328,8 +328,8 @@ function PlaceCaretAtEnd(el) {
         iframe.dataset.videoType = videoType;
         iframe.dataset.videoId = videoId;
         iframe.setAttribute("src", videoUrl);
-        iframe.setAttribute("width", 560);
-        iframe.setAttribute("height", 315);
+        iframe.setAttribute("width", 548);
+        iframe.setAttribute("height", 308);
         p.appendChild(iframe);
 
         var nextP = this.document.createElement("p");

--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -291,6 +291,20 @@ $h2_top_margin: 24;
     margin-top: 0px;
     margin-bottom: 0px;
   }
+
+  iframe, img {
+    margin: 0 auto;
+    display: block;
+    width: 100% !important;
+  }
+
+  @include tablet() {
+    iframe.carrot-no-preview, img.carrot-no-preview {
+      width: calc(100% + 32px) !important;
+      margin: 0 0 0 -16px;
+      max-width: calc(100% + 32px);
+    }
+  }
 }
 
 @mixin activity-attachment($hide-remove-button: false){

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -178,17 +178,23 @@
       [:div.stream-item-body-ext.group
         {:class (when expanded? "expanded")}
         [:div.thumbnail-container.group
-          {:on-click #(when (and truncated? (not expanded?))
+          {:on-click #(when (and ;; it's truncated
+                                 truncated?
+                                 ;; it's not already expanded
+                                 (not expanded?)
+                                 ;; click is not on a Ziggeo video to play it inline
+                                 (not (utils/event-inside? % (rum/ref-node s :ziggeo-player))))
                        (expand s true))}
           (if has-video
-            (rum/with-key
+            [:div.group
+             {:key (str "ziggeo-player-" (:fixed-video-id activity-data) "-" (if expanded? "exp" ""))
+              :ref :ziggeo-player}
              (ziggeo-player {:video-id (:fixed-video-id activity-data)
                              :width (:width video-size)
                              :height (:height video-size)
                              :lazy (not video-player-show)
                              :video-image (:video-image activity-data)
-                             :video-processed (:video-processed activity-data)})
-              (str "ziggeo-player-" (:fixed-video-id activity-data) "-" (if expanded? "exp" "")))
+                             :video-processed (:video-processed activity-data)})]
             (when (:body-thumbnail activity-data)
               [:div.body-thumbnail
                 {:class (:type (:body-thumbnail activity-data))


### PR DESCRIPTION
Card: https://trello.com/c/9knIY0e6

To test:
- on desktop
- add a post with a ziggeo video
- add a post with a YT video
- add a post with a vimeo video
- add a post with a big image
- [x] do you see the thumbnail for all? Good
- [x] can you play the Ziggeo video w/o expanding the post? Good
- [x] do you expand the post if you click on YT, Vimeo and image posts? Good
- open the same org on mobile
- [x] do you see the big video for Ziggeo? Good
- [x] do you see the small image for YT, Vimeo and the image posts? Good
- [x] if you expand these posts do you see the videos or the image displayed from edge to edge? Good
- [x] do you NOT notice any issue in the size of the videos or image? Good



Test unchecked item in the card (i couldn't reproduce). NB: if you test locally don't forget to setup ngrok to get the Ziggeo callback:
- on FF
- create a post
- add a Ziggeo video
- wait until it finishes uploading
- publish
- [x] do you see the "processing video" turning into a video player eventually? Good
- now do the same but publish the post as soon as you finish recording
- wait w/o refreshing the page
- [x] do you see the "processing video" turning into a video player after uploading finishes (and ~30 more seconds, depends on video length)? Good
