### PR TITLE
Org settings multiple saves

### DIFF
--- a/src/oc/web/components/ui/org_settings_main_panel.cljs
+++ b/src/oc/web/components/ui/org_settings_main_panel.cljs
@@ -237,11 +237,9 @@
           {:disabled (or @(::saving s)
                          (:saved org-editing)
                          (not (:has-changes org-editing))
-                         (s/blank? (:name org-editing))
                          (< (count (s/trim (:name org-editing))) 3))
            :class (when (:saved org-editing) "no-disable")
-           :on-click #(do
-                        (reset! (::saving s) true)
+           :on-click #(when (compare-and-set! (::saving s) false true)
                         (org-actions/org-edit-save @(drv/get-ref s :org-editing)))}
           (if (:saved org-editing)
             "Saved!"


### PR DESCRIPTION
Card: https://trello.com/c/cvD1ripe

To test:
- open org settings
- change the org name
- rage click the Save button
- [x] do you see only one PATCH request to `/orgs/{org-slug}`? Good
- now change the name again
- [x] the save button is enabled again? Good
- now go to invite panel
- add an email in the field
- rage click on the invite button
- [x] do you see only one POST request to invite that email? Good
- add another valid email in the field
- [x] invite button become enabled again? Good