### PR TITLE
Sentry empty team name

### DIFF
--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -147,7 +147,7 @@ div.org-settings {
 
         &.save-btn {
           width: 100px;
-          border-radius: 100px;
+          border-radius: 6px;
           background-color: $carrot_green;
           color: white;
           @include avenir_H();

--- a/scss/partials/_org_settings_main_panel.scss
+++ b/scss/partials/_org_settings_main_panel.scss
@@ -102,7 +102,7 @@ div.org-settings div.org-settings-inner div.org-settings-main {
         padding: 6px 13px;
         background-color: $feint_emerald;
         height: 32px;
-        border-radius: 100px;
+        border-radius: 6px;
         margin-right: 8px;
         color: $carrot_green;
         border: none;

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -248,8 +248,9 @@
   (org-loaded (json->cljs body) true))
 
 (defn org-edit-save [org-data]
-  (let [org-patch-link (utils/link-for (:links (dis/org-data)) "partial-update")]
-    (api/patch-org org-patch-link org-data org-edit-save-cb)))
+  (let [org-patch-link (utils/link-for (:links (dis/org-data)) "partial-update")
+        with-trimmed-name (assoc org-data :name (clojure.string/trim (:name org-data)))]
+    (api/patch-org org-patch-link with-trimmed-name org-edit-save-cb)))
 
 (defn org-avatar-edit-save-cb [{:keys [success body status]}]
   (if success

--- a/src/oc/web/components/ui/org_settings_main_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_main_panel.cljs
@@ -235,7 +235,8 @@
         [:button.mlb-reset.save-btn
           {:disabled (or @(::saving s)
                          (:saved org-editing)
-                         (not (:has-changes org-editing)))
+                         (not (:has-changes org-editing))
+                         (clojure.string/blank? (:name org-editing)))
            :class (when (:saved org-editing) "no-disable")
            :on-click #(do
                         (reset! (::saving s) true)

--- a/src/oc/web/components/ui/org_settings_main_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_main_panel.cljs
@@ -1,5 +1,6 @@
 (ns oc.web.components.ui.org-settings-main-panel
   (:require [rum.core :as rum]
+            [clojure.string :as s]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.api :as api]
             [oc.web.lib.jwt :as jwt]
@@ -236,7 +237,8 @@
           {:disabled (or @(::saving s)
                          (:saved org-editing)
                          (not (:has-changes org-editing))
-                         (clojure.string/blank? (:name org-editing)))
+                         (s/blank? (:name org-editing))
+                         (< (count (s/trim (:name org-editing))) 3))
            :class (when (:saved org-editing) "no-disable")
            :on-click #(do
                         (reset! (::saving s) true)


### PR DESCRIPTION
Sentry: https://sentry.io/opencompany/oc-beta-web/issues/856037577/?referrer=slack

To test:
- open team settings (as an admin)
- remove the name
- [x] can you NOT save? Good
- insert only spaces as name
- [x] can you NOT save? Good
- now insert a name of 2 chars
- [x] can you save? Good
- [x] check that names are trimmed and that the 3 minimum chars are counted after trim