### PR TITLE
Can add reminder

### DIFF
--- a/scss/partials/_reminders.scss
+++ b/scss/partials/_reminders.scss
@@ -118,7 +118,7 @@ div.reminders-container {
           text-align: center;
           width: 396px;
           margin: 24px auto 0;
-          padding: 0 24px;
+          padding: 0 24px 32px;
 
           div.empty-reminders-logo {
             width: 56px;
@@ -147,7 +147,7 @@ div.reminders-container {
           }
 
           button.add-reminder-bt {
-            margin: 16px auto 32px;
+            margin: 16px auto 0;
             width: 192px;
             height: 40px;
             border-radius: 100px;

--- a/src/oc/web/components/reminders.cljs
+++ b/src/oc/web/components/reminders.cljs
@@ -204,16 +204,17 @@
 
 ;; Manage reminders component
 
-(def empty-reminders
+(defn empty-reminders [show-add-reminder-bt]
   [:div.empty-reminders
     [:div.empty-reminders-logo]
     [:div.empty-reminders-title
       "Update your team on time"]
     [:div.empty-reminders-description
       "Make it easy for team leaders to remember when it's time to update everyone."]
-    [:button.mlb-reset.add-reminder-bt
-      {:on-click #(reminder-actions/new-reminder)}
-      "Create new reminder"]])
+    (when show-add-reminder-bt
+      [:button.mlb-reset.add-reminder-bt
+        {:on-click #(reminder-actions/new-reminder)}
+        "Create new reminder"])])
 
 (rum/defcs manage-reminders < rum/reactive
                               (drv/drv :show-reminders-tooltip)
@@ -222,10 +223,11 @@
                                (nux-actions/dismiss-reminders-tooltip)
                                s)}
   [s reminders-data]
-  (let [reminders-list (:items reminders-data)]
+  (let [reminders-list (:items reminders-data)
+        can-add-reminder? (utils/link-for (:links reminders-data) "create")]
     [:div.reminders-tab.manage-reminders
       (if (empty? reminders-list)
-        empty-reminders
+        (empty-reminders can-add-reminder?)
         [:div.reminders-list-container
           (when (drv/react s :show-reminders-tooltip)
             [:div.reminder-tooltip
@@ -291,7 +293,8 @@
         editing-reminder? (string? reminder-tab)
         alert-modal-data (drv/react s :alert-modal)
         reminders-data (drv/react s :reminders-data)
-        reminder-edit-data (drv/react s :reminder-edit)]
+        reminder-edit-data (drv/react s :reminder-edit)
+        can-add-reminder? (utils/link-for (:links reminders-data) "create")]
     [:div.reminders-container.fullscreen-page
       [:div.reminders-inner
         {:class (utils/class-set {:no-bottom-padding (= reminder-tab :reminders)
@@ -311,7 +314,8 @@
                 {:on-click #(nav-actions/show-reminders)
                  :class (when (= reminder-tab :reminders) "active")}
                 "MANAGE"]
-              (when reminders-data
+              (when (and reminders-data
+                         can-add-reminder?)
                 [:div.reminders-header-tab
                   {:on-click #(reminder-actions/new-reminder)
                    :class (when (= reminder-tab :new) "active")}

--- a/src/oc/web/components/reminders.cljs
+++ b/src/oc/web/components/reminders.cljs
@@ -84,7 +84,8 @@
                             (swap! (::assignee-dropdown s) not)
                             (reset! (::frequency-dropdown s) false)
                             (reset! (::on-dropdown s) false))}
-              (when (:assignee reminder-data)
+              (when (and (:assignee reminder-data)
+                         (:avatar-url (:assignee reminder-data)))
                 (user-avatar-image (:assignee reminder-data)))
               (when (:assignee reminder-data)
                 (str (utils/name-or-email (:assignee reminder-data))

--- a/src/oc/web/components/ui/dropdown_list.cljs
+++ b/src/oc/web/components/ui/dropdown_list.cljs
@@ -64,7 +64,8 @@
                   (when unselected-icon
                     [:img.dropdown-list-item-icon {:src unselected-icon}])))
               (when (and (string? (:label item))
-                         (:user-map item))
+                         (:user-map item)
+                         (:avatar-url (:user-map item)))
                 (user-avatar-image (:user-map item)))
               (when (string? (:label item))
                 [:span.dropdown-list-item-label


### PR DESCRIPTION
Show the add reminder buttons only if the user has the link to add one.
Buttons are 2:
- NEW REMINDER in the reminders tab besides MANAGE
- in the reminders list empty state

To test:
- with a viewer open the UI
- click on reminders
- [x] do you NOT see the NEW REMINDER tab at the top? Good
- [x] do you NOT see the new remidner button in the empty state? Good
- now with an author or admin
- [x] can you add a new reminder? Good
- [x] do you NOT see the spinner in the users list? Good