### PR TITLE
Fix page white band

### DIFF
--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -265,7 +265,7 @@ div.left-navigation-sidebar {
   }
 
   &.navigation-sidebar-overflow {
-    position: absolute;
+    position: relative;
     overflow-x: unset;
     overflow-y: unset;
     overflow: auto;

--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -235,13 +235,13 @@
 div.left-navigation-sidebar {
   position: absolute;
   position: fixed;
-  max-height: calc(100vh - 96px);
+  max-height: calc(100vh - 90px);
   overflow-y: auto;
   overflow-x: visible;
   padding-bottom: 20px;
   width: #{$left_navigation_sidebar_width}px;
-  top: 96px;
-  height: calc(100vh - 80px);
+  top: 90px;
+  height: calc(100vh - 90px);
   @include no-user-select();
 
   @include mobile() {
@@ -258,6 +258,7 @@ div.left-navigation-sidebar {
     height: unset;
     overflow-y: unset;
     overflow-x: unset;
+    padding-bottom: 0;
 
     &.show-mobile-boards-menu {
       display: block;

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -123,7 +123,8 @@
         showing-qsg (:visible qsg-data)]
     [:div.left-navigation-sidebar.group
       {:class (utils/class-set {:show-mobile-boards-menu mobile-navigation-sidebar
-                                :navigation-sidebar-overflow (not is-tall-enough?)})
+                                :navigation-sidebar-overflow (and (not is-mobile?)
+                                                                  (not is-tall-enough?))})
        :style {:left (when (and (not is-mobile?)
                                 is-tall-enough?)
                       (str (/ (- @(::window-width s) 952 (when showing-qsg 220)) 2) "px"))

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -124,7 +124,8 @@
     [:div.left-navigation-sidebar.group
       {:class (utils/class-set {:show-mobile-boards-menu mobile-navigation-sidebar
                                 :navigation-sidebar-overflow (not is-tall-enough?)})
-       :style {:left (when-not is-mobile?
+       :style {:left (when (and (not is-mobile?)
+                                is-tall-enough?)
                       (str (/ (- @(::window-width s) 952 (when showing-qsg 220)) 2) "px"))
                :overflow (when (= (:step qsg-data) :add-section-1)
                            "visible")}}


### PR DESCRIPTION
Card: https://trello.com/c/EG1bL939

BUG: if you have a lot of sections, go to an empty one and resize the browser window to not be tall enough to fit all the sections list you see a white band at the bottom if you scroll down.

<img src="https://user-images.githubusercontent.com/642704/54610732-e53a7580-4a55-11e9-92c4-a90463633c8a.png" width="500">

This fixes the above issue for desktop by setting the left navigation bar to relative positioning.

To test:
- use an org with ~10 sections
- nav to an empty section
- with full height browser window (make sure the left navigation bar is completely visible and fixed, doesn't scroll with the page)
- [x] everything good? Good
- [x] invite, reminders and support buttons are at the bottom of the page? Good
- now resize the window so the left navigation bar has not enough space to be totally visible
- [x] while resizing do you NOT see the top of the navigation bar moving? Good
- [x] once resized, if you scroll down to the bottom of the page do you NOT see a white bad? Good
- now switch to mobile and refresh
- open the navigation menu
- [x] everything good? Good

