### PR TITLE
UX mobile: alert modal padding

### DIFF
--- a/scss/partials/_alert_modal.scss
+++ b/scss/partials/_alert_modal.scss
@@ -49,8 +49,8 @@ div.alert-modal-container {
       text-align: center;
 
       @include mobile() {
-        margin: 100px 0px 0px;
-        width: 100%;
+        margin: 100px 16px 0px;
+        width: calc(100% - 32px);
         border-radius: 8px;
       }
 

--- a/src/oc/web/components/ui/more_menu.cljs
+++ b/src/oc/web/components/ui/more_menu.cljs
@@ -30,10 +30,10 @@
                     :title "Delete this post?"
                     :message "This action cannot be undone."
                     :link-button-style :green
-                    :link-button-title "No, keep post"
+                    :link-button-title "No, keep it"
                     :link-button-cb #(alert-modal/hide-alert)
                     :solid-button-style :red
-                    :solid-button-title "Yes, delete post"
+                    :solid-button-title "Yes, delete it"
                     :solid-button-cb #(let [org-slug (router/current-org-slug)
                                             board-slug (router/current-board-slug)
                                             board-url (oc-urls/board org-slug board-slug)]


### PR DESCRIPTION
Card: https://trello.com/c/EWeD04Dg

To test:
- on mobile
- delete a post
- [x] do you see some padding on sides of the alert modal? Good
- [x] do the buttons fit ? Good
- check some other modals (exit reminder w/o saving, delete a comment, exit user profile w/o saving etc...)
- [x] now check at least one modal on desktop for regression