### PR TITLE
Share rage click

### DIFF
--- a/scss/partials/_activity_share.scss
+++ b/scss/partials/_activity_share.scss
@@ -302,8 +302,8 @@ div.activity-share-modal-container {
           height: 48px;
           padding: .2em 1.8em;
 
-          &.disabled {
-            opacity: 0.6;
+          &:disabled, &.disabled {
+            opacity: 0.6 !important;
           }
         }
 

--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -215,24 +215,27 @@
                 [:button.mlb-reset.mlb-black-link
                   {:on-click #(close-clicked s)}
                   "Cancel"]
-                [:button.mlb-reset.share-button
-                  {:on-click #(let [email-share {:medium :email
-                                                 :note (:note email-data)
-                                                 :subject (:subject email-data)
-                                                 :to (:to email-data)}]
-                                (if (empty? (:to email-data))
-                                  (reset! (::email-data s) (merge email-data {:to-error true}))
-                                  (do
-                                    (reset! (::sharing s) true)
-                                    (activity-actions/activity-share activity-data [email-share]))))
-                   :class (when (empty? (:to email-data)) "disabled")}
-                  (if @(::shared s)
-                    (if (= @(::shared s) :shared)
-                      "Shared!"
-                      "Ops...")
-                    [(when @(::sharing s)
-                      (small-loading))
-                     "Share"])]]]])
+                (let [share-bt-disabled? (or @(::sharing s)
+                                             (empty? (:to email-data)))]
+                  [:button.mlb-reset.share-button
+                    {:on-click #(when-not share-bt-disabled?
+                                  (let [email-share {:medium :email
+                                                     :note (:note email-data)
+                                                     :subject (:subject email-data)
+                                                     :to (:to email-data)}]
+                                    (if (empty? (:to email-data))
+                                      (reset! (::email-data s) (merge email-data {:to-error true}))
+                                      (do
+                                        (reset! (::sharing s) true)
+                                        (activity-actions/activity-share activity-data [email-share])))))
+                     :class (when share-bt-disabled? "disabled")}
+                    (if @(::shared s)
+                      (if (= @(::shared s) :shared)
+                        "Shared!"
+                        "Ops...")
+                      [(when @(::sharing s)
+                        (small-loading))
+                       "Share"])])]]])
         (when (= medium :url)
           [:div.activity-share-modal-shared.group
             [:form
@@ -324,21 +327,24 @@
                 [:button.mlb-reset.mlb-black-link
                   {:on-click #(close-clicked s)}
                   "Cancel"]
-                [:button.mlb-reset.share-button
-                  {:on-click #(let [slack-share {:medium :slack
-                                                 :note (:note slack-data)
-                                                 :channel (:channel slack-data)}]
-                                (if (empty? (:channel slack-data))
-                                  (when (empty? (:channel slack-data))
-                                    (reset! (::slack-data s) (merge slack-data {:channel-error true})))
-                                  (do
-                                    (reset! (::sharing s) true)
-                                    (activity-actions/activity-share activity-data [slack-share]))))
-                   :class (when (empty? (:channel slack-data)) "disabled")}
-                  (if @(::shared s)
-                    (if (= @(::shared s) :shared)
-                      "Sent!"
-                      "Ops...")
-                    [(when @(::sharing s)
-                      (small-loading))
-                     "Send"])]]]])]]))
+                (let [send-bt-disabled? (or @(::sharing s)
+                                           (empty? (:channel slack-data)))]
+                  [:button.mlb-reset.share-button
+                    {:on-click #(when-not send-bt-disabled?
+                                  (let [slack-share {:medium :slack
+                                                     :note (:note slack-data)
+                                                     :channel (:channel slack-data)}]
+                                    (if (empty? (:channel slack-data))
+                                      (when (empty? (:channel slack-data))
+                                        (reset! (::slack-data s) (merge slack-data {:channel-error true})))
+                                      (do
+                                        (reset! (::sharing s) true)
+                                        (activity-actions/activity-share activity-data [slack-share])))))
+                     :class (when send-bt-disabled? "disabled")}
+                    (if @(::shared s)
+                      (if (= @(::shared s) :shared)
+                        "Sent!"
+                        "Ops...")
+                      [(when @(::sharing s)
+                        (small-loading))
+                       "Send"])])]]])]]))

--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -83,9 +83,9 @@
                                    (js/$ slack-button)
                                    #js {:trigger "manual"})))
                               s)
