### PR TITLE
Don't restart NUX on email verification

### DIFF
--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -240,7 +240,8 @@
   (if success
     (do
       (update-jwt body)
-      (when (not= token-type :password-reset)
+      (when (and (not= token-type :password-reset)
+                 (empty? (jwt/get-key :name)))
         (nux-actions/new-user-registered "email"))
       (auth-with-token-success token-type body))
     (cond

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -838,9 +838,7 @@
                         (if org
                           (if (and (empty? (jwt/get-key :first-name))
                                    (empty? (jwt/get-key :last-name)))
-                            (do
-                              (nux-actions/new-user-registered "email")
-                              (router/nav! oc-urls/confirm-invitation-profile))
+                            (router/nav! oc-urls/confirm-invitation-profile)
                             (router/nav! (oc-urls/org (:slug org))))
                           (router/nav! oc-urls/login)))
            :on-touch-start identity}


### PR DESCRIPTION
Card: https://trello.com/c/7G6bFctz

When clicking the verification email link we are resetting the user NUX cookie.

To test:
- clear you cookie for the domain you are going to use
- signup with email
- during onboard invite a new user
- enter your dashboard
- [x] do you see a cookie called: `{env}-nux-{user-id}`? Good
- now dismiss all the NUX tooltips (they are 4: welcome, cmail, draft, after adding first post)
- [x] make sure the NUX cookie is gone
- now find the invite email (not the verification email that is sent with 15 minutes delay)
- in a new session open the link
- [x] do you see the NUX cookie for this new user? Good
- [x] do you see the NUX tooltips? Good
- now find the verification email for the first user (you need to wait 15 minutes from signup)
- open it in the first session
- [x] do you NOT see the NUX cookie again? Good
- [x] do you NOT see the first tooltip or any other of them? Good