### PR TITLE
Sentry NullPointer exception

### DIFF
--- a/src/oc/web/components/ui/notifications.cljs
+++ b/src/oc/web/components/ui/notifications.cljs
@@ -68,11 +68,12 @@
                               :slack-bot slack-bot
                               :opac opac
                               :mention-notification (and mention mention-author)
-                              :inline-bt ((keyword id) #{:slack-team-added :slack-bot-added
-                                                         :org-settings-saved :invitation-resent
-                                                         :cancel-invitation :member-removed-from-team
-                                                         :reminder-created :reminder-updated
-                                                         :reminder-deleted})
+                              :inline-bt (when id
+                                           ((keyword id) #{:slack-team-added :slack-bot-added
+                                                           :org-settings-saved :invitation-resent
+                                                           :cancel-invitation :member-removed-from-team
+                                                           :reminder-created :reminder-updated
+                                                           :reminder-deleted}))
                               :dismiss-button dismiss-bt})
      :on-mouse-enter #(clear-timeout s)
      :on-mouse-leave #(setup-timeout s)


### PR DESCRIPTION
Sentries:
- https://sentry.io/opencompany/oc-beta-web/issues/856039101/?referrer=slack
- https://sentry.io/opencompany/oc-beta-web/issues/856039122/?referrer=slack

Problem is that the notification shown after updating the org logo has no `:id` key in the passed map. That's used to determine what type of notification, if it's missing is causing a NullPointer exception. Now it won't.

To test:
- go to settings
- change logo
- [x] do you see the notification? Good