### PR TITLE
Fix last used section

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -59,7 +59,6 @@
         (router/redirect-404!))
       (when (and (not should-404?)
                  (= (router/current-board-slug) "all-posts"))
-        (au/save-last-used-section "all-posts")
         (cook/set-cookie! (router/last-board-cookie org) "all-posts" (* 60 60 24 6)))
       (request-reads-count (keys (:fixed-items fixed-all-posts)))
       (watch-boards (:fixed-items fixed-all-posts))
@@ -87,7 +86,7 @@
           must-see-data (when success (json->cljs body))
           must-see-posts (au/fix-container (:collection must-see-data) (dis/change-data))]
       (when (= (router/current-board-slug) "must-see")
-        (au/save-last-used-section "must-see"))
+        (cook/set-cookie! (router/last-board-cookie org) "all-posts" (* 60 60 24 6)))
       (watch-boards (:fixed-items must-see-posts))
       (dis/dispatch! [:must-see-get/finish org must-see-posts]))))
 


### PR DESCRIPTION
Card: https://trello.com/c/9zfdFqKW

To test:
- go to All Posts
- add and publish a post to the second or third section in the list
- refresh the page
- now open Cmail
- [x] is the default section the last one you published to? Good
- now go to a another section
- open Cmail
- [x] do you see the current section as default? Good (this is by design)