### PR TITLE
Remove NUX invite step

### DIFF
--- a/scss/partials/_onboard_wrapper.scss
+++ b/scss/partials/_onboard_wrapper.scss
@@ -259,7 +259,7 @@ div.onboard-lander {
     }
 
     div.steps {
-      width: 96px;
+      width: 64px;
       height: 8px;
       margin: 24px auto 0;
 

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -156,7 +156,7 @@
 
 (defn- org-created [org-data]
   (utils/after 0
-   #(router/nav! (oc-urls/sign-up-invite (:slug org-data)))))
+   #(router/nav! (oc-urls/sign-up-setup-sections (:slug org-data)))))
 
 (defn team-patch-cb [org-data {:keys [success body status]}]
   (when success

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -232,7 +232,6 @@
         (when-not has-org?
           [:div.steps.first-step
             [:div.step]
-            [:div.step]
             [:div.step]])
         [:div.steps-separator]]
       (when (:error edit-user-profile)
@@ -473,8 +472,7 @@
            "Start"]]
         [:div.title
           "Pick a few topics to start"]
-        [:div.steps.third-step
-          [:div.step]
+        [:div.steps.second-step
           [:div.step]
           [:div.step]]
         [:div.steps-separator]]
@@ -572,7 +570,7 @@
           "Invite your team"]
         [:div.subtitle
           "Invite some colleagues to explore Carrot with you."]
-        [:div.steps.second-step
+        [:div.steps.third-step
           [:div.step]
           [:div.step]
           [:div.step]]


### PR DESCRIPTION
Card: https://trello.com/c/18SYwjr7

To test:
- sign up with email
- fill in your profile
- [x] profile/team step had 1 of 2 steps at the top? Good
- proceed
- [x] do you see the sections step now? Good
- [x] do you see 2 of 2 steps? Good
- proceed
- [x] did you NOT get the invite step? Good
- now invite a user via email (do not use email domains or Slack)
- accept the invite
- [x] could you accept the invite and onboard to the invitee org? Good