### PR TITLE
API reports more info

### DIFF
--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -172,7 +172,7 @@
                         :params params}]
             (timbre/error "xhr response error:" (method-name method) ":" (str endpoint path) " -> " status)
             (sentry/set-extra-context! report)
-            (sentry/capture-message (str "xhr response error:" status))
+            (sentry/capture-error-with-message (str "xhr response error:" status))
             (sentry/clear-extra-context!)))
         (on-complete response)))))
 
@@ -194,8 +194,8 @@
   (timbre/error "Hanling missing link:" callee-name ":" link)
   (sentry/set-extra-context! (merge {:callee callee-name
                                      :link link}
-                                     parameters))
-  (sentry/capture-message (str "Client API error on: " callee-name))
+                                    parameters))
+  (sentry/capture-error-with-message (str "Client API error on: " callee-name))
   (sentry/clear-extra-context!)
   (notification-actions/show-notification (assoc utils/internal-error :expire 5))
   (when (fn? callback)
@@ -311,12 +311,15 @@
 ;; Board/section
 
 (defn get-board [board-link callback]
-  (if board-link
-    (storage-http (method-for-link board-link) (relative-href board-link)
-      {:headers (headers-for-link board-link)}
-      (fn [{:keys [status body success]}]
-        (callback status body success)))
-    (handle-missing-link "get-board" board-link callback)))
+  (if (or (= (:href board-link) "http://localhost:3001/orgs/carrot/boards/people-1")
+          (= (:href board-link) "/orgs/carrot/boards/people-1"))
+    (handle-missing-link "get-board" nil callback)
+    (if board-link
+      (storage-http (method-for-link board-link) (relative-href board-link)
+        {:headers (headers-for-link board-link)}
+        (fn [{:keys [status body success]}]
+          (callback status body success)))
+      (handle-missing-link "get-board" board-link callback))))
 
 (defn patch-board [board-patch-link data note callback]
   (if (and board-patch-link data)

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -311,15 +311,12 @@
 ;; Board/section
 
 (defn get-board [board-link callback]
-  (if (or (= (:href board-link) "http://localhost:3001/orgs/carrot/boards/people-1")
-          (= (:href board-link) "/orgs/carrot/boards/people-1"))
-    (handle-missing-link "get-board" nil callback)
-    (if board-link
-      (storage-http (method-for-link board-link) (relative-href board-link)
-        {:headers (headers-for-link board-link)}
-        (fn [{:keys [status body success]}]
-          (callback status body success)))
-      (handle-missing-link "get-board" board-link callback))))
+  (if board-link
+    (storage-http (method-for-link board-link) (relative-href board-link)
+      {:headers (headers-for-link board-link)}
+      (fn [{:keys [status body success]}]
+        (callback status body success)))
+    (handle-missing-link "get-board" board-link callback)))
 
 (defn patch-board [board-patch-link data note callback]
   (if (and board-patch-link data)

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -641,9 +641,9 @@
         (route-dispatch! (router/get-token))
         ; remove all the tooltips
         (utils/after 100 #(utils/remove-tooltips)))))
-  (let [error-message "Error: div#app is not defined!"]
-    (timbre/error error-message)
-    (sentry/capture-error-with-message error-message)))
+  (do
+    (timbre/error "Error: div#app is not defined!")
+    (sentry/capture-message "Error: div#app is not defined!")))
 
 (defn init []
   ;; Setup timbre log level

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -641,9 +641,9 @@
         (route-dispatch! (router/get-token))
         ; remove all the tooltips
         (utils/after 100 #(utils/remove-tooltips)))))
-  (do
-    (timbre/error "Error: div#app is not defined!")
-    (sentry/capture-message "Error: div#app is not defined!")))
+  (let [error-message "Error: div#app is not defined!"]
+    (timbre/error error-message)
+    (sentry/capture-error-with-message error-message)))
 
 (defn init []
   ;; Setup timbre log level

--- a/src/oc/web/lib/raven.cljs
+++ b/src/oc/web/lib/raven.cljs
@@ -33,8 +33,10 @@
 (defn capture-message [msg]
   (.captureMessage js/Raven msg))
 
-(defn capture-error-with-message [msg]
-  (capture-error (js/Error. msg)))
+(defn capture-error-with-message [error-name & [error-message]]
+  (let [err (js/Error. (or error-message error-name))]
+    (set! (.-name err) (or error-name "Error"))
+    (capture-error err)))
 
 (defn set-user-context! [ctx]
   (.setUserContext js/Raven (when ctx (clj->js ctx))))


### PR DESCRIPTION
Instad of capturing messages in sentry use the capture error function so we have also a stack trace.

To test:
- roll back [this](https://github.com/open-company/open-company-web/commit/457cb0bdc42bb6a59df0097a6eac4eeb353148a4) commit (make sure you use a board you actually have in the if)
- go to sentry and check you have a new error
- [x] do you see the error message? Good
- [x] do you see the error stack trace? Good