### PR TITLE
In-app Only notifications

### DIFF
--- a/src/oc/web/components/user_profile_notifications_tab.cljs
+++ b/src/oc/web/components/user_profile_notifications_tab.cljs
@@ -107,7 +107,7 @@
                     "Daily"
                     "weekly"
                     "Weekly"
-                    "Never")]
+                    "In-app Only")]
                 [:ul.dropdown-menu.user-type-dropdown-menu
                   {:aria-labelledby "user-digest-frequency-dropdown"}
                   [:li
@@ -118,7 +118,7 @@
                     "Weekly"]
                   [:li
                     {:on-click #(change! s :digest-frequency "never")}
-                    "Never"]]]]]]]
+                    "In-app Only"]]]]]]]
       [:div.user-profile-footer.group
         [:button.mlb-reset.save-bt
           {:on-click #(save-clicked s)


### PR DESCRIPTION
Card: https://trello.com/c/SuIKZlvY

Change Never to In-app Only in notification frequency.

To test:
- go to Notifications settings
- change it to In-app Only
- save
- refresh
- open Notifications settings
- [x] do you see In-app Only? Good
- change it back no Email or Slack
- refresh
- open Notifications settings
- [x] do you see the last value set? Good