### PR TITLE
Fix secure read action

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -679,11 +679,11 @@
               publisher-id (:user-id (:publisher activity-data))
               container-id (:board-uuid activity-data)
               token-data (jwt/get-id-token-contents)
-              user-id (:user-id token-data)
+              user-name (:name token-data)
               avatar-url (:avatar-url token-data)
               org-id (:uuid (dis/org-data))]
     (ws-cc/item-seen publisher-id container-id activity-id)
-    (ws-cc/item-read org-id container-id activity-id user-id avatar-url)))
+    (ws-cc/item-read org-id container-id activity-id user-name avatar-url)))
 
 (defn- send-item-read
   "Actually send the read. Needs to get the activity data from the app-state


### PR DESCRIPTION
BUG: secure activity view is sending the read message with the user-id instead of the name so we are seeing user ids in the WRT modal.

This fixes the bug but doesn't fix the user ids already in DynamoDB, going to fix those with a script or manually.

To test:
- grab a secure activity url with the id-token
- copy it
- open a new incognito window
- open dev tools (before loading the url to make sure all network requests are recorded)
- paste the url and load it
- check the change WS for item/read action(s)
- [x] do you see your name instead of your user-id in the read requests? Good
- you can double check loading the full web app and checking WRT for that post