### PR TITLE
Remove more rich content on copy paste

### DIFF
--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -307,7 +307,7 @@
                  :paste #js {:forcePlainText false
                              :cleanPastedHTML true
                              :cleanAttrs #js ["style" "alt" "dir" "size" "face" "color" "itemprop" "name" "id"]
-                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input" "textarea"]
+                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input" "textarea" "style" "javascript"]
                              :unwrapTags (clj->js (remove nil? ["div" "label" "font" "h1"
                                                    (when-not show-subtitle "h2") "h3" "h4" "h5"
                                                    "h6" "strong" "section" "time" "em" "main" "u" "form" "header" "footer"

--- a/src/oc/web/components/rich_body_editor.cljs
+++ b/src/oc/web/components/rich_body_editor.cljs
@@ -307,11 +307,13 @@
                  :paste #js {:forcePlainText false
                              :cleanPastedHTML true
                              :cleanAttrs #js ["style" "alt" "dir" "size" "face" "color" "itemprop" "name" "id"]
-                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input" "textarea" "style" "javascript"]
+                             :cleanTags #js ["meta" "video" "audio" "img" "button" "svg" "canvas" "figure" "input"
+                                             "textarea" "style" "javascript"]
                              :unwrapTags (clj->js (remove nil? ["div" "label" "font" "h1"
                                                    (when-not show-subtitle "h2") "h3" "h4" "h5"
                                                    "h6" "strong" "section" "time" "em" "main" "u" "form" "header" "footer"
-                                                   "details" "summary" "nav" "abbr"]))}
+                                                   "details" "summary" "nav" "abbr"
+                                                   "table" "thead" "tbody" "tr" "th" "td"]))}
                  :placeholder #js {:text placeholder
                                    :hideOnClick true}
                  :keyboardCommands #js {:commands #js [


### PR DESCRIPTION
Bug: if you load the attached HTML page in the browser and click the button then paste the content in a post body you'll see that the style tag and also the table tags are preserved, they should not.

To test:
- copy the content from the HTML page
- paste it into a post body
- [x] do you NOT see a style, table, thead, tbody, tr, th or td tags in it? Good


[HTML file](https://gist.github.com/bago2k4/6df2887ad4db25b4588c8aabe8bd12c6)