### PR TITLE
Fix editor placeholder

### DIFF
--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -256,6 +256,7 @@
                    ;; Locals
                    (rum/local "" ::initial-body)
                    (rum/local "" ::initial-headline)
+                   (rum/local true ::show-placeholder)
                    (rum/local nil ::initial-uuid)
                    (rum/local nil ::headline-input-listener)
                    (rum/local nil ::uploading-media)
@@ -282,7 +283,8 @@
                         (nux-actions/dismiss-add-post-tooltip))
                       (reset! (::initial-body s) initial-body)
                       (reset! (::initial-headline s) initial-headline)
-                      (reset! (::initial-uuid s) (:uuid cmail-data)))
+                      (reset! (::initial-uuid s) (:uuid cmail-data))
+                      (reset! (::show-placeholder s) (not (.match initial-body #"(?i).*(<iframe\s?.*>).*"))))
                     s)
                    :did-mount (fn [s]
                     (calc-video-height s)
@@ -513,7 +515,7 @@
                                :use-inline-media-picker false
                                :multi-picker-container-selector "div#cmail-footer-multi-picker"
                                :initial-body @(::initial-body s)
-                               :show-placeholder true
+                               :show-placeholder @(::show-placeholder s)
                                :show-h2 true
                                :dispatch-input-key :cmail-data
                                :upload-progress-cb (fn [is-uploading?]


### PR DESCRIPTION
Card: https://trello.com/c/28eLSq7O

BUG: When the only element in the body is an iframe (ie: a video) MediumEditor shows the placeholder in front of it or above it (see loom video in the card).

To test:
- create a new post
- [ ] do you see the placeholder in the body? Good
- insert only a video (loom or YT or Vimeo)
- publish it
- edit the published post
- [ ] do you NOT see the placeholder in the editor? Good
- now add and publish a post with only the headline
- edit the post
- [ ] do you see the placeholder? Good