### PR TITLE
WRT viewers update

### DIFF
--- a/resources/public/img/ML/viewers_icon.svg
+++ b/resources/public/img/ML/viewers_icon.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="8px" height="8px" viewBox="0 0 8 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.2 (67145) - http://www.bohemiancoding.com/sketch -->
+    <title>Combined Shape</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Archiving" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="New-post-(archivable-in-new-post)" transform="translate(-448.000000, -212.000000)" fill="#888D94">
+            <path d="M449.8,214.071459 C449.8,212.927424 450.784974,212 452,212 C453.215026,212 454.2,212.927424 454.2,214.071459 C454.2,214.556933 454.115203,215.301799 453.885447,215.998488 C454.686611,216.304556 456,216.800293 456,217.996194 L456,218.799054 C456,219.241076 454.273975,220 452,220 C449.726025,220 448,219.239568 448,218.799054 L448,217.996194 C448,216.796167 449.314124,216.304986 450.114892,215.999517 C449.88488,215.302533 449.8,214.557172 449.8,214.071459 Z" id="Combined-Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/scss/partials/_wrt.scss
+++ b/scss/partials/_wrt.scss
@@ -12,6 +12,21 @@ div.wrt-container {
     font-size: 12px;
     color: $ui_grey;
     cursor: pointer;
+    padding-left: 12px;
+    position: relative;
+
+    &:before {
+      content: "";
+      width: 8px;
+      height: 8px;
+      position: absolute;
+      top: 3px;
+      left: 0;
+      background-image: cdnUrl("/img/ML/viewers_icon.svg");
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 8px 8px;
+    }
   }
 
   div.wrt-popup {

--- a/src/oc/web/components/ui/wrt.cljs
+++ b/src/oc/web/components/ui/wrt.cljs
@@ -107,8 +107,8 @@
       [:div.wrt-count
         {:ref :wrt-count}
         (if read-count
-          (str read-count " view" (when (not= read-count 1) "s"))
-          "0 Views")]
+          (str read-count " Viewer" (when (not= read-count 1) "s"))
+          "0 Viewers")]
       (when (and @(::showing-popup s)
                  (:reads read-data))
         [:div.wrt-popup


### PR DESCRIPTION
Card: https://trello.com/c/ZV3esqy9
Abstract: https://share.goabstract.com/0be83571-fa7e-4848-8ef2-0c55a70c3758
(it's not the correct abstract link since that's about archiving but it has these changes too)

Add icon before WRT label (see design), change views to viewers.

To test:
- [x] see the person icon? Good
- [x] also on FF? Good
- [x] also on mobile? Good
- [x] does it say `x Viewer(s)`? Good