### PR TITLE
Add "you" besides your user in team management settings panel.

### DIFF
--- a/scss/partials/_org_settings_team_panel.scss
+++ b/scss/partials/_org_settings_team_panel.scss
@@ -79,6 +79,11 @@ div.org-settings {
                 &.pending.removing {
                   max-width: calc(100% - 253px);
                 }
+
+                span.current-user {
+                  font-size: 11px;
+                  color: $ui_grey;
+                }
               }
 
               div.tooltip {

--- a/src/oc/web/components/ui/org_settings_team_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_team_panel.cljs
@@ -88,6 +88,7 @@
                         pending? (and (= "pending" (:status user))
                                       (or (contains? user :email)
                                           (contains? user :slack-id)))
+                        current-user (= (:user-id user) (:user-id cur-user-data))
                         display-name (utils/name-or-email user)
                         removing? (@(::removing s) (:user-id user))
                         remove-fn (fn []
@@ -169,7 +170,9 @@
                      :data-toggle "tooltip"
                      :data-html "true"
                      :data-placement "top"}
-                    display-name]
+                    display-name
+                    (when current-user
+                      [:span.current-user " (you)"])]
                   (when pending?
                     [:div.pending-user
                       " (pending: "


### PR DESCRIPTION
From Slack discussion: https://opencompanyhq.slack.com/archives/C06SBQ3FD/p1544626567178700

Adds a small _(you)_ label besides your username in the team management panel to know which user you are currently logged in with.

To test:
- login with an admin
- go to team management
- [x] check that only your user has the label
- merge