### PR TITLE
Sections list scroll

### DIFF
--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -264,6 +264,18 @@ div.left-navigation-sidebar {
     }
   }
 
+  &.navigation-sidebar-overflow {
+    position: absolute;
+    overflow-x: unset;
+    overflow-y: unset;
+    overflow: auto;
+    height: auto;
+    max-height: unset;
+    top: unset;
+    left: unset;
+    float: left;
+  }
+
   div.mobile-header-container {
     display: none;
 
@@ -649,7 +661,7 @@ div.left-navigation-sidebar {
       }
     }
 
-    &.navigation-sidebar-overflow {
+    &.push-to-bottom {
       position: absolute;
       bottom: 23px;
       padding-bottom: 0px;


### PR DESCRIPTION
Card: https://trello.com/c/y90s90LF

To test:
- size you browser window to full height
- visit AP
- scroll the page
- [x] do you see the sections list fixed to the left? Good
- now resize the window to be very small in height (make sure all the sections list can't fit in it)
- scroll again
- [x] do you see the sections list that scrolls out of view with the rest of the page? Good
- now visit AP on mobile
- open the sections list
- [x] can you scroll and switch section as usual? Good