### PR TITLE
Publish post delay fix

### DIFF
--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -31,7 +31,7 @@
       (utils/clean-body-html (.-innerHTML body-el)))))
 
 (defn real-close []
-  (utils/after 180 activity-actions/cmail-hide))
+  (activity-actions/cmail-hide))
 
 ;; Local cache for outstanding edits
 

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -115,9 +115,8 @@
                     (if (= board-slug utils/default-drafts-board-slug)
                       #(not= (:status %) "published")
                       #(and (= (:board-slug %) board-slug)
-                                                   (= (:status %) "published"))))
-        board-posts (map :uuid (filter filter-fn posts-list))]
-    (select-keys posts-data board-posts)))
+                            (= (:status %) "published"))))]
+    (filter (comp filter-fn last) posts-data)))
 
 ;; Functions needed by derivatives
 


### PR DESCRIPTION
Card: https://trello.com/c/7yoQRSUJ

Bug: i found out that we had 2 bugs that were preventing a just published post from appearing in the list, this meant that you had to wait for the org and then AP/board data to be refreshed before seeing the post. This delay is longer if you have a lot of posts.

Fix: i fixed it and now the posts are added immediately to the list so you see the post appear briefly before Cmail closes.

To test:
- comment out src/oc/web/components/cmail.cljs:320~336
- go to AP
- click new and add title and body
- wait for autosave
- post
- [x] do you see the post appear in the list? Good
- now go to a board
- click new and add title and body
- wait for autosave
- post
- [x] do you see the post appear in the list? Good