### PR TITLE
Non admins can open settings from share dialog

### DIFF
--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -136,14 +136,15 @@
                :data-container "body"
                :data-tooltip (if has-bot? "" "tooltip")
                :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"
-               :title "Enable the Carrot Bot for Slack in Settings"
+               :title "Team admins can enable the Carrot bot for Slack in Settings"
                :ref "slack-button"
                :on-click (fn [e]
                            (utils/event-stop e)
                            (when-not @(::sharing s)
                              (if has-bot?
                                (dis/dispatch! [:input [:activity-share-medium] :slack])
-                               (org-settings/show-modal :main))))}
+                               (when (jwt/is-admin? (:team-id org-data))
+                                 (org-settings/show-modal :main)))))}
               "Slack"])]
         [:div.activity-share-divider-line]
         (when (= medium :email)

--- a/src/oc/web/components/ui/activity_share.cljs
+++ b/src/oc/web/components/ui/activity_share.cljs
@@ -136,7 +136,7 @@
                :data-container "body"
                :data-tooltip (if has-bot? "" "tooltip")
                :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"
-               :title "Team admins can enable the Carrot bot for Slack in Settings"
+               :title "Team admins can enable the ’Carrot bot for Slack’ in Settings"
                :ref "slack-button"
                :on-click (fn [e]
                            (utils/event-stop e)


### PR DESCRIPTION
Error: https://app.fullstory.com/ui/BSJZW/session/5752049815781376:(5752049815781376!5629499534213120(5668600916475904(1392:1392:456445)))/devtools/console

If user is not an admin he shouldn't be allowed to access settings.

To test:
- use an org w/o Slack
- use a user that is not an admin
- go to share
- [ ] do you see the tooltip to add Slack? Good
- [ ] can you NOT open settings clicking it? Good
- now use an admin
- [ ] can you open settings clicking on Slack in the share dialog? Good