### PR TITLE
Show less jumps fix

### DIFF
--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -290,7 +290,10 @@
             [:button.mlb-reset.expand-button
               {:class (when expanded? "expanded")
                :ref :expand-button
-               :on-click #(expand s (not expanded?))}
+               :on-click #(when-not expanded?
+                            (expand s true))
+               :on-mouse-down #(when expanded?
+                                (expand s false))}
               [:span.expand-icon]
               [:span.expand-label
                 (if expanded?


### PR DESCRIPTION
Card: https://trello.com/c/yFOWlAZq

To test:
- add a long post
- expand the post
- focus on add comment
- click on Show less
- [x] does the post gets collapsed back? Good
- before it was only removing the focus to the add comment field causing a jump in the view, but no collapse