### PR TITLE
Auto-share to Slack tooltip

### DIFF
--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -258,21 +258,40 @@ div.dashboard-layout {
             line-height: 20px;
             margin-top: 8px;
 
-            button.post-added-bt {
-              display: inline;
-              background-color: transparent;
-              padding: 0;
-              margin: 0;
-              color: $carrot_green;
-              @include avenir_H();
-              font-size: 16px;
-              line-height: 20px;
-            }
-
             @include tablet() {
               float: unset;
               margin: 8px auto 0px;
               width: 100%;
+            }
+          }
+
+          button.post-added-bt {
+            width: auto;
+            margin-top: 16px;
+            padding: 1px 24px 2px;
+            height: 40px;
+            background-color: transparent;
+            border-radius: 6px;
+            color: white;
+            background-color: $carrot_green;
+            @include avenir_H();
+            font-size: 16px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
+            @include mobile() {
+              width: 100%;
+            }
+
+            span.slack-icon {
+              width: 16px;
+              height: 16px;
+              background-size: 16px;
+              background-position: 0px 0px;
+              background-image: cdnUrl("/img/ML/slack_white_icon.svg");
+              float: left;
+              margin-right: 8px;
             }
           }
 

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -309,16 +309,16 @@
                     [:div.post-added-tooltips
                       [:div.post-added-tooltip-box-mobile]
                       [:div.post-added-tooltip-title
-                        "Well done!"]
+                        "Auto-share to Slack!"]
                       [:div.post-added-tooltip
-                        "Using Slack? "
-                        [:button.mlb-reset.post-added-bt
-                          {:on-click #(do
-                                       (nux-actions/dismiss-post-added-tooltip)
-                                       (org-actions/bot-auth team-data current-user-data
-                                        (str (router/get-token) "?org-settings=main")))}
-                          "Connect to Slack"]
-                        " so your team can see posts and  join the discussion from Slack, too."]
+                        "Using Slack? Connect to Slack so your team can view and comment on posts from within Slack, too."]
+                      [:button.mlb-reset.post-added-bt
+                        {:on-click #(do
+                                     (nux-actions/dismiss-post-added-tooltip)
+                                     (org-actions/bot-auth team-data current-user-data
+                                      (str (router/get-token) "?org-settings=main")))}
+                        [:span.slack-icon]
+                        "Connect to Slack"]
                       [:div.post-added-tooltip-box]]]))
               ;; Board content: empty org, all posts, empty board, drafts view, entries view
               (cond


### PR DESCRIPTION
Card: https://trello.com/c/DYmFpIei

To test:
- signup
- create a new post
- [x] do you see the auto share to Slack tooltip? Good
- [x] does it reflect the button in the card attached image? Good
- switch to mobile (refresh if you need)
- [x] does it look good on mobile too? Good
- click the button to enable Slack
- [x] does it work? Good