### PR TITLE
Fix remove email domain button position (only FF)

### DIFF
--- a/scss/partials/_org_settings_main_panel.scss
+++ b/scss/partials/_org_settings_main_panel.scss
@@ -120,6 +120,7 @@ div.org-settings div.org-settings-inner div.org-settings-main {
           background-size: 8px 8px;
           background-position: 6px 10px;
           background-repeat: no-repeat;
+          display: block;
         }
       }
     }


### PR DESCRIPTION
Card: https://trello.com/c/vbxZMxNm

To test:
- open FF
- add an email domain
- [x] the X to remove the email domain is aligned with the domain? Good
- click it
- [x] did it work? Good