### PR TITLE
Fix possible race-condition on add comment box

### DIFF
--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -14,21 +14,21 @@
             [oc.web.components.ui.user-avatar :refer (user-avatar-image)]))
 
 (defn enable-add-comment? [s]
-  (let [add-comment-div (rum/ref-node s "add-comment")
-        comment-text (cu/add-comment-content add-comment-div)
-        next-add-bt-disabled (or (nil? comment-text) (zero? (count comment-text)))]
-    (when (not= next-add-bt-disabled @(::add-button-disabled s))
-      (reset! (::add-button-disabled s) next-add-bt-disabled))))
+  (when-let [add-comment-div (rum/ref-node s "add-comment")]
+    (let [comment-text (cu/add-comment-content add-comment-div)
+          next-add-bt-disabled (or (nil? comment-text) (zero? (count comment-text)))]
+      (when (not= next-add-bt-disabled @(::add-button-disabled s))
+        (reset! (::add-button-disabled s) next-add-bt-disabled)))))
 
 (defn editable-input-change [s editable event]
   (enable-add-comment? s))
 
-(defn add-comment-focus [s]
+(defn focus-add-comment [s]
   (enable-add-comment? s)
   (comment-actions/add-comment-focus (:uuid (first (:rum/args s)))))
 
 (defn disable-add-comment-if-needed [s]
-  (let [add-comment-node (rum/ref-node s "add-comment")]
+  (when-let [add-comment-node (rum/ref-node s "add-comment")]
     (enable-add-comment? s)
     (when (and (zero? (count (.-innerText add-comment-node)))
                (not @(::emoji-picker-open s)))
@@ -60,7 +60,7 @@
                               (partial editable-input-change s))
                              (reset! (::focus-listener s)
                               (events/listen add-comment-node EventType/FOCUS
-                               #(add-comment-focus s)))
+                               #(focus-add-comment s)))
                              (reset! (::blur-listener s)
                               (events/listen add-comment-node EventType/BLUR
                                #(disable-add-comment-if-needed s)))


### PR DESCRIPTION
Sean found himself in this situation:

<img src="https://user-images.githubusercontent.com/642704/50292756-30061a80-0472-11e9-938f-a858837a9337.png" width="500">

I think it can be a race condition between render cycle. If the "add-comment" reference is not available it can be that the `disable-add-comment-if-needed` function disable them even if the user has text typed inside the field or is typing it.

This avoid making any action if the reference is not present.

To test:
- add the very first comment on a post from AP
- add the very first comment on a post from full post view
- remove your comment from AP
- remove your comment from full post view
- edit a comment from AP
- edit a comment from full post view
- make sure the buttons appear when you focus add comment field (both AP and post view)
- make sure the comment button is enabled when you type something in the field (both AP and post view)