### PR TITLE
Update the regular expression to check the email domain.

### DIFF
--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -270,7 +270,7 @@
 
 (defn valid-domain? [domain]
   (when (string? domain)
-    (let [re (js/RegExp "^@?[a-z0-9.-]+\\.[a-z]{2,4}$" "i")]
+    (let [re #"(?i)^@?([a-z0-9][a-z0-9\-]{1,61}[A-Za-z0-9]\.)+[A-Za-z]+$"]
       (pos? (count (.match domain re))))))
 
 (defn remove-tooltips []


### PR DESCRIPTION
Card: https://trello.com/c/QpszTYWy

To test make sure you can add the following email domains (try all with and without @):
- skylight.digital
- google.com (it's blacklisted on the server)
- gmail.com
- hello.bye
- carrot.io
- opencompany.hq
- open-company.hq
- 1234a.domain

but not the follwing:
- carrot!.io
- digital
- chris@skylight.digital
- domain.1abc

and all the other you can think of, especially including special chars.