### PR TITLE
Tablet navigation fix

### DIFF
--- a/scss/partials/_navigation_sidebar.scss
+++ b/scss/partials/_navigation_sidebar.scss
@@ -275,6 +275,7 @@ div.left-navigation-sidebar {
     top: unset;
     left: unset;
     float: left;
+    min-height: calc(100vh - 90px);
   }
 
   div.mobile-header-container {

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -142,7 +142,8 @@
         is-all-posts (utils/in? (:route route) "all-posts")
         is-must-see (utils/in? (:route route) "must-see")
         current-activity-id (router/current-activity-id)
-        is-mobile? (responsive/is-tablet-or-mobile?)
+        is-tablet-or-mobile? (responsive/is-tablet-or-mobile?)
+        is-mobile? (responsive/is-mobile-size?)
         empty-board? (zero? (count posts-data))
         is-drafts-board (= (:slug board-data) utils/default-drafts-board-slug)
         all-boards (drv/react s :editable-boards)
@@ -168,7 +169,7 @@
             (navigation-sidebar))
           ;; Show the board always on desktop and
           ;; on mobile only when the navigation menu is not visible
-          (when (or (not is-mobile?)
+          (when (or (not is-tablet-or-mobile?)
                     (not mobile-navigation-sidebar))
             [:div.board-container.group
               ;; Board name row: board name, settings button and say something button
@@ -213,7 +214,7 @@
                     [:div.board-settings-container
                       ;; Settings button
                       [:button.mlb-reset.board-settings-bt
-                        {:data-toggle (when-not is-mobile? "tooltip")
+                        {:data-toggle (when-not is-tablet-or-mobile? "tooltip")
                          :data-placement "top"
                          :data-container "body"
                          :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"
@@ -266,7 +267,7 @@
                                      (activity-actions/activity-edit {:board-slug (:value item)
                                                                       :board-name (:label item)}))}))])
                 ;; Commenting out grid view switcher for now
-                ; (when-not is-mobile?
+                ; (when-not is-tablet-or-mobile?
                 ;   [:div.board-switcher.group
                 ;     (let [grid-view? (= @board-switch :grid)]
                 ;       [:button.mlb-reset.board-switcher-bt
@@ -340,7 +341,7 @@
                   (section-stream)))
               ;; Add entry floating button
               (when can-compose
-                (let [opacity (if is-mobile?
+                (let [opacity (if is-tablet-or-mobile?
                                 0
                                 (calc-opacity (document-scroll-top)))]
                   [:div.new-post-floating-dropdown-container.group
@@ -351,7 +352,7 @@
                     [:button.mlb-reset.mlb-default.add-to-board-floating-button.qsg-create-post-1
                       {:data-placement "left"
                        :data-container "body"
-                       :data-toggle (when-not is-mobile? "tooltip")
+                       :data-toggle (when-not is-tablet-or-mobile? "tooltip")
                        :title "Start a new post"
                        :data-delay "{\"show\":\"500\", \"hide\":\"0\"}"
                        :on-click #(ui-compose @(drv/get-ref s :show-add-post-tooltip))}

--- a/src/oc/web/components/navigation_sidebar.cljs
+++ b/src/oc/web/components/navigation_sidebar.cljs
@@ -113,20 +113,24 @@
         is-admin-or-author? (utils/is-admin-or-author? org-data)
         show-invite-people (and org-slug
                                 is-admin-or-author?)
+        is-mobile? (responsive/is-mobile-size?)
         is-tall-enough? (or (not @(::content-height s))
                             (not @(::footer-height s))
                             (not (neg?
                              (- @(::window-height s) sidebar-top-margin @(::content-height s) @(::footer-height s)))))
-        is-mobile? (responsive/is-tablet-or-mobile?)
+        is-wide-enough? (pos? (- @(::window-width s) 980))
+        window-overflow? (and (not is-mobile?)
+                              (or (not is-tall-enough?)
+                                  (not is-wide-enough?)))
         show-reminders? (utils/link-for (:links org-data) "reminders")
         qsg-data (drv/react s :qsg)
         showing-qsg (:visible qsg-data)]
     [:div.left-navigation-sidebar.group
       {:class (utils/class-set {:show-mobile-boards-menu mobile-navigation-sidebar
-                                :navigation-sidebar-overflow (and (not is-mobile?)
-                                                                  (not is-tall-enough?))})
+                                :navigation-sidebar-overflow window-overflow?})
        :style {:left (when (and (not is-mobile?)
-                                is-tall-enough?)
+                                is-tall-enough?
+                                is-wide-enough?)
                       (str (/ (- @(::window-width s) 952 (when showing-qsg 220)) 2) "px"))
                :overflow (when (= (:step qsg-data) :add-section-1)
                            "visible")}}


### PR DESCRIPTION
Card: https://trello.com/c/bIOg3nld

BUG: on tablet window size (with btw 768 and 980 pixels) we remove the navigation sidebar but don't show the mobile navigation too so users are left in a limbo.

Fix: show the navigation sidebar to all tablets too, make sure the navigation sidebar has no fixed positioning when the screen is not wide enough: needed to avoid getting the stream of posts scroll above the navigation sidebar horizontally.

To test:
- use an org with at least 10 sections
- big web 1280x950
- [x] do you see the navigation sidebar? Good
- [x] can you see the bottom of the sidebar? Good
- [x] can you NOT see a horizontal scroll? Good
- big web with short height win 1280x600
- [x] do you see the navigation sidebar? Good
- [x] can you see the bottom of the sidebar? Good
- [x] can you NOT see a horizontal scroll? Good
- tablet portrait 768x1024
- [x] do you see the navigation sidebar? Good
- [x] do you see the nav sidebar scrolling out of view when you scroll horizontally? Good
- [x] can you see the bottom of the sidebar? Good
- [x] can you see a horizontal scroll? Good
- tablet landscape 768x1024
- [x] do you see the navigation sidebar? Good
- [x] can you see the bottom of the sidebar? Good
- [x] can you NOT see a horizontal scroll? Good
- tablet small screen 768x768
- [x] do you see the navigation sidebar? Good
- [x] do you see the nav sidebar scrolling out of view when you scroll horizontally? Good
- [x] can you see the bottom of the sidebar? Good
- [x] can you see a horizontal scroll? Good
- mobile 
- [x] do you NOT see the navigation sidebar? Good
- [x] do you see the ham button in top left corner? Good
- [x] can you open the sections list? Good
- [x] can you scroll to the bottom of it? Good
- [x] search button works? Good
- [x] notifications button works? Good
- [x] plus button works? Good
- merge 🎉 🎉 🎉 🎉