### PR TITLE
Change Slack tooltip when it's not enabled.

### DIFF
--- a/src/oc/web/components/ui/org_settings_invite_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_invite_panel.cljs
@@ -126,9 +126,7 @@
                :data-toggle (when-not slack-enabled? "tooltip")
                :data-placement "top"
                :data-container "body"
-               :title (if has-slack-org?
-                        "Enable Carrot Bot for Slack"
-                        "Enable Slack for Carrot")
+               :title "In Settings, enable the Carrot Bot for Slack."
                :class (utils/class-set {:disabled (not slack-enabled?)
                                         :active (= "slack" @(::inviting-from s))})}
               "Slack"])]


### PR DESCRIPTION
Card: https://trello.com/c/wjZ9AzSJ

To test:
- signup with email
- go to invite
- hover on Slack button
- [x] do you see a tooltip that reads: "In settings, enable the Carrot Bot for Slack"? Good
- now add a slack team from settings
- add the bot
- [ ] slack invite is now enabled? Good