### PR TITLE
Test for current activity id to allow share urls to work.

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -509,8 +509,11 @@
    (some #{status} [401 404])
    (router/redirect-404!)
 
-   (not= (:uuid activity-data)
-         (router/current-activity-id))
+   ;; The id token will have a current activity id, shared urls will not.
+   ;; if the ids don't match return a 404
+   (and (some? (router/current-activity-id))
+        (not= (:uuid activity-data)
+              (router/current-activity-id)))
    (router/redirect-404!)
 
    (and secure-uuid


### PR DESCRIPTION
Fix for shared urls that are available to all.

To test:
copy a public/shared url 
- [x]  when opening the url while logged in does it redirect to the private url?
- [x] when opening the url while logged out ,does it show the post but asks you to login?

- [x] open a digest url while logged in, does it open the private url?
- [x] open a digest url while logged out, does it open the url as the user but asks the user to login?
-  change the digest url to a different post uuid
- [x] does it 404?