### PR TITLE
Fix horizontal scrolling

### DIFF
--- a/scss/partials/_shared_misc.scss
+++ b/scss/partials/_shared_misc.scss
@@ -130,7 +130,7 @@ section.testimonials-section {
   &:before {
     content: "";
     position: absolute;
-    width: 100vw;
+    width: 100%;
     height: 100%;
     background-color: $another_ui_grey;
     top: 0;
@@ -667,7 +667,8 @@ section.home-keep-aligned {
           height: 1006px;
           position: absolute;
           left: 0;
-          width: 100vw;
+          width: calc(100vw - 16px);
+          padding-right: 16px;
           max-width: initial;
         }
 
@@ -1233,7 +1234,7 @@ div.animation-lightbox-container {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   background-color: $carrot_modal_bg;
   text-align: center;
@@ -1241,7 +1242,7 @@ div.animation-lightbox-container {
   display: none;
 
   div.animation-lightbox {
-    width: 100vw;
+    width: 100%;
     height: 100vh;
     max-width: 1080px;
     max-height: 608px;

--- a/scss/partials/_site_header.scss
+++ b/scss/partials/_site_header.scss
@@ -40,7 +40,7 @@ span.go-to-digest {
 nav.site-navbar {
   height: 64px;
   position: fixed;
-  width: 100vw;
+  width: 100%;
   z-index: 100;
   background-color: transparent;
   border-bottom: 1px solid transparent;
@@ -175,7 +175,7 @@ nav.site-navbar {
     margin: 0 auto;
 
     @include tablet() {
-      width: 100vw;
+      width: 100%;
       padding: 22px 24px;
       height: 72px;
     }


### PR DESCRIPTION
Card: https://trello.com/c/4uEWSNWU

BUG: if you check `always` the _Show scroll bars_ settings in MacOS General panel you see the homepage (and probably /slack) page scrolling horizontally. That's because 100vw needs to be used for the slack/email digest horizontal scroll on tablet and mobile layout. 100vw doesn't count for possible scroll bars, since the vertical scroll bar is always visible 100vw of that view is exceeding the maximum window width that is 100 viewport width - width of the vertical scroll bar.

FIX: i removed all the 100vw that were no needed except one (the one explained above), for that i had to set it to `calc(100vw - 16px)` that shows a small problem when the scroll bars are not shown (check the right side of the image below, you'll see the scrolling images doesn't touch the right end of the page):
<img src="https://user-images.githubusercontent.com/642704/55018682-aa0aea00-4ff3-11e9-99f3-a1c61262fd45.png" width="300">

To test:
- turn to `always` the _Show scroll bars_ settings
- go to homepage 
- [x] no horizontal scroll on desktop layout? Good
- [x] no horizontal scroll on tablet layout? Good
- [x] no horizontal scroll on mobile layout? Good
- [x] repeat for slack landing
- now detach your mouse and use a track pad (if you can), turn the _Show scroll bars_ settings to `Automatically based on mouse or trackpad`
- go to homepage 
- [x] no horizontal scroll on desktop layout? Good
- [x] no horizontal scroll on tablet layout? Good
- [x] no horizontal scroll on mobile layout? Good
- [x] repeat for slack landing