### PR TITLE
Dismiss add Slack bot tooltip when user clicks CTA button

### DIFF
--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -306,8 +306,7 @@
                            (drv/react s :show-post-added-tooltip))
                   [:div.post-added-tooltip-container.group
                     [:button.mlb-reset.post-added-tooltip-dismiss
-                      {:on-click #(do
-                                   (nux-actions/dismiss-post-added-tooltip))}]
+                      {:on-click #(nux-actions/dismiss-post-added-tooltip)}]
                     [:div.post-added-tooltips
                       [:div.post-added-tooltip-box-mobile]
                       [:div.post-added-tooltip-title
@@ -315,8 +314,10 @@
                       [:div.post-added-tooltip
                         "Using Slack? "
                         [:button.mlb-reset.post-added-bt
-                          {:on-click #(org-actions/bot-auth team-data current-user-data
-                                       (str (router/get-token) "?org-settings=main"))}
+                          {:on-click #(do
+                                       (nux-actions/dismiss-post-added-tooltip)
+                                       (org-actions/bot-auth team-data current-user-data
+                                        (str (router/get-token) "?org-settings=main")))}
                           "Connect to Slack"]
                         " so your team can see posts and  join the discussion from Slack, too."]
                       [:div.post-added-tooltip-box]]]))


### PR DESCRIPTION
Card: https://trello.com/c/lSVsr0xA

To test:
- signup as a new user with Slack (new Slack team since you need to add the bot later)
- click Create a new post in the tooltip
- dismiss the tooltip inside Cmail
- edit and publish
- [x] do you see the add Slack bot tooltip now? Good
- click Connect to Slack button inside the tooltip
- grant bot permissions
- [x] do you NOT see the add bot tooltip when you get back? Good