### PR TITLE
Drift fallback

### DIFF
--- a/scss/partials/_alert_modal.scss
+++ b/scss/partials/_alert_modal.scss
@@ -83,6 +83,10 @@ div.alert-modal-container {
         font-size: 16px;
         color: $oc_gray_7;
         margin-top: 8px;
+
+        a {
+          color: $carrot_green;
+        }
       }
 
       div.alert-modal-buttons {

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -23,8 +23,7 @@
                     (ui-mixins/render-on-resize nil)
                     (rum/local false ::expanded-user-menu)
                     (on-window-click-mixin (fn [s e]
-                     (when-not (utils/event-inside? e (rum/ref-node s "user-menu"))
-                       (reset! (::expanded-user-menu s) false))))
+                     (reset! (::expanded-user-menu s) false)))
                     {:did-mount (fn [s]
                      (when-not (utils/is-test-env?)
                        (when-not (responsive/is-tablet-or-mobile?)

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -23,7 +23,8 @@
                     (ui-mixins/render-on-resize nil)
                     (rum/local false ::expanded-user-menu)
                     (on-window-click-mixin (fn [s e]
-                     (reset! (::expanded-user-menu s) false)))
+                     (when-not (utils/event-inside? e (rum/ref-node s "user-menu"))
+                       (reset! (::expanded-user-menu s) false))))
                     {:did-mount (fn [s]
                      (when-not (utils/is-test-env?)
                        (when-not (responsive/is-tablet-or-mobile?)

--- a/src/oc/web/lib/chat.cljs
+++ b/src/oc/web/lib/chat.cljs
@@ -4,6 +4,7 @@
 
 (defn check-drift-dialog []
   (let [$drift-el (js/$ "#drift-widget-container iframe")]
+    (js/console.log "DBG check-drift-dialog" $drift-el (.width $drift-el))
     (when (or (zero? (.-length $drift-el))
               (zero? (.width $drift-el)))
       (let [alert-data {:action "drift-not-working"

--- a/src/oc/web/lib/chat.cljs
+++ b/src/oc/web/lib/chat.cljs
@@ -1,4 +1,26 @@
-(ns oc.web.lib.chat)
+(ns oc.web.lib.chat
+  (:require [oc.web.lib.utils :as utils]
+            [oc.web.components.ui.alert-modal :as alert-modal]))
+
+(defn check-drift-dialog []
+  (let [$drift-el (js/$ "#drift-widget-container iframe")]
+    (when (or (zero? (.-length $drift-el))
+              (zero? (.width $drift-el)))
+      (let [alert-data {:action "drift-not-working"
+                        :title "Chat not available"
+                        :message [:span
+                                   "If you want to chat with us please disable"
+                                   " your ad blocker and reload this page."
+                                   "Or send us an email: "
+                                   [:a {:href "mailto:hello@carrot.io"
+                                        :target "_blank"}
+                                    "hello@carrot.io"]
+                                  "."]
+                        :solid-button-style :red
+                        :solid-button-title "Ok, got it!"
+                        :solid-button-cb #(alert-modal/hide-alert)}]
+        (alert-modal/show-alert alert-data)))))
 
 (defn chat-click [interaction]
-  (.startInteraction js/drift.api (clj->js {:interactionId interaction})))
+  (.startInteraction js/drift.api (clj->js {:interactionId interaction}))
+  (utils/after 500 #(check-drift-dialog)))

--- a/src/oc/web/lib/chat.cljs
+++ b/src/oc/web/lib/chat.cljs
@@ -5,14 +5,15 @@
 (defn check-drift-dialog []
   (let [$drift-el (js/$ "#drift-widget-container iframe")]
     (js/console.log "DBG check-drift-dialog" $drift-el (.width $drift-el))
-    (when (or (zero? (.-length $drift-el))
+    (when (or (not (exists? js/drift))
+              (zero? (.-length $drift-el))
               (zero? (.width $drift-el)))
       (let [alert-data {:action "drift-not-working"
-                        :title "Chat not available"
+                        :title "Support chat not available"
                         :message [:span
-                                   "If you want to chat with us please disable"
-                                   " your ad blocker and reload this page."
-                                   "Or send us an email: "
+                                   "Oh no! It seems our support chat has been blocked. "
+                                   "You can whitelist Carrot in your ad-blocker settings, "
+                                   "or just send us an email instead at "
                                    [:a {:href "mailto:hello@carrot.io"
                                         :target "_blank"}
                                     "hello@carrot.io"]


### PR DESCRIPTION
Card: https://trello.com/c/OV9ge2sQ

NB: if you want to test this locally you need to:
- replace DRIFT_KEY with our drift key in drift.js
- enable /lib/drift.js load in `oc.pages/app-shell`

To test:
- install this on Chrome https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm?hl=en-GB&utm_source=chrome-ntp-launcher
- make sure uBlock origin is enabled
- refresh the app
- click the user menu
- click Support
- [x] the Drift chat DOESN'T open? Good
- [x] do you see an alert instead telling you how you can work around it? Good
- now disable ublock origin for the site (or for the browser)
- refresh the page
- click Support
- [x] do you get the Drift Chat? Good
- [x] do you NOT get the alert modal? Good
- now open safari
- install this https://safari-extensions.apple.com/details/?id=com.el1t.uBlock-3NU33NW2M3
- [x] repeat the 2 tests above
- [x] same for FF if you want https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/