### PR TITLE
New & edit parameters

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -759,7 +759,6 @@
   (let [board-data (if (seq board-slug)
                     (dis/board-data (router/current-org-slug) board-slug)
                     (dis/board-data))]
-    (js/console.log "DBG get-board-for-edit board-slug" board-slug "board-data" board-data)
     (if (or (not board-data)
             (= (:slug board-data) utils/default-drafts-board-slug))
       (get-default-section)

--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -807,7 +807,11 @@
 (defn cmail-reopen? []
   (when (compare-and-set! cmail-reopen-only-one false true)
     (if (contains? (router/query-params) :new)
-      (cmail-show (get-board-for-edit (router/query-param :new)))
+      (let [new-data (get-board-for-edit (router/query-param :new))
+            with-headline (if (router/query-param :headline)
+                           (assoc new-data :headline (router/query-param :headline))
+                           new-data)]
+        (cmail-show with-headline))
       (let [edit-param (router/query-param :edit)
             edit-activity (dis/activity-data edit-param)]
         (if edit-activity

--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -480,6 +480,7 @@
     (refresh-org-data)))
 
 (defn activity-delete [activity-data]
+  (remove-cached-item (:uuid activity-data))
   (api/delete-activity activity-data activity-delete-finish)
   (dis/dispatch! [:activity-delete (router/current-org-slug) activity-data]))
 
@@ -742,6 +743,29 @@
         sample-posts (filterv :sample (vals all-posts))]
     (pos? (count sample-posts))))
 
+;; Last used and default section for editing
+
+(defn get-default-section []
+  (let [org-slug (router/current-org-slug)
+        editable-boards (dis/editable-boards-data org-slug)
+        cookie-value (au/last-used-section)
+        board-from-cookie (some #(when (= (:slug %) cookie-value) %) (vals editable-boards))
+        filtered-boards (filterv #(not (:draft %)) (vals editable-boards))
+        board-data (or board-from-cookie (first (sort-by :name filtered-boards)))]
+    {:board-name (:name board-data)
+     :board-slug (:slug board-data)}))
+
+(defn get-board-for-edit [& [board-slug]]
+  (let [board-data (if (seq board-slug)
+                    (dis/board-data (router/current-org-slug) board-slug)
+                    (dis/board-data))]
+    (js/console.log "DBG get-board-for-edit board-slug" board-slug "board-data" board-data)
+    (if (or (not board-data)
+            (= (:slug board-data) utils/default-drafts-board-slug))
+      (get-default-section)
+      {:board-slug (:slug board-data)
+       :board-name (:name board-data)})))
+
 ;; Cmail
 
 (defn- cmail-fullscreen-cookie []
@@ -782,16 +806,24 @@
 
 (defn cmail-reopen? []
   (when (compare-and-set! cmail-reopen-only-one false true)
-    (when-let [activity-uuid (cook/get-cookie (edit-open-cookie))]
-      (cmail-show (dis/activity-data activity-uuid)))))
+    (if (contains? (router/query-params) :new)
+      (cmail-show (get-board-for-edit (router/query-param :new)))
+      (let [edit-param (router/query-param :edit)
+            edit-activity (dis/activity-data edit-param)]
+        (if edit-activity
+          (cmail-show edit-activity)
+          (when-let [activity-uuid (cook/get-cookie (edit-open-cookie))]
+            (cmail-show (dis/activity-data activity-uuid))))))))
 
 (defn activity-edit
-  [activity-data]
-  (let [fixed-activity-data (if (not (seq (:uuid activity-data)))
-                              (assoc activity-data :must-see (= (router/current-board-slug) "must-see"))
-                              activity-data)
-        is-published? (= (:status fixed-activity-data) "published")
-        initial-cmail-state (if is-published?
-                              {:fullscreen true :auto true}
-                              {})]
-    (cmail-show fixed-activity-data initial-cmail-state)))
+  ([]
+    (activity-edit (get-board-for-edit)))
+  ([activity-data]
+    (let [fixed-activity-data (if (not (seq (:uuid activity-data)))
+                                (assoc activity-data :must-see (= (router/current-board-slug) "must-see"))
+                                activity-data)
+          is-published? (= (:status fixed-activity-data) "published")
+          initial-cmail-state (if is-published?
+                                {:fullscreen true :auto true}
+                                {})]
+      (cmail-show fixed-activity-data initial-cmail-state))))

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -57,24 +57,6 @@
       (.add (.-classList dashboard-layout) "sticky-board-name")
       (.remove (.-classList dashboard-layout) "sticky-board-name"))))
 
-(defn get-default-section [s]
-  (let [editable-boards @(drv/get-ref s :editable-boards)
-        org-slug (router/current-org-slug)
-        cookie-value (au/last-used-section)
-        board-from-cookie (some #(when (= (:slug %) cookie-value) %) (vals editable-boards))
-        filtered-boards (filterv #(not (:draft %)) (vals editable-boards))
-        board-data (or board-from-cookie (first (sort-by :name filtered-boards)))]
-    {:board-name (:name board-data)
-     :board-slug (:slug board-data)}))
-
-(defn get-board-for-edit [s]
-  (let [board-data @(drv/get-ref s :board-data)]
-    (if (or (not board-data)
-            (= (:slug board-data) utils/default-drafts-board-slug))
-      (get-default-section s)
-      {:board-slug (:slug board-data)
-       :board-name (:name board-data)})))
-
 (defn win-width
   "Save the window width in the state."
   [s]
@@ -94,7 +76,7 @@
 
 (defn compose [s]
   (utils/remove-tooltips)
-  (activity-actions/activity-edit (get-board-for-edit s))
+  (activity-actions/activity-edit)
   ;; If the add post tooltip is visible
   (when @(drv/get-ref s :show-add-post-tooltip)
     ;; Dismiss it and bring up the invite people tooltip
@@ -357,7 +339,7 @@
                 (empty-org)
                 ;; Empty board
                 empty-board?
-                (empty-board (when can-compose (get-board-for-edit s)))
+                (empty-board)
                 ;; All Posts
                 (and (or is-all-posts
                          is-must-see)

--- a/src/oc/web/components/ui/empty_board.cljs
+++ b/src/oc/web/components/ui/empty_board.cljs
@@ -14,9 +14,11 @@
 
 (rum/defcs empty-board < rum/reactive
                          (drv/drv :board-data)
+                         (drv/drv :editable-boards)
                          section-mixins/container-nav-in
-  [s edit-board]
+  [s]
   (let [board-data (drv/react s :board-data)
+        editable-boards (drv/react s :editable-boards)
         is-all-posts? (= (router/current-board-slug) "all-posts")
         is-must-see? (= (router/current-board-slug) "must-see")
         is-drafts-board? (= (router/current-board-slug) utils/default-drafts-board-slug)]
@@ -38,7 +40,7 @@
            is-must-see? "When someone marks a post as “must see” everyone will see it here."
            is-drafts-board? "Keep a private draft until you're ready to share it with your team."
            :else (str "Looks like there aren’t any posts in " (:name board-data) "."))]
-        (when edit-board
+        (when (pos? (count editable-boards))
           [:button.mlb-reset.create-new-post-bt
-            {:on-click #(activity-actions/activity-edit edit-board)}
+            {:on-click #(activity-actions/activity-edit)}
             "Create a new post"])]]))

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -168,7 +168,7 @@
   (let [org (:org (:params params))
         board (:board (:params params))
         query-params (:query-params params)]
-    (pre-routing query-params)
+    (pre-routing query-params true {:query-params query-params :keep-params [:at]})
     ;; save route
     (router/set-route! [org route] {:org org :board board :query-params (:query-params params)})
     ;; load data from api

--- a/src/oc/web/router.cljs
+++ b/src/oc/web/router.cljs
@@ -116,6 +116,9 @@
 (defn query-params []
   (:query-params @path))
 
+(defn query-param [k]
+  (get (:query-params @path) k nil))
+
 (defn last-org-cookie
   "Cookie to save the last accessed org"
   []


### PR DESCRIPTION
Card: https://trello.com/c/c89sqgE8

Added 2 different parameters for the org:
- `new`: can be empty or have a board slug as value, open Cmail with the last used board or the specified board slug
- `headline`: is accepted only with `new` parameter and is used to specify a headline
- `edit`: need to be a valid activity uuid, open Cmail with the specified entry in edit mode

To test:
- signup to an org
- [x] visit AP, all good? Great
- now visite the same url adding `?new`
- [x] do you get Cmail to open with the last used section already selected? Good
- now visit AP with `?new=general` or another board-slug different than the one above
- [x] do you get Cmail to open with the specified board selected? Good
- click the delete button (to make sure the activity is not cached)
- now visit AP with `?new=general&headline=Monthlt%20update`
- [x] do you get Cmail to open with the specified headline already in place? Good
- now get the UUID of an existing activity of the current org
- visit: `?edit=activity-uuid` where activity-uuid is the id you just found
- [x] do you get Cmail to open with the specified activity in edit mode? Good
- now visit `?edit=1234-1234-1234`
- [x] do you NOT get Cmail to open? Good
- merge
- deploy
