### PR TITLE
Fix share popup position.

### DIFF
--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -84,13 +84,6 @@ div.stream-item {
     }
   }  
 
-  div.activity-share-container {
-    div.activity-share-modal-container {
-      right: -9px;
-      margin-top: 0;
-    }
-  }
-
   div.stream-item-header {
     position: relative;
 
@@ -579,6 +572,13 @@ div.stream-item {
       @include mobile() {
         margin-top: 16px;
         height: 24px;
+      }
+    }
+
+    div.activity-share-container {
+      div.activity-share-modal-container {
+        right: -9px;
+        margin-top: -280px;
       }
     }
 

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -161,7 +161,6 @@
                              (not is-mobile?))
                    (activity-actions/activity-edit activity-data))
        :id dom-element-id}
-      [:div.activity-share-container]
       [:div.stream-item-header.group
         [:div.stream-header-head-author
           (user-avatar-image publisher)
@@ -311,6 +310,7 @@
                 (if expanded?
                   "Show less"
                   "Show more")]]
+            [:div.activity-share-container]
             (when (and is-published?
                        (not is-mobile?))
               (more-menu activity-data dom-element-id


### PR DESCRIPTION
Card: https://trello.com/c/9pIHPcTn

To test:
- open big web to All Posts
- click Share on a few posts
- [x] do you always see the popup in the right position? Good
- now get the link of a short post (only a few line of body)
- open the link
- click share at the bottom
- [x] do you see the share popup? Good
- now get the link of a long post (lots of test maybe an image or video embedded)
- open it
- scroll to the bottom
- click share
- [x] do you see the share popup w/o scrolling up? Good
- merge