### PR TITLE
Fix mobile login dialog

### DIFF
--- a/scss/partials/_base.scss
+++ b/scss/partials/_base.scss
@@ -71,6 +71,12 @@ div.fullscreen-page {
 
 .no-scroll {
   overflow-y: hidden;
+
+  @include mobile() {
+    div#app {
+      max-height: 100vh;
+    }
+  }
 }
 
 h1, h2, h3, h4, h5, h6, .oc-header {

--- a/scss/partials/_login_overlay.scss
+++ b/scss/partials/_login_overlay.scss
@@ -13,7 +13,7 @@ div.login-overlay-container {
   @include mobile{
     width: 100%;
     height: auto;
-    min-height: 100%;
+    min-height: 100vh;
     overflow: auto;
     position: relative;
     background-color: white;
@@ -51,7 +51,7 @@ div.login-overlay-container {
       margin-left: 0px;
       width: 100%;
       height: auto;
-      min-height: 100%;
+      min-height: 100vh;
       left: 0px;
       top: 0px;
       overflow: auto;


### PR DESCRIPTION
Card: https://trello.com/c/1krHDHHU

To test:
- add a long post (enough long to scroll some on your mobile device)
- send yourself a digest on Slack
- open a digest link
- if you are logged in logout, go back and click the link again
- now scroll to the bottom of the post
- click the green button Log in as Yourname
- [x] do you see the login dialog appearing? Good
- [x] no need to scroll? Good
- now scroll to the bottom of the screen
- [x] do you NOT see the post below the login view? Good