### PR TITLE
WS authentication failed: closed

### DIFF
--- a/src/oc/web/ws/notify_client.cljs
+++ b/src/oc/web/ws/notify_client.cljs
@@ -2,15 +2,14 @@
   (:require-macros [cljs.core.async.macros :refer [go go-loop]]
                    [taoensso.encore :refer (have)])
   (:require [cljs.core.async :refer [chan <! >! timeout pub sub unsub unsub-all]]
+            [goog.Uri :as guri]
             [taoensso.sente :as s]
             [taoensso.timbre :as timbre]
             [oc.web.lib.jwt :as j]
             [oc.lib.time :as time]
-            [oc.web.local-settings :as ls]
             [oc.web.actions.jwt :as ja]
-            [oc.web.lib.utils :as utils]
-            [oc.web.ws.utils :as ws-utils]
-            [goog.Uri :as guri]))
+            [oc.web.local-settings :as ls]
+            [oc.web.ws.utils :as ws-utils]))
 
 ;; Sente WebSocket atoms
 (defonce channelsk (atom nil))
@@ -39,47 +38,6 @@
   (send! chsk-send! [:watch/notifications {}]))
 
 ;; Auth
-(declare reconnect)
-
-(defn should-disconnect? [rep]
-  (if (and (s/cb-success? rep)
-           (:valid rep))
-    (notifications-watch)
-    (do
-      (timbre/warn "disconnecting client due to invalid JWT!" rep)
-      (s/chsk-disconnect! @channelsk)
-      (cond
-        (j/expired?)
-        (ja/jwt-refresh
-         #(reconnect @last-ws-link (j/user-id)))
-        (= rep :chsk/timeout)
-        (do
-          (ws-utils/report-connect-timeout "Notify" ch-state)
-          ;; retry in 10 seconds if sente is not trying reconnecting
-          (when (and @ch-state
-                     (not (:udt-next-reconnect @@ch-state)))
-            (utils/after (* 10 1000)
-             (reconnect @last-ws-link (j/user-id)))))
-        (or (= rep :chsk/closed)
-            (= rep "closed"))
-        (do
-          (ws-utils/sentry-report "Notify" chsk-send! ch-state "jwt-validation/should-disconnect?"
-           {:chsk/closed (= rep :chsk/closed)
-            :closed (= rep "closed")})
-          ;; retry in 10 seconds if sente is not trying reconnecting
-          (when (and @ch-state
-                     (not (:udt-next-reconnect @@ch-state)))
-            (utils/after (* 10 1000)
-             (reconnect @last-ws-link (j/user-id)))))
-        :else
-        (ws-utils/report-invalid-jwt "Notify" ch-state rep)))))
-
-(defn post-handshake-auth []
-  (timbre/debug "Trying post handshake jwt auth")
-  (if (j/expired?)
-    (ja/jwt-refresh
-     #(send! chsk-send! [:auth/jwt {:jwt (j/jwt)}] 60000 should-disconnect?))
-    (send! chsk-send! [:auth/jwt {:jwt (j/jwt)}] 60000 should-disconnect?)))
 
 (defn subscribe
   [topic handler-fn]
@@ -145,9 +103,14 @@
   (timbre/debug "Push event from server: " ?data)
   (apply event-handler ?data))
 
+(declare reconnect)
+
 (defmethod -event-msg-handler :chsk/handshake
   [{:as ev-msg :keys [?data]}]
-  (post-handshake-auth)
+  (let [auth-cb (partial ws-utils/auth-check "Notify" ch-state chsk-send!
+                 channelsk ja/jwt-refresh #(reconnect @last-ws-link (j/user-id)) notifications-watch)]
+    (ws-utils/post-handshake-auth ja/jwt-refresh
+     #(send! chsk-send! [:auth/jwt {:jwt (j/jwt)}] 60000 auth-cb)))
   (let [[?uid ?csrf-token ?handshake-data] ?data]
     (timbre/debug "Handshake:" ?uid ?csrf-token ?handshake-data)))
 

--- a/src/oc/web/ws/utils.cljs
+++ b/src/oc/web/ws/utils.cljs
@@ -6,7 +6,7 @@
 
 ;; Connection check
 
-(defn- sentry-report [service-name chsk-send! ch-state & [action-id]]
+(defn- sentry-report [service-name chsk-send! ch-state & [action-id infos]]
   (let [connection-status (if @ch-state
                             @@ch-state
                             nil)
@@ -14,6 +14,7 @@
         ctx {:action action-id
              :connection-status connection-status
              :send-fn ch-send-fn?
+             :infos infos
              :sessionURL (when (exists? js/FS) (.-getCurrentSessionURL js/FS))}]
     (sentry/set-extra-context! ctx)
     (sentry/capture-message (str "Send over closed " service-name " WS connection"))

--- a/src/oc/web/ws/utils.cljs
+++ b/src/oc/web/ws/utils.cljs
@@ -1,6 +1,8 @@
 (ns oc.web.ws.utils
   (:require [taoensso.timbre :as timbre]
+            [taoensso.sente :as s]
             [oc.web.lib.jwt :as j]
+            [oc.web.lib.utils :as utils]
             [oc.web.lib.raven :as sentry]
             [oc.web.local-settings :as ls]))
 
@@ -57,3 +59,42 @@
     (sentry/capture-message (str service-name " WS: handshake timeout"))
     (sentry/clear-extra-context!)
     (timbre/error (str service-name " WS: handshake timeout") ctx)))
+
+(defn auth-check [service-name ch-state chsk-send! channelsk jwt-refresh-cb reconnect-cb success-cb rep]
+  (if (and (s/cb-success? rep)
+           (:valid rep))
+    (when (fn? success-cb)
+      (success-cb rep))
+    (do
+      (timbre/warn "disconnecting client due to invalid JWT!" rep)
+      (s/chsk-disconnect! @channelsk)
+      (cond
+        (j/expired?)
+        (jwt-refresh-cb reconnect-cb)
+        (= rep :chsk/timeout)
+        (do
+          (report-connect-timeout service-name ch-state)
+          ;; retry in 10 seconds if sente is not trying reconnecting
+          (when (and @ch-state
+                     (not (:udt-next-reconnect @@ch-state)))
+            (utils/after (* 10 1000)
+             (reconnect-cb))))
+        (or (= rep :chsk/closed)
+            (= rep "closed"))
+        (do
+          (sentry-report service-name chsk-send! ch-state "jwt-validation/auth-check"
+           {:chsk/closed (= rep :chsk/closed)
+            :closed (= rep "closed")})
+          ;; retry in 10 seconds if sente is not trying reconnecting
+          (when (and @ch-state
+                     (not (:udt-next-reconnect @@ch-state)))
+            (utils/after (* 10 1000)
+             (reconnect-cb))))
+        :else
+        (report-invalid-jwt service-name ch-state rep)))))
+
+(defn post-handshake-auth [jwt-refresh-cb auth-cb]
+  (timbre/debug "Trying post handshake jwt auth")
+  (if (j/expired?)
+    (jwt-refresh-cb auth-cb)
+    (auth-cb)))


### PR DESCRIPTION
Card: https://trello.com/c/FjI2y4nq

#### Bug
After adding more info to the failure of ws authentication i found out that sometimes the jwt is refused because the connection is closed.
Check this sentry https://sentry.io/opencompany/oc-beta-web/issues/779441312/?referrer=slack, if you scroll down to the additional data section you see under `rep` it says `closed`. That's the response we get for the auth request.
It probably means the connection was closed while it was attempting the auth.

#### Solution
So i added some code to handle the closed connection and retrying to connect.

#### To test:
This is hard to test since it's mostly a race condition, just check the code and check if you can get interaction and notify to connect locally and on staging.