### PR TITLE
Draft navigation bug

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -212,7 +212,7 @@
                     (:has-changes entry-map)
                     (not (:auto-saving entry-map)))
            ;; dispatch that you are auto saving
-           (dis/dispatch! [:update [edit-key ] #(merge % {:auto-saving true :has-changes false})])
+           (dis/dispatch! [:update [edit-key ] #(merge % {:auto-saving true :has-changes false :body (:body entry-map)})])
            (entry-save edit-key entry-map section-editing
              (fn [entry-data-saved edit-key-saved {:keys [success body status]}]
                (if-not success


### PR DESCRIPTION
Card: https://trello.com/c/ny0Ohg6z

Bug:
- open Cmail
- type title and body
- wait for autosave
- navigate to another section
- body is empty

This fix avoid losing the body of a post when you navigate btw sections.

To test repeat the steps in the bug report and make sure it's fixed.