### PR TITLE
Mention with only email

### DIFF
--- a/resources/public/lib/MediumEditorExtensions/MediumEditorTCMention/CustomizedTagComponent.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorTCMention/CustomizedTagComponent.js
@@ -32,7 +32,19 @@ function getUserDisplayName(user) {
 }
 
 function getUserSelectedDisplayValue(user) {
-  return (user["selectedKey"] === "slack-username")? user["slack-username"] : user["name"] || (user["first-name"] + " " + user["last-name"]);
+  if (user["selectedKey"] === "slack-username" && user["slack-username"]) {
+    return user["slack-username"];
+  }else if (user["name"]) {
+    return user["name"];
+  }else if (user["first-name"] && user["last-name"]) {
+    return user["first-name"] + " " + user["last-name"];
+  }else if (user["first-name"]) {
+    return user["first-name"];
+  }else if (user["last-name"]) {
+    return user["last-name"];
+  }else {
+    return user["email"];
+  }
 }
 
 function getSlackUsername(user) {
@@ -146,6 +158,7 @@ class CustomizedTagComponent extends React.PureComponent {
 
   selectItem(user){
     let selectedValue = getUserSelectedDisplayValue(user);
+    console.log("DBG CustomizedTagComponent.selectItem", user, selectedValue);
     this.props.selectMentionCallback("@" + selectedValue, user);
   }
 

--- a/resources/public/lib/MediumEditorExtensions/MediumEditorTCMention/CustomizedTagComponent.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorTCMention/CustomizedTagComponent.js
@@ -158,7 +158,6 @@ class CustomizedTagComponent extends React.PureComponent {
 
   selectItem(user){
     let selectedValue = getUserSelectedDisplayValue(user);
-    console.log("DBG CustomizedTagComponent.selectItem", user, selectedValue);
     this.props.selectMentionCallback("@" + selectedValue, user);
   }
 

--- a/scss/partials/_oc_mentions.scss
+++ b/scss/partials/_oc_mentions.scss
@@ -115,13 +115,14 @@ div.oc-mention-popup {
   background-color: $deep_navy;
   border-radius: 6px;
   padding: 16px;
-  height: 56px;
+  max-height: 56px;
   overflow: hidden;
   z-index: 1000;
 
   div.oc-mention-popup-avatar {
     width: 24px;
     height: 24px;
+    margin-right: 16px;
     background-size: 24px auto;
     background-position: center;
     background-repeat: no-repeat;
@@ -131,7 +132,6 @@ div.oc-mention-popup {
   }
 
   div.oc-mention-popup-name {
-    margin-left: 40px;
     @include avenir_H();
     font-size: 14px !important;
     color: white !important;
@@ -140,10 +140,12 @@ div.oc-mention-popup {
     text-overflow: ellipsis;
     white-space: nowrap;
     margin-top: -2px;
+    margin-bottom: 4px;
+    max-width: 208px;
+    min-width: 140px;
   }
 
   div.oc-mention-popup-subline {
-    margin-left: 40px;
     @include avenir_R();
     font-size: 12px !important;
     color: rgba(white, 0.8) !important;
@@ -152,7 +154,7 @@ div.oc-mention-popup {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    margin-top: 4px;
+    max-width: 208px;
 
     &.slack-icon {
       &:before {

--- a/src/oc/web/mixins/mention.cljs
+++ b/src/oc/web/mixins/mention.cljs
@@ -24,12 +24,16 @@
         fixed-top-pos (if (> (+ top-pos 56) (- win-height 20))
                         (- (.-top mention-offset) (.scrollTop $win) 56 8)
                         top-pos)
-        format-str (str "<div class=\"oc-mention-popup-avatar\" style=\"background-image: url('" user-avatar-url "');\"></div>"
-                        "<div class=\"oc-mention-popup-name\">" user-name "</div>"
-                        "<div class=\"oc-mention-popup-subline"
-                         (when has-slack-username
-                           " slack-icon")
-                         "\">" user-subline "</div>")
+        avatar-div (when user-avatar-url
+                    (str "<div class=\"oc-mention-popup-avatar\" style=\"background-image: url('" user-avatar-url "');\"></div>"))
+        name-div (when (and user-name (not= user-name " "))
+                  (str "<div class=\"oc-mention-popup-name\">" user-name "</div>"))
+        subline-div (when user-subline
+                     (str "<div class=\"oc-mention-popup-subline" (when has-slack-username " slack-icon")
+                          "\">" user-subline "</div>"))
+        format-str (str avatar-div
+                        name-div
+                        subline-div)
         popup-node (.html (js/$ "<div contenteditable=\"false\" class=\"oc-mention-popup\">") format-str)]
     (.append $mention-el (.css popup-node #js {:left (str fixed-left-pos "px")
                                                :top (str fixed-top-pos "px")}))))


### PR DESCRIPTION
Card: https://trello.com/c/ySPKgxEa

If you have an active user with only email address it is going to break mentions.

Check this loom if you don't believe me https://www.useloom.com/share/4a28ac20409d4ff5adbd2897e02ebc61.

You can get an active user with only the email by inviting them and accepting the invitation but leaving the invitation flow before entering any data about yourself (you can enter a password if you need to come back).

To test:
- try the flow above and see that it breaks the mentions
- switch to this branch
- mention the above user with only email
- [x] can you mention him? Good