### PR TITLE
Section editor multiple save clicks

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -293,10 +293,9 @@
       (send-item-read (:uuid saved-activity-data)))))
 
 (defn board-name-exists-error [edit-key]
-  (dis/dispatch!
-   [:input
-    [edit-key :section-name-error]
-    utils/section-name-exists-error]))
+  (dis/dispatch! [:update [edit-key] #(-> %
+                                        (assoc :section-name-error utils/section-name-exists-error)
+                                        (dissoc :loading))]))
 
 (defn entry-modal-save [activity-data section-editing]
   (if (and (= (:board-slug activity-data) utils/default-section-slug)

--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -117,12 +117,13 @@
 
 (defn section-name-error [status]
   ;; Board name exists or too short
-  (dispatcher/dispatch!
-   [:input
-    [:section-editing :section-name-error]
-    (cond
-      (= status 409) "Section name already exists or isn't allowed"
-      :else "An error occurred, please retry.")]))
+  (dispatcher/dispatch! [:update [:section-editing]
+   #(-> %
+     (assoc :section-name-error
+      (cond
+        (= status 409) "Section name already exists or isn't allowed"
+        :else "An error occurred, please retry."))
+     (dissoc :loading))]))
 
 (defn section-save
   ([section-data note] (section-save section-data note nil))
@@ -242,6 +243,7 @@
   (if (< (count section-name) min-section-name-length)
     (dispatcher/dispatch! [:section-edit/error (str "Name must be at least " min-section-name-length " characters.")])
     (let [next-section-editing (merge section-editing {:slug utils/default-section-slug
+                                                       :loading true
                                                        :name section-name})]
       (dispatcher/dispatch! [:input [:section-editing] next-section-editing])
       (success-cb next-section-editing))))

--- a/src/oc/web/stores/activity.cljs
+++ b/src/oc/web/stores/activity.cljs
@@ -83,7 +83,9 @@
   (assoc-in db [edit-key :publishing] true))
 
 (defmethod dispatcher/action :section-edit/error [db [_ error]]
-  (assoc-in db [:section-editing :section-name-error] error))
+  (-> db
+    (assoc-in [:section-editing :section-name-error] error)
+    (update-in [:section-editing] dissoc :loading)))
 
 (defmethod dispatcher/action :entry-publish-with-board/finish
   [db [_ new-board-data edit-key]]


### PR DESCRIPTION
Card: https://trello.com/c/zipqWPVU

To test:
- click + to add a new section
- add a name and wait for preflight to check ok
- rage click the Done button
- [x] do you see only one POST request? Good
- [x] do you see only one section created in the left navbar? Good
- now go to a section
- click the COG
- change the section name
- rage click the Save button
- [x] do you see only one PATCH request? Good
- now click the + to add a new section
- add a name and wait for preflight to check it ok
- now stop Storage service
- click the Done button
- [x] do you see an error? Good
- now restart the Storage service and wait for it to come up
- change the section name
- [x] do you see the Done button enabled again when preflight finishes? Good