### PR TITLE
Section settings Slack prompt

### DIFF
--- a/scss/partials/_section_editor.scss
+++ b/scss/partials/_section_editor.scss
@@ -267,6 +267,28 @@ div.section-editor-container {
         }
       }
 
+      div.section-editor-enable-slack-bot {
+        margin-top: 8px;
+        @include avenir_R();
+        font-size: 13px;
+        color: $deep_navy;
+        height: 24px;
+        line-height: 24px;
+
+        button.enable-slack-bot-bt {
+          color: $carrot_green;
+          display: inline;
+          padding: 0;
+          margin-left: 8px;
+
+          @include big_web() {
+            &:hover {
+              text-decoration: underline;
+            }
+          }
+        }
+      }
+
       div.section-editor-access-public-description {
         @include avenir_R();
         font-size: 14px;

--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -248,7 +248,7 @@
                        (pos? (count slack-users))
                        (pos? (count slack-orgs)))
               [:div.section-editor-enable-slack-bot.group
-                "Want to automatically share to Slack?"
+                "Automatically share posts to Slack?"
                 [:button.mlb-reset.enable-slack-bot-bt
                   {:on-click (fn [_]
                                (org-actions/bot-auth team-data cur-user-data (router/get-token)))}

--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -4,10 +4,12 @@
             [cuerdas.core :as string]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.lib.jwt :as jwt]
+            [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.mixins.ui :as mixins]
             [oc.web.actions.qsg :as qsg-actions]
+            [oc.web.actions.org :as org-actions]
             [oc.web.actions.section :as section-actions]
             [oc.web.components.org-settings :as org-settings]
             [oc.web.mixins.ui :refer (on-window-click-mixin)]
@@ -119,6 +121,7 @@
                             (drv/drv :team-data)
                             (drv/drv :team-channels)
                             (drv/drv :team-roster)
+                            (drv/drv :current-user-data)
                             {:will-mount (fn [s]
                               (let [initial-section-data (first (:rum/args s))
                                     new-section (nil? initial-section-data)
@@ -156,6 +159,9 @@
         show-slack-channels? (pos? (apply + (map #(-> % :channels count) slack-teams)))
         channel-name (when @(::editing-existing-section s) (:channel-name (:slack-mirror section-data)))
         roster (drv/react s :team-roster)
+        slack-orgs (:slack-orgs team-data)
+        cur-user-data (drv/react s :current-user-data)
+        slack-users (:slack-users cur-user-data)
         current-user-id (jwt/user-id)
         ;; user can edit the private section users if
         ;; he's creating a new section
@@ -214,16 +220,18 @@
           (when show-slack-channels?
             [:div.section-editor-add-label
               "Auto-share to Slack"
-              [:span.info]
-              (carrot-checkbox {:selected @(::slack-enabled s)
-                                :did-change-cb #(do
-                                                  (reset! (::slack-enabled s) %)
-                                                  (when-not %
-                                                    (dis/dispatch!
-                                                     [:input
-                                                      [:section-editing :slack-mirror]
-                                                      nil])))})])
-          (when show-slack-channels?
+              (when show-slack-channels?
+                [:span.info])
+              (when show-slack-channels?
+                (carrot-checkbox {:selected @(::slack-enabled s)
+                                  :did-change-cb #(do
+                                                    (reset! (::slack-enabled s) %)
+                                                    (when-not %
+                                                      (dis/dispatch!
+                                                       [:input
+                                                        [:section-editing :slack-mirror]
+                                                        nil])))}))])
+          (if show-slack-channels?
             [:div.section-editor-add-slack-channel.group
               {:class (when-not @(::slack-enabled s) "disabled")}
               (slack-channels-dropdown {:initial-value (when channel-name (str "#" channel-name))
@@ -233,7 +241,18 @@
                                                        [:section-editing :slack-mirror]
                                                        {:channel-id (:id channel)
                                                         :channel-name (:name channel)
-                                                        :slack-org-id (:slack-org-id team)}]))})])
+                                                        :slack-org-id (:slack-org-id team)}]))})]
+            ;; If they don't have bot installed already but have slack org associated to the team
+            ;; and user has a slack user (if not they can't add the bot) let's prompt to add the bot
+            (when (and (not (jwt/team-has-bot? (:team-id team-data)))
+                       (pos? (count slack-users))
+                       (pos? (count slack-orgs)))
+              [:div.section-editor-enable-slack-bot.group
+                "Want to automatically share to Slack?"
+                [:button.mlb-reset.enable-slack-bot-bt
+                  {:on-click (fn [_]
+                               (org-actions/bot-auth team-data cur-user-data (router/get-token)))}
+                  "Add Carrot bot"]]))
           [:div.section-editor-add-label
             "Who can view this section?"]
           [:div.section-editor-add-access


### PR DESCRIPTION
Card: https://trello.com/c/H547XlW5

To test:
- signup for a new org via email
- go to section COG
- [x] do you NOT see a prompt to add a bot? Good
- signup with Slack for a new org
- do NOT add bot
- click + to add a new section
- [x] do you see the prompt to add bot to autoshare? Good
- now nav to a section
- click settings COG
- [x] do you see the same prompt? Good
- now invite someone via email
- signup with the email user
- [x] do you NOT see the same prompt? Good (user w/o a Slack user can't add bot directly)
- go back to the previous Slack user
- go to section COG
- click Add Carrot bot button
- [x] did it work? Good
- [x] no more prompt in section settings? Good
- [x] do you see the auto-share option now? Good
