### PR TITLE
Remove the settings COG from navigation sidebar.

### DIFF
--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -147,10 +147,6 @@
     }
   }
 
-  button.section-cog {
-    display: none;
-  }
-
   div.all-posts-label, div.drafts-label, div.must-see-label {
     font-size: 14px;
     text-decoration: none;
@@ -204,11 +200,6 @@
       color: $deep_navy;
     }
   }
-
-  button.section-cog {
-    display: block;
-  }
-
 
   &:active, &:focus {
     text-decoration: none;
@@ -635,24 +626,6 @@ div.left-navigation-sidebar {
 
           .emojione {
             @include emoji-size(12);
-          }
-        }
-
-        button.section-cog {
-          width: 13px;
-          height: 14px;
-          background-image: cdnUrl("/img/ML/section_settings_gear.svg");
-          background-size: 13px 14px;
-          background-position: center;
-          background-repeat: no-repeat;
-          opacity: 0.6;
-          float: right;
-          margin-right: 8px;
-          margin-top: 6px;
-          display: none;
-
-          &:hover {
-            opacity: 0.8;
           }
         }
       }

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -202,17 +202,7 @@
                     {:class (utils/class-set {:new (seq (:unseen board-change-data))
                                               :has-icon (#{"public" "private"} (:access board))})
                      :key (str "board-list-" (name (:slug board)) "-internal")
-                     :dangerouslySetInnerHTML (utils/emojify (or (:name board) (:slug board)))}]
-                  (when-not (:read-only board-data)
-                    [:button.mlb-reset.section-cog
-                      {:data-toggle (when-not is-mobile? "tooltip")
-                       :data-placement "top"
-                       :data-container "body"
-                       :title "Section settings"
-                       :on-click #(do
-                                   (utils/event-stop %)
-                                   (nav-actions/nav-to-url! % board-url)
-                                   (dis/dispatch! [:input [:show-section-editor] true]))}])]])])]
+                     :dangerouslySetInnerHTML (utils/emojify (or (:name board) (:slug board)))}]]])])]
       [:div.left-navigation-sidebar-footer
         {:ref "left-navigation-sidebar-footer"
          :class (utils/class-set {:navigation-sidebar-overflow is-tall-enough?})}


### PR DESCRIPTION
Card: https://trello.com/c/GP0mEXFM

To test:
- run this branch
- hover on the list of sections in left navbar (desktop)
- [x] do you NOT see the COG on the right side on hover? Good
- [x] check mobile sections menu for regressions