-                             :before-render (fn [s]
+                             :did-update (fn [s]
                               ;; When we have a sharing response
-                              (js/console.log "DBG activity-share/before-render")
+                              (js/console.log "DBG activity-share/did-update")
                               (when-let [shared-data @(drv/get-ref s :activity-shared-data)]
                                 (js/console.log "DBG    activity-shared-data" shared-data)
                                 (when (compare-and-set! (::sharing s) true false)

--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -85,8 +85,11 @@
                               s)
                              :before-render (fn [s]
                               ;; When we have a sharing response
+                              (js/console.log "DBG activity-share/before-render")
                               (when-let [shared-data @(drv/get-ref s :activity-shared-data)]
+                                (js/console.log "DBG    activity-shared-data" shared-data)
                                 (when (compare-and-set! (::sharing s) true false)
+                                  (js/console.log "DBG       sharing reset!")
                                   (reset!
                                    (::shared s)
                                    (if (:error shared-data) :error :shared))
@@ -217,17 +220,16 @@
                   "Cancel"]
                 (let [share-bt-disabled? (or @(::sharing s)
                                              (empty? (:to email-data)))]
+                  (js/console.log "DBG activity-share/render email chs" (:to email-data) "sharing" @(::sharing s))
                   [:button.mlb-reset.share-button
                     {:on-click #(when-not share-bt-disabled?
+                                  (js/console.log "DBG email share clicked")
+                                  (reset! (::sharing s) true)
                                   (let [email-share {:medium :email
                                                      :note (:note email-data)
                                                      :subject (:subject email-data)
                                                      :to (:to email-data)}]
-                                    (if (empty? (:to email-data))
-                                      (reset! (::email-data s) (merge email-data {:to-error true}))
-                                      (do
-                                        (reset! (::sharing s) true)
-                                        (activity-actions/activity-share activity-data [email-share])))))
+                                    (activity-actions/activity-share activity-data [email-share])))
                      :class (when share-bt-disabled? "disabled")}
                     (if @(::shared s)
                       (if (= @(::shared s) :shared)
@@ -329,17 +331,15 @@
                   "Cancel"]
                 (let [send-bt-disabled? (or @(::sharing s)
                                            (empty? (:channel slack-data)))]
+                  (js/console.log "DBG activity-share/render slack chs" (:channel slack-data) "sharing" @(::sharing s))
                   [:button.mlb-reset.share-button
                     {:on-click #(when-not send-bt-disabled?
+                                  (js/console.log "DBG slack share clicked")
+                                  (reset! (::sharing s) true)
                                   (let [slack-share {:medium :slack
                                                      :note (:note slack-data)
                                                      :channel (:channel slack-data)}]
-                                    (if (empty? (:channel slack-data))
-                                      (when (empty? (:channel slack-data))
-                                        (reset! (::slack-data s) (merge slack-data {:channel-error true})))
-                                      (do
-                                        (reset! (::sharing s) true)
-                                        (activity-actions/activity-share activity-data [slack-share])))))
+                                    (activity-actions/activity-share activity-data [slack-share])))
                      :class (when send-bt-disabled? "disabled")}
                     (if @(::shared s)
                       (if (= @(::shared s) :shared)

--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -118,6 +118,9 @@
                                   (utils/after 2000 #(reset! (::shared s) false)))
                                 (js/console.log "DBG    activity-share-reset")
                                 (activity-actions/activity-share-reset))
+                              s)
+                             :will-unmount (fn [s]
+                              (js/console.log "DBG activity-share/will-unmount")
                               s)}
   [s]
   (let [activity-data (:share-data (drv/react s :activity-share))

--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -233,7 +233,7 @@
                                              (empty? (:to email-data)))]
                   (js/console.log "DBG    email share disabled?" share-bt-disabled? "to:" (:to email-data))
                   [:button.mlb-reset.share-button
-                    {:on-click #(when-not share-bt-disabled?
+                    {:on-click (fn[]
                                   (js/console.log "DBG email share clicked")
                                   (reset! (::sharing s) true)
                                   (let [email-share {:medium :email
@@ -241,7 +241,7 @@
                                                      :subject (:subject email-data)
                                                      :to (:to email-data)}]
                                     (activity-actions/activity-share activity-data [email-share])))
-                     :class (when share-bt-disabled? "disabled")}
+                     :disabled share-bt-disabled?}
                     (if @(::shared s)
                       (if (= @(::shared s) :shared)
                         "Shared!"
@@ -344,14 +344,14 @@
                                            (empty? (:channel slack-data)))]
                   (js/console.log "DBG    slack share disabled?" send-bt-disabled? "to:" (:channel slack-data))
                   [:button.mlb-reset.share-button
-                    {:on-click #(when-not send-bt-disabled?
+                    {:on-click (fn[]
                                   (js/console.log "DBG slack share clicked")
                                   (reset! (::sharing s) true)
                                   (let [slack-share {:medium :slack
                                                      :note (:note slack-data)
                                                      :channel (:channel slack-data)}]
                                     (activity-actions/activity-share activity-data [slack-share])))
-                     :class (when send-bt-disabled? "disabled")}
+                     :disabled send-bt-disabled?}
                     (if @(::shared s)
                       (if (= @(::shared s) :shared)
                         "Sent!"


### PR DESCRIPTION
Card: https://trello.com/c/4VMmgSje

Disable the Share (for email) and Send (for Slack) buttons when the user clicks them to avoid multiple share requests.

To test:
- click share on an entry
- select Slack
- select a channel
- rage click the Send button
- [x] how many share did you get? only one? Good!
- [x] can you share again once the share requests succeed? Good
- no repeat and select email
- insert at least an email address
- rage click the Share button
- [x] how many emails did you get? only one? Good!
- [x] can you share again once the share requests succeed? Good
- merge