### PR TITLE
Fix reactions tooltip

### DIFF
--- a/src/oc/web/components/reactions.cljs
+++ b/src/oc/web/components/reactions.cljs
@@ -31,6 +31,12 @@
                        (on-window-click-mixin (fn [s e]
                         (when-not (utils/event-inside? e (rum/dom-node s))
                           (reset! (::show-picker s) false))))
+                       {:did-remount (fn [_ s]
+                        (when-not (responsive/is-tablet-or-mobile?)
+                          (doto (js/$ "[data-toggle=\"tooltip\"]" (rum/dom-node s))
+                            (.tooltip "fixTitle")
+                            (.tooltip "hide")))
+                        s)}
   [s entry-data hide-last-reaction?]
   (let [reactions-data (if hide-last-reaction?
                          (vec (take (dec default-reaction-number) (:reactions entry-data)))


### PR DESCRIPTION
Card: https://trello.com/c/FPVjC6mi

BUG: when adding a reaction it shows the browser default tooltip until you nav or refresh the page.

To test:
- add a reaction
- hover the new reaction
- [x] see the bootstrap tooltip? Good