### PR TITLE
User notifications fixes

### DIFF
--- a/scss/partials/_user_profile.scss
+++ b/scss/partials/_user_profile.scss
@@ -6,7 +6,7 @@ div.user-profile {
   position: fixed;
   top: 0px;
   left: 0px;
-  z-index: 1000;
+  z-index: #{$navbar_zindex + 156};
   overflow-x: hidden;
   overflow-y: auto;
   width: 100vw;

--- a/scss/partials/_user_profile.scss
+++ b/scss/partials/_user_profile.scss
@@ -282,6 +282,10 @@ div.user-profile {
               }
             }
 
+            ul.user-type-dropdown-menu {
+              left: 0;
+            }
+
             input, select {
               width: 100%;
               height: 40px;

--- a/src/oc/web/components/user_profile_notifications_tab.cljs
+++ b/src/oc/web/components/user_profile_notifications_tab.cljs
@@ -84,12 +84,20 @@
                 [:ul.dropdown-menu.user-type-dropdown-menu
                   {:aria-labelledby "user-digest-medium-dropdown"}
                   [:li
-                    {:on-click #(change! s :digest-medium "email")}
+                    {:on-click #(do
+                                  (when (and (= (:digest-medium current-user-data) "in-app")
+                                             (= (:digest-frequency current-user-data) "never"))
+                                    (change! s :digest-frequency "daily"))
+                                  (change! s :digest-medium "email"))}
                     "Email"]
                   ;; Show Slack digest option if
                   (when (jwt/team-has-bot? (:team-id org-data))
                     [:li
-                      {:on-click #(change! s :digest-medium "slack")}
+                      {:on-click #(do
+                                    (when (and (= (:digest-medium current-user-data) "in-app")
+                                               (= (:digest-frequency current-user-data) "never"))
+                                      (change! s :digest-frequency "daily"))
+                                    (change! s :digest-medium "slack"))}
                       "Slack"])
                   [:li
                     {:on-click #(change! s :digest-medium "in-app")}

--- a/src/oc/web/components/user_profile_notifications_tab.cljs
+++ b/src/oc/web/components/user_profile_notifications_tab.cljs
@@ -78,7 +78,9 @@
                   (case (:digest-medium current-user-data)
                     "slack"
                     "Slack"
-                    "Email")]
+                    "email"
+                    "Email"
+                    "In-app only")]
                 [:ul.dropdown-menu.user-type-dropdown-menu
                   {:aria-labelledby "user-digest-medium-dropdown"}
                   [:li
@@ -88,7 +90,10 @@
                   (when (jwt/team-has-bot? (:team-id org-data))
                     [:li
                       {:on-click #(change! s :digest-medium "slack")}
-                      "Slack"])]]]]]
+                      "Slack"])
+                  [:li
+                    {:on-click #(change! s :digest-medium "in-app")}
+                    "In-app only"]]]]]]
         ; Right column
         [:div.user-profile-column-right.fs-hide
           ;; Digest Medium
@@ -101,13 +106,15 @@
                   {:id "user-digest-frequency-dropdown"
                    :data-toggle "dropdown"
                    :aria-haspopup true
-                   :aria-expanded false}
+                   :aria-expanded false
+                   :disabled (and (not= (:digest-medium current-user-data) "email")
+                                  (not= (:digest-medium current-user-data) "slack"))}
                   (case (:digest-frequency current-user-data)
                     "daily"
                     "Daily"
                     "weekly"
                     "Weekly"
-                    "In-app Only")]
+                    "Never")]
                 [:ul.dropdown-menu.user-type-dropdown-menu
                   {:aria-labelledby "user-digest-frequency-dropdown"}
                   [:li
@@ -118,7 +125,7 @@
                     "Weekly"]
                   [:li
                     {:on-click #(change! s :digest-frequency "never")}
-                    "In-app Only"]]]]]]]
+                    "Never"]]]]]]]
       [:div.user-profile-footer.group
         [:button.mlb-reset.save-bt
           {:on-click #(save-clicked s)


### PR DESCRIPTION
Card: https://trello.com/c/ItvVtQQS

Related PRs:
- [auth](https://github.com/open-company/open-company-auth/pull/66)
- [digest](https://github.com/open-company/open-company-digest/pull/9)

To test:
- go to Notifications settings
- change a value of the dropdown
- click the X to close it
- [x] can you see the alert modal asking to save before closing? Good
- dismiss it
- now set you preference to Email/Daily
- on digest folder:
- [x] run `lein dry-run-daily`: see your user with `email`? Good
- [x] run `lein dry-run-wekly`: NOT see your user? Good
- now set you preference to Slack/Daily
- [x] run `lein dry-run-daily`: see your user with `slack`? Good
- [ ] run `lein dry-run-wekly`: NOT see your user? Good
- now set you preference to Email/Weekly
- [x] run `lein dry-run-daily`: NOT see your user? Good
- [ ] run `lein dry-run-wekly`: see your user with `email`? Good
- now set you preference to Slack/weekly
- [x] run `lein dry-run-daily`: NOT see your user? Good
- [x] run `lein dry-run-wekly`: see your user with `slack`? Good
- now set you preference to Email/Never
- [x] run `lein dry-run-daily`: NOT see your user? Good
- [x] run `lein dry-run-wekly`: NOT see your user? Good
- now set you preference to Slack/Never
- [x] run `lein dry-run-daily`: NOT see your user? Good
- [ ] run `lein dry-run-wekly`: NOT see your user? Good
- now set you preference to In-app/[disabled]
- [x] run `lein dry-run-daily`: NOT see your user? Good
- [x] run `lein dry-run-wekly`: NOT see your user? Good
