### PR TITLE
WURFL not available

### DIFF
--- a/src/oc/web/lib/responsive.cljs
+++ b/src/oc/web/lib/responsive.cljs
@@ -6,6 +6,7 @@
             [goog.events.EventType :as EventType]))
 
 (def big-web-min-width 768)
+(def tablet-max-width 980)
 (def navbar-height 56)
 
 (defn ww []
@@ -43,9 +44,11 @@
   ;; check if it's test env, can't import utils to avoid circular dependencies
   (if (.-_phantom js/window)
     false
-    (or (= (gobj/get js/WURFL "form_factor") "Tablet")
-        (= (gobj/get js/WURFL "form_factor") "Smartphone")
-        (= (gobj/get js/WURFL "form_factor") "Other Mobile"))))
+    (if-not (.-WURFL js/window)
+      (<= (ww) tablet-max-width)
+      (or (= (gobj/get js/WURFL "form_factor") "Tablet")
+          (= (gobj/get js/WURFL "form_factor") "Smartphone")
+          (= (gobj/get js/WURFL "form_factor") "Other Mobile")))))
 
 (when-not (.-_phantom js/window)
   (events/listen js/window EventType/RESIZE set-browser-type!))


### PR DESCRIPTION
Fix for this sentry: https://sentry.io/opencompany/oc-beta-web/issues/746200962/?referrer=slack

If WURFL for any reason was not loaded (network issue, blocked by an extension, whatever), fallback to the viewport width check to determine if it's a tablet or a mobile device.

To test:
- in `oc.pages/app-shell` comment out line 1088 (wurfl.js load)
- refresh page
- [x] do you NOT get an error? Good
- [x] do you see desktop app if your screen is >=981 pixels in width? Good
- [x] do you see mobile app if your screen is under that? Good
- now add back the load of wurfl.js
- reload with both screen widths
- [x] everything good? Good
- in the console print out the value of `window.WURFL`
- [x] do you get the right values? Good