### PR TITLE
Better error reporting for WS send failure

### DIFF
--- a/src/oc/web/ws/utils.cljs
+++ b/src/oc/web/ws/utils.cljs
@@ -6,6 +6,35 @@
             [oc.web.lib.raven :as sentry]
             [oc.web.local-settings :as ls]))
 
+;; Connection check
+
+(defn sentry-report [message chsk-send! ch-state & [action-id infos]]
+  (let [connection-status (if @ch-state
+                            @@ch-state
+                            nil)
+        ch-send-fn? (fn? @chsk-send!)
+        ctx {:action action-id
+             :connection-status connection-status
+             :send-fn ch-send-fn?
+             :infos infos
+             :sessionURL (when (exists? js/FS) (.-getCurrentSessionURL js/FS))}]
+    (sentry/set-extra-context! ctx)
+    (sentry/capture-message message)
+    (sentry/clear-extra-context!)
+    (timbre/error message ctx)))
+
+;; Real send
+
+(defn- real-send [service-name chsk-send! ch-state args]
+ (try
+   (apply @chsk-send! args)
+   (catch ExceptionInfo e
+     (js/console.log "DBG ex-info" e args)
+     (sentry-report (str "Error sending event for " service-name)
+      chsk-send! ch-state (first (first args))
+      {:rest-args (rest (first args))
+       :ex-message (.-message e)}))))
+
 ;; cmd queue
 (defonce cmd-queue (atom {}))
 
@@ -19,36 +48,20 @@
   (reset! cmd-queue (assoc @cmd-queue (keyword service-name) [])))
 
 (defn send-queue [service-name chsk-send! ch-state]
-  (when (and chsk-send! (:open? @@ch-state))
+  (when (and @chsk-send! (:open? @@ch-state))
     (doseq [qargs ((keyword service-name) @cmd-queue)]
-      (apply chsk-send! qargs))
+      (real-send service-name chsk-send! ch-state qargs))
     (reset-queue service-name)))
 
 (defn send! [service-name chsk-send! ch-state args]
   (if (and @chsk-send! (:open? @@ch-state))
     (do
       ;; empty queue first
-      (send-queue service-name @chsk-send! ch-state)
+      (send-queue service-name chsk-send! ch-state)
       ;; send current command
-      (apply @chsk-send! args))
+      (real-send service-name chsk-send! ch-state args))
     ;;disconnected
     (buffer-cmd service-name args)))
-
-;; Connection check
-(defn sentry-report [service-name chsk-send! ch-state & [action-id infos]]
-  (let [connection-status (if @ch-state
-                            @@ch-state
-                            nil)
-        ch-send-fn? (fn? @chsk-send!)
-        ctx {:action action-id
-             :connection-status connection-status
-             :send-fn ch-send-fn?
-             :infos infos
-             :sessionURL (when (exists? js/FS) (.-getCurrentSessionURL js/FS))}]
-    (sentry/set-extra-context! ctx)
-    (sentry/capture-message (str "Send over closed " service-name " WS connection"))
-    (sentry/clear-extra-context!)
-    (timbre/error "Send over closed " service-name " WS connection" ctx)))
 
 (defn check-interval [last-interval service-name chsk-send! ch-state]
   (when @last-interval
@@ -58,11 +71,11 @@
     #(when (or (not @ch-state)
                (not @@ch-state)
                (not (:open? @@ch-state)))
-       (sentry-report service-name chsk-send! ch-state))
+       (sentry-report (str "Send over closed " service-name " WS connection") chsk-send! ch-state))
     (* ls/ws-monitor-interval 1000))))
 
 (defn reconnect [last-interval service-name chsk-send! ch-state]
-  (send-queue service-name @chsk-send! ch-state)
+  (send-queue service-name chsk-send! ch-state)
   (check-interval last-interval service-name chsk-send! ch-state))
 
 (defn report-invalid-jwt [service-name ch-state rep]
@@ -113,7 +126,7 @@
         (or (= rep :chsk/closed)
             (= rep "closed"))
         (do
-          (sentry-report service-name chsk-send! ch-state "jwt-validation/auth-check"
+          (sentry-report (str "Auth failed for" service-name) chsk-send! ch-state "jwt-validation/auth-check"
            {:chsk/closed (= rep :chsk/closed)
             :closed (= rep "closed")})
           ;; retry in 10 seconds if sente is not trying reconnecting


### PR DESCRIPTION
This adds some infos to the Sentry report when a send over WS fails.

Needed for testing:
```
(defn send-error []
  (send! chsk-send! [[:abs] {:a 1 :b 2}]))
```

To test:
- add the above code in change_client.cljs (or interaction/notify)
- build and open AP
- in console call `oc.web.ws.change-client.send-error()`
- [x] check the error printed in console: do you see all the arguments `[[:abs] {:a 1 :b 2}]`? Good
- [x] open sentry and check the sentry error: do you see the arguments there too? Good
- [x] do you see the `Invalid event` label in both? Good