### PR TITLE
Notification light theme

### DIFF
--- a/scss/partials/_notifications.scss
+++ b/scss/partials/_notifications.scss
@@ -38,9 +38,40 @@ div.notifications {
       }
 
       button.notification-dismiss-bt {
-        // background-image: cdnUrl("/img/ML/close_notification_black.svg");
-        content: "Ok";
         color: white;
+      }
+    }
+
+    @include big_web() {
+      &:not(.server-error).light-theme {
+        background-color: white;
+
+        span.slack-icon {
+          background-image: cdnUrl("/img/ML/slack_normal.svg");
+        }
+
+        div.notification-title {
+          color: $light_navy;
+        }
+
+        div.notification-description {
+          color: $light_navy;
+
+          &.oc-mentions span.oc-mention[data-found="true"] {
+            color: $light_navy;
+          }
+        }
+
+        button.notification-button {
+          &.solid-green {
+            color: $carrot_green;
+            background-color: $feint_emerald;
+          }
+
+          &.default-link {
+            color: $light_navy;
+          }
+        }
       }
     }
 
@@ -130,11 +161,6 @@ div.notifications {
       height: 24px;
       padding: 0;
       margin: 0;
-      // background-size: 12px 12px;
-      // background-image: cdnUrl("/img/ML/close_notification_white.svg");
-      // background-position: center;
-      // background-repeat: no-repeat;
-      content: "Ok";
       color: $carrot_green;
     }
 

--- a/src/oc/web/components/ui/notifications.cljs
+++ b/src/oc/web/components/ui/notifications.cljs
@@ -62,12 +62,14 @@
              primary-bt-cb primary-bt-title primary-bt-style primary-bt-dismiss
              primary-bt-inline secondary-bt-cb secondary-bt-title secondary-bt-style
              secondary-bt-dismiss app-update slack-bot mention mention-author
-             click] :as notification-data}]
+             click] :as notification-data}
+      light-theme]
   [:div.notification.group
     {:class (utils/class-set {:server-error server-error
                               :app-update app-update
                               :slack-bot slack-bot
                               :opac opac
+                              :light-theme light-theme
                               :mention-notification (and mention mention-author)
                               :inline-bt (or primary-bt-inline
                                              (and id
@@ -112,9 +114,27 @@
 (rum/defcs notifications < rum/static
                            rum/reactive
                            (drv/drv :notifications-data)
+                           (drv/drv :expanded-user-menu)
+                           (drv/drv :org-settings)
+                           (drv/drv :user-settings)
+                           (drv/drv :show-reminders)
+                           (drv/drv :show-section-add)
+                           (drv/drv :show-section-editor)
   [s]
-  (let [notifications-data (drv/react s :notifications-data)]
+  (let [notifications-data (drv/react s :notifications-data)
+        expanded-user-menu (drv/react s :expanded-user-menu)
+        org-settings (drv/react s :org-settings)
+        user-settings (drv/react s :user-settings)
+        show-reminders (drv/react s :show-reminders)
+        show-section-editor (drv/react s :show-section-editor)
+        show-section-add (drv/react s :show-section-add)
+        light-theme (or expanded-user-menu
+                        org-settings
+                        user-settings
+                        show-reminders
+                        show-section-editor
+                        show-section-add)]
     [:div.notifications
       (for [idx (range (count notifications-data))
             :let [n (nth notifications-data idx)]]
-        (rum/with-key (notification n) (str "notif-" (:id n))))]))
+        (rum/with-key (notification n light-theme) (str "notif-" (:id n))))]))


### PR DESCRIPTION
Card: https://trello.com/c/TwWjv2jC

To test:
- open carrot
- open console
- run: `oc.web.actions.notifications.show_notification(cljs.core.merge(oc.web.lib.utils.app_update_error, clojure.walk.keywordize_keys(cljs.core.js__GT_clj({"expire": 0, "title": "Test", "description": "Test here too", "id": cljs.core.keyword("hello-there")}))))`
- before dismissing the notification
- open the menu
- [x] do you see the notification turning light on dark? Good
- close the menu
- [x] do you see it turning back to dark on light? Good
- [x] check it stays light when you open reminders
- [x] check it stays light when you open org settings
- [x] check it stays light when you open user settings
- [x] check it stays light when you open reminders
- [x] check it turns light when you open section settings
- [x] check it turns light when you open add a section
- now dismiss the notification
- go to user settings
- change your avatar
- [x] notification is light? Good
- [x] repeat with org icon