### PR TITLE
QSG tweaks

### DIFF
--- a/scss/partials/_menu.scss
+++ b/scss/partials/_menu.scss
@@ -249,7 +249,7 @@ div.menu {
     }
   }
 
-  a.qsg-profile-photo-2, a.qsg-company-logo-2 {
+  a.qsg-profile-photo-2, a.qsg-company-logo-2, a.qsg-invite-team-2, a.qsg-create-reminder-2 {
     position: relative;
   }
 

--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -340,6 +340,10 @@ div.org-settings-tabs {
     margin: 1px 24px 0px 0px;
     border-bottom: 1px solid transparent;
 
+    a.qsg-invite-team-3 {
+      position: relative;
+    }
+
     a.org-settings-tab-link {
       display: block;
       width: auto;

--- a/scss/partials/_org_settings.scss
+++ b/scss/partials/_org_settings.scss
@@ -340,10 +340,6 @@ div.org-settings-tabs {
     margin: 1px 24px 0px 0px;
     border-bottom: 1px solid transparent;
 
-    a.qsg-invite-team-3 {
-      position: relative;
-    }
-
     a.org-settings-tab-link {
       display: block;
       width: auto;

--- a/scss/partials/_qsg_breadcrumb.scss
+++ b/scss/partials/_qsg_breadcrumb.scss
@@ -10,41 +10,41 @@ div.qsg-breadcrumb {
   transition: opacity 180ms;
   opacity: 0;
 
-  &.profile-photo-1, &.company-logo-1 {
+  // Top of dropdown menu button
+  &.profile-photo-1, &.company-logo-1, &.invite-team-1, &.create-reminder-1{
     animation: topSwing .8s infinite linear;
     top: 50px;
   }
 
-  &.profile-photo-2, &.company-logo-2 {
+  // Inside dropdown menu
+  &.profile-photo-2, &.company-logo-2, &.invite-team-2, &.create-reminder-2 {
     left: -37px;
     animation: leftSwing .8s infinite linear;
     top: 8px;
   }
 
+  // Org settings panel
+  &.invite-team-3 {
+    top: -12px;
+    right: -32px;
+    animation: rightSwing .8s infinite linear;
+  }
+
+  // Prg settings and profile settings
   &.profile-photo-3, &.company-logo-3,  {
     animation: leftSwing .8s infinite linear;
     left: -37px;
     top: 8px;
   }
 
-  &.invite-team-1 {
-    animation: leftSwing .8s infinite linear;
-    left: -37px;
-    top: 0;
-  }
-
+  // New button
   &.create-post-1 {
     animation: leftSwing .8s infinite linear;
     left: -37px;
     top: 4px;
   }
 
-  &.create-reminder-1 {
-    animation: leftSwing .8s infinite linear;
-    left: -37px;
-    top: 0;
-  }
-
+  // Navigation sidebar plus button
   &.add-section-1 {
     animation: rightSwing .8s infinite linear;
     right: -38px;

--- a/scss/partials/_qsg_breadcrumb.scss
+++ b/scss/partials/_qsg_breadcrumb.scss
@@ -23,13 +23,6 @@ div.qsg-breadcrumb {
     top: 8px;
   }
 
-  // Org settings panel
-  &.invite-team-3 {
-    top: -12px;
-    right: -32px;
-    animation: rightSwing .8s infinite linear;
-  }
-
   // Prg settings and profile settings
   &.profile-photo-3, &.company-logo-3,  {
     animation: leftSwing .8s infinite linear;

--- a/src/oc/web/actions/qsg.cljs
+++ b/src/oc/web/actions/qsg.cljs
@@ -133,6 +133,9 @@
 (defn start-invite-team-trail []
   (dis/dispatch! [:qsg-invite-team :invite-team-1]))
 
+(defn next-invite-team-trail []
+  (dis/dispatch! [:qsg-invite-team]))
+
 (defn finish-invite-team-trail []
   (dis/dispatch! [:qsg-invite-team :invited?])
   (update-qsg-checklist))
@@ -150,6 +153,9 @@
 
 (defn start-create-reminder-trail []
   (dis/dispatch! [:qsg-create-reminder :create-reminder-1]))
+
+(defn next-create-reminder-trail []
+  (dis/dispatch! [:qsg-create-reminder]))
 
 (defn finish-create-reminder-trail []
   (dis/dispatch! [:qsg-create-reminder :add-reminder?])

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -9,7 +9,6 @@
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
             [oc.web.mixins.ui :as ui-mixins]
-            [oc.web.actions.qsg :as qsg-actions]
             [oc.web.actions.nux :as nux-actions]
             [oc.web.components.ui.menu :as menu]
             [oc.web.lib.responsive :as responsive]
@@ -126,9 +125,7 @@
       {:class (utils/class-set {:show-mobile-boards-menu mobile-navigation-sidebar})
        :style {:left (when-not is-mobile?
                       (str (/ (- @(::window-width s) 952 (when showing-qsg 220)) 2) "px"))
-               :overflow (when (or (= (:step qsg-data) :invite-team-1)
-                                   (= (:step qsg-data) :create-reminder-1)
-                                   (= (:step qsg-data) :add-section-1))
+               :overflow (when (= (:step qsg-data) :add-section-1)
                            "visible")}}
       [:div.mobile-header-container
         [:button.mlb-reset.mobile-header-close
@@ -235,7 +232,6 @@
         (when show-reminders?
           [:button.mlb-reset.bottom-nav-bt
             {:on-click #(do
-                          (qsg-actions/finish-create-reminder-trail)
                           (nav-actions/show-reminders)
                           (utils/after 500 utils/remove-tooltips))
              :title "Set reminders to update your team on time"
@@ -243,12 +239,10 @@
              :data-placement "top"
              :data-container "body"
              :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"}
-            (when (= (:step qsg-data) :create-reminder-1)
-              (qsg-breadcrumb qsg-data))
             [:div.bottom-nav-icon.reminders-icon]
             [:span "Reminders"]])
         (when show-invite-people
-          [:button.mlb-reset.bottom-nav-bt.qsg-invite-team-1
+          [:button.mlb-reset.bottom-nav-bt
             {:on-click #(do
                           (nav-actions/show-invite)
                           (utils/after 500 utils/remove-tooltips))
@@ -257,8 +251,6 @@
              :data-placement "top"
              :data-container "body"
              :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"}
-            (when (= (:step qsg-data) :invite-team-1)
-              (qsg-breadcrumb qsg-data))
             [:div.bottom-nav-icon.invite-people-icon]
             [:span "Invite team"]])
         [:button.mlb-reset.bottom-nav-bt

--- a/src/oc/web/components/org_settings.cljs
+++ b/src/oc/web/components/org_settings.cljs
@@ -18,6 +18,7 @@
             [oc.web.components.ui.alert-modal :as alert-modal]
             [oc.web.components.ui.org-avatar :refer (org-avatar)]
             [oc.web.actions.notifications :as notification-actions]
+            [oc.web.components.ui.qsg-breadcrumb :refer (qsg-breadcrumb)]
             [oc.web.components.ui.org-settings-main-panel :refer (org-settings-main-panel)]
             [oc.web.components.ui.org-settings-team-panel :refer (org-settings-team-panel)]
             [oc.web.components.ui.org-settings-invite-panel :refer (org-settings-invite-panel)]))

--- a/src/oc/web/components/org_settings.cljs
+++ b/src/oc/web/components/org_settings.cljs
@@ -18,7 +18,6 @@
             [oc.web.components.ui.alert-modal :as alert-modal]
             [oc.web.components.ui.org-avatar :refer (org-avatar)]
             [oc.web.actions.notifications :as notification-actions]
-            [oc.web.components.ui.qsg-breadcrumb :refer (qsg-breadcrumb)]
             [oc.web.components.ui.org-settings-main-panel :refer (org-settings-main-panel)]
             [oc.web.components.ui.org-settings-team-panel :refer (org-settings-team-panel)]
             [oc.web.components.ui.org-settings-invite-panel :refer (org-settings-invite-panel)]))
@@ -32,7 +31,7 @@
   (dis/dispatch! [:input [:org-settings] nil]))
 
 (rum/defc org-settings-tabs
-  [org-data active-tab qsg-data]
+  [org-data active-tab]
   [:div.org-settings-tabs.group
     [:div.org-settings-bottom-line]
     (when (utils/is-admin? org-data)
@@ -52,14 +51,11 @@
     (when (utils/is-admin-or-author? org-data)
       [:div.org-settings-tab
         {:class (when (= :invite active-tab) "active")}
-        [:a.org-settings-tab-link.qsg-invite-team-3
+        [:a.org-settings-tab-link
           {:href "#"
            :on-click (fn [e]
                        (utils/event-stop e)
-                       (qsg-actions/finish-invite-team-trail)
                        (show-modal :invite))}
-          (when (= (:step qsg-data) :invite-team-3)
-            (qsg-breadcrumb qsg-data))
           "INVITE PEOPLE"]])])
 
 (defn close-clicked [s]
@@ -190,7 +186,7 @@
               (org-avatar org-data-for-avatar false :never)]
             [:div.org-name (:name org-data)]
             [:div.org-url (str ls/web-server "/" (:slug org-data))]]
-          (org-settings-tabs org-data settings-tab qsg-data)
+          (org-settings-tabs org-data settings-tab)
           (case settings-tab
             :team
             (org-settings-team-panel org-data)

--- a/src/oc/web/components/org_settings.cljs
+++ b/src/oc/web/components/org_settings.cljs
@@ -7,10 +7,10 @@
             [oc.web.urls :as oc-urls]
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
-            [oc.web.actions.qsg :as qsg-actions]
             [oc.web.local-settings :as ls]
             [oc.web.lib.image-upload :as iu]
             [oc.web.utils.org :as org-utils]
+            [oc.web.actions.qsg :as qsg-actions]
             [oc.web.actions.org :as org-actions]
             [oc.web.actions.team :as team-actions]
             [oc.web.mixins.ui :refer (no-scroll-mixin)]
@@ -32,7 +32,7 @@
   (dis/dispatch! [:input [:org-settings] nil]))
 
 (rum/defc org-settings-tabs
-  [org-data active-tab]
+  [org-data active-tab qsg-data]
   [:div.org-settings-tabs.group
     [:div.org-settings-bottom-line]
     (when (utils/is-admin? org-data)
@@ -52,9 +52,14 @@
     (when (utils/is-admin-or-author? org-data)
       [:div.org-settings-tab
         {:class (when (= :invite active-tab) "active")}
-        [:a.org-settings-tab-link
+        [:a.org-settings-tab-link.qsg-invite-team-3
           {:href "#"
-           :on-click #(do (utils/event-stop %) (show-modal :invite))}
+           :on-click (fn [e]
+                       (utils/event-stop e)
+                       (qsg-actions/finish-invite-team-trail)
+                       (show-modal :invite))}
+          (when (= (:step qsg-data) :invite-team-3)
+            (qsg-breadcrumb qsg-data))
           "INVITE PEOPLE"]])])
 
 (defn close-clicked [s]
@@ -185,7 +190,7 @@
               (org-avatar org-data-for-avatar false :never)]
             [:div.org-name (:name org-data)]
             [:div.org-url (str ls/web-server "/" (:slug org-data))]]
-          (org-settings-tabs org-data settings-tab)
+          (org-settings-tabs org-data settings-tab qsg-data)
           (case settings-tab
             :team
             (org-settings-team-panel org-data)

--- a/src/oc/web/components/ui/menu.cljs
+++ b/src/oc/web/components/ui/menu.cljs
@@ -56,10 +56,11 @@
 
 (defn manage-team-click [e qsg-data]
   (.preventDefault e)
-  (when (= (:step qsg-data) :invite-team-2)
-    (qsg-actions/next-invite-team-trail))
-  (mobile-menu-toggle)
-  (utils/after (+ utils/oc-animation-duration 100) #(org-settings/show-modal :team)))
+  (let [invite-team-step? (= (:step qsg-data) :invite-team-2)]
+    (when invite-team-step?
+      (qsg-actions/finish-invite-team-trail))
+    (mobile-menu-toggle)
+    (utils/after (+ utils/oc-animation-duration 100) #(org-settings/show-modal (if invite-team-step? :invite :team)))))
 
 (defn sign-in-sign-up-click [e]
   (mobile-menu-toggle)

--- a/src/oc/web/components/ui/menu.cljs
+++ b/src/oc/web/components/ui/menu.cljs
@@ -30,13 +30,11 @@
   (dis/dispatch! [:input [:mobile-menu-open] false]))
 
 (defn logout-click [e]
-  ; (utils/event-stop e)
   (.preventDefault e)
   (mobile-menu-toggle)
   (jwt-actions/logout))
 
 (defn user-profile-click [e]
-  ; (utils/event-stop e)
   (.preventDefault e)
   (qsg-actions/next-profile-photo-trail)
   (if (responsive/is-tablet-or-mobile?)
@@ -45,21 +43,21 @@
   (mobile-menu-toggle))
 
 (defn notifications-settings-click [e]
-  ; (utils/event-stop e)
   (.preventDefault e)
   (mobile-menu-toggle)
   (utils/after (+ utils/oc-animation-duration 100) #(user-profile/show-modal :notifications)))
 
-(defn team-settings-click [e]
-  ; (utils/event-stop e)
+(defn team-settings-click [e qsg-data]
   (.preventDefault e)
-  (qsg-actions/next-company-logo-trail)
+  (when (= (:step qsg-data) :company-logo-2)
+    (qsg-actions/next-company-logo-trail))
   (mobile-menu-toggle)
   (utils/after (+ utils/oc-animation-duration 100) #(org-settings/show-modal :main)))
 
-(defn manage-team-click [e]
-  ; (utils/event-stop e)
+(defn manage-team-click [e qsg-data]
   (.preventDefault e)
+  (when (= (:step qsg-data) :invite-team-2)
+    (qsg-actions/next-invite-team-trail))
   (mobile-menu-toggle)
   (utils/after (+ utils/oc-animation-duration 100) #(org-settings/show-modal :team)))
 
@@ -77,9 +75,11 @@
   (.preventDefault e)
   (whats-new/show))
 
-(defn reminders-click [e]
-  (mobile-menu-toggle)
+(defn reminders-click [e qsg-data]
   (.preventDefault e)
+  (when (= (:step qsg-data) :create-reminder-2)
+    (qsg-actions/finish-create-reminder-trail))
+  (mobile-menu-toggle)
   (nav-actions/show-reminders))
 
 (rum/defcs menu < rum/reactive
@@ -134,9 +134,11 @@
           [:div.oc-menu-item.notifications-settings
             "Notification Settings"]])
       (when show-reminders?
-        [:a
+        [:a.qsg-create-reminder-2
           {:href "#"
-           :on-click reminders-click}
+           :on-click #(reminders-click % qsg-data)}
+          (when (= (:step qsg-data) :create-reminder-2)
+            (qsg-breadcrumb qsg-data))
           [:div.oc-menu-item.reminders
             "Reminders"]])
       [:div.oc-menu-separator]
@@ -148,9 +150,11 @@
       (when (and (not is-mobile?)
                  (router/current-org-slug)
                  (= user-role :admin))
-        [:a
+        [:a.qsg-invite-team-2
           {:href "#"
-           :on-click manage-team-click}
+           :on-click #(manage-team-click % qsg-data)}
+          (when (= (:step qsg-data) :invite-team-2)
+            (qsg-breadcrumb qsg-data))
           [:div.oc-menu-item.manage-team
             "Manage Team"]])
       (when (and (not is-mobile?)
@@ -158,7 +162,7 @@
                  (router/current-org-slug))
         [:a.qsg-company-logo-2
           {:href "#"
-           :on-click team-settings-click}
+           :on-click #(team-settings-click % qsg-data)}
           (when (= (:step qsg-data) :company-logo-2)
             (qsg-breadcrumb qsg-data))
           [:div.oc-menu-item.digest-settings

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -132,9 +132,11 @@
               (if (jwt/jwt)
                 [:div.group
                   (user-notifications)
-                  [:div.user-menu.qsg-profile-photo-1.qsg-company-logo-1
+                  [:div.user-menu.qsg-profile-photo-1.qsg-company-logo-1.qsg-invite-team-1.qsg-create-reminder-1
                     (when (or (= (:step qsg-data) :profile-photo-1)
-                              (= (:step qsg-data) :company-logo-1))
+                              (= (:step qsg-data) :company-logo-1)
+                              (= (:step qsg-data) :invite-team-1)
+                              (= (:step qsg-data) :create-reminder-1))
                       (qsg-breadcrumb qsg-data))
                     [:div
                       {:ref "user-menu"}
@@ -142,9 +144,16 @@
                        {:click-cb #(do
                                      (when (= (:step qsg-data) :profile-photo-1)
                                        (qsg-actions/next-profile-photo-trail))
+                                     (when (= (:step qsg-data) :invite-team-1)
+                                        (qsg-actions/next-invite-team-trail))
                                      (when (= (:step qsg-data) :company-logo-1)
                                        (qsg-actions/next-company-logo-trail))
-                                     (swap! (::expanded-user-menu s) not))})
+                                     (when (= (:step qsg-data) :create-reminder-1)
+                                       (qsg-actions/next-create-reminder-trail))
+                                     (swap! (::expanded-user-menu s) not)
+                                     ;; Dismiss the QSG tooltip is it's open
+                                     (when (:show-qsg-tooltip? qsg-data)
+                                       (qsg-actions/dismiss-qsg-tooltip)))})
                       (when (:show-qsg-tooltip? qsg-data)
                         [:div.qsg-tooltip-container.group
                           [:div.qsg-tooltip-top-arrow]

--- a/src/oc/web/components/ui/qsg_breadcrumb.cljs
+++ b/src/oc/web/components/ui/qsg_breadcrumb.cljs
@@ -33,13 +33,22 @@
                                   (= step :company-logo-3)
                                   (qsg-actions/reset-qsg)
                                   ;; Invite team
-                                  (= step :invite-team-1)
+                                  (and (= step :invite-team-1)
+                                       (not (utils/event-inside? e (sel1 :.qsg-invite-team-1))))
+                                  (qsg-actions/reset-qsg)
+                                  (and (= step :invite-team-2)
+                                       (not (utils/event-inside? e (sel1 :.qsg-invite-team-2))))
+                                  (qsg-actions/reset-qsg)
+                                  (= step :invite-team-3)
                                   (qsg-actions/reset-qsg)
                                   ;; Create post
                                   (= step :create-post-1)
                                   (qsg-actions/reset-qsg)
                                   ;; Create reminder
-                                  (= step :create-reminder-1)
+                                  (and (= step :create-reminder-1)
+                                       (not (utils/event-inside? e (sel1 :.qsg-create-reminder-1))))
+                                  (qsg-actions/reset-qsg)
+                                  (= step :create-reminder-3)
                                   (qsg-actions/reset-qsg)
                                   ;; Create section
                                   (= step :add-section-1)

--- a/src/oc/web/components/ui/qsg_breadcrumb.cljs
+++ b/src/oc/web/components/ui/qsg_breadcrumb.cljs
@@ -36,10 +36,7 @@
                                   (and (= step :invite-team-1)
                                        (not (utils/event-inside? e (sel1 :.qsg-invite-team-1))))
                                   (qsg-actions/reset-qsg)
-                                  (and (= step :invite-team-2)
-                                       (not (utils/event-inside? e (sel1 :.qsg-invite-team-2))))
-                                  (qsg-actions/reset-qsg)
-                                  (= step :invite-team-3)
+                                  (= step :invite-team-2)
                                   (qsg-actions/reset-qsg)
                                   ;; Create post
                                   (= step :create-post-1)

--- a/src/oc/web/stores/qsg.cljs
+++ b/src/oc/web/stores/qsg.cljs
@@ -118,9 +118,6 @@
     :invite-team-2
 
     :invite-team-2
-    :invite-team-3
-
-    :invite-team-3
     nil
 
     ;; default

--- a/src/oc/web/stores/qsg.cljs
+++ b/src/oc/web/stores/qsg.cljs
@@ -115,6 +115,12 @@
     :invite-team-1
 
     :invite-team-1
+    :invite-team-2
+
+    :invite-team-2
+    :invite-team-3
+
+    :invite-team-3
     nil
 
     ;; default
@@ -163,6 +169,9 @@
     :create-reminder-1
 
     :create-reminder-1
+    :create-reminder-2
+
+    :create-reminder-2
     nil
 
     ;; default


### PR DESCRIPTION
Card: https://trello.com/c/NXXqBbb7

To test:
- signup with a brand new company
- add a post (or do whatever you need to make the QSG appear)
- [x] invite team trail works? Good
- [x] it goes through Manage team instead of Settings? Good
- [x] when you land into the invite people panel the item is checked out in QSG? Good
- [x] check out reminders trail works? Good
- [x] when you open the reminders view from the menu the item is  checked out in QSG? Good
- now dismiss the QSG view
- [x] do you see the QSG tooltip? Good
- click on your icon to open the dropdown menu
- [x] the tooltip was dismissed? Good