### PR TITLE
Fix Fullstory checks

### DIFF
--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -170,7 +170,7 @@
                         :method (method-name method)
                         :jwt (j/jwt)
                         :params params
-                        :sessionURL (when js/FS (.-getCurrentSessionURL js/FS))}]
+                        :sessionURL (when (exists? js/FS) (.-getCurrentSessionURL js/FS))}]
             (timbre/error "xhr response error:" (method-name method) ":" (str endpoint path) " -> " status)
             (sentry/set-extra-context! report)
             (sentry/capture-error-with-message (str "xhr response error:" status))
@@ -195,7 +195,7 @@
   (timbre/error "Hanling missing link:" callee-name ":" link)
   (sentry/set-extra-context! (merge {:callee callee-name
                                      :link link
-                                     :sessionURL (when js/FS (.-getCurrentSessionURL js/FS))}
+                                     :sessionURL (when (exists? js/FS) (.-getCurrentSessionURL js/FS))}
                                     parameters))
   (sentry/capture-error-with-message (str "Client API error on: " callee-name))
   (sentry/clear-extra-context!)

--- a/src/oc/web/ws/utils.cljs
+++ b/src/oc/web/ws/utils.cljs
@@ -14,7 +14,7 @@
         ctx {:action action-id
              :connection-status connection-status
              :send-fn ch-send-fn?
-             :sessionURL (when js/FS (.-getCurrentSessionURL js/FS))}]
+             :sessionURL (when (exists? js/FS) (.-getCurrentSessionURL js/FS))}]
     (sentry/set-extra-context! ctx)
     (sentry/capture-message (str "Send over closed " service-name " WS connection"))
     (sentry/clear-extra-context!)
@@ -39,7 +39,7 @@
              :connection-status connection-status
              :timestamp (.getTime (new js/Date))
              :auth-response auth-response
-             :sessionURL (when js/FS (.-getCurrentSessionURL js/FS))}]
+             :sessionURL (when (exists? js/FS) (.-getCurrentSessionURL js/FS))}]
     (sentry/set-extra-context! ctx)
     (sentry/capture-message (str service-name " WS: not valid JWT"))
     (sentry/clear-extra-context!)
@@ -51,7 +51,7 @@
                             nil)
         ctx {:timestamp (.getTime (new js/Date))
              :connection-status connection-status
-             :sessionURL (when js/FS (.-getCurrentSessionURL js/FS))}]
+             :sessionURL (when (exists? js/FS) (.-getCurrentSessionURL js/FS))}]
     (sentry/set-extra-context! ctx)
     (sentry/capture-message (str service-name " WS: handshake timeout"))
     (sentry/clear-extra-context!)


### PR DESCRIPTION
Card: https://trello.com/c/oBupmvDY

Issue: https://sentry.io/opencompany/oc-staging-web/issues/781088497/?referrer=slack

Improve the checks before calling Fullstory session URL function to avoid errors like the one above.

To test:
- run on localhost (don't change FS setup)
- have a service return a 400 or a 422 (or you can add any other error status at `oc.web.api:167`)
- now make sure the UI is doing that request
- [x] do you see a sentry reporting that error? Good
- [x] do you NOT see an error like the one above about `FS` not defined? Good
- merge