### PR TITLE
Sentry on get-reminders

### DIFF
--- a/src/oc/web/actions/reminder.cljs
+++ b/src/oc/web/actions/reminder.cljs
@@ -1,4 +1,5 @@
 (ns oc.web.actions.reminder
+  (:require-macros [if-let.core :refer (when-let*)])
   (:require [oc.web.api :as api]
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
@@ -36,8 +37,8 @@
   Load the reminders list.
   NB: first reminders is loaded in did-mount of dashboard-layout component."
   []
-  (let [org-data (dis/org-data)
-        reminders-link (utils/link-for (:links org-data) "reminders")]
+  (when-let* [org-data (dis/org-data)
+              reminders-link (utils/link-for (:links org-data) "reminders")]
     (api/get-reminders reminders-link reminders-loaded)))
 
 (defn edit-reminder


### PR DESCRIPTION
Sentry: https://sentry.io/opencompany/oc-beta-web/issues/856375404/?referrer=slack

To test:
- visit a public section as anonymous
- [x] do you NOT see an error about get-reminders? Good
- now visit a section while logged in
- [x] do you see the reminders list being loaded in the Network tab? Good