### PR TITLE
Bump boot-cljs-repl deps and include instructions for development with emacs+cider

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,47 @@ cljs.user=> (utils/vec-dissoc [:a :b :c] :a)
 [:b :c]
 ```
 
+#### Cider
+
+For cider users, the steps are just slightly different. Within emacs:
+
+```console
+M-x cider-jack-in-cljs
+```
+
+When prompted to select a ClojureScript REPL type, choose `custom` (we will
+start our own). Wait for the REPL to connect, and again it will prompt you to
+enter the custom form to start the ClojureScript REPL. Just press enter. You now
+have a running Clojure REPL with all the required middleware.
+
+From here on out, the process is very similar to starting things up from the terminal.
+At the REPL, we're going to start the `boot dev` task as a future process:
+
+```console
+user=> (in-ns 'boot.user)
+#namespace[boot.user]
+boot.user=> (def p (future (boot (dev))))
+```
+
+Once that's finished compiling, open your browser window: [http://localhost:3559/](http://localhost:3559/)
+
+Now you're ready to start the ClojureScript REPL:
+
+```console
+boot.user=> (start-repl)
+```
+
+Wait for compilation to finish, and you should be dropped into the `cljs.user` namespace. If not, try
+refreshing the browser. Sometimes it needs a gentle nudge.
+
+Let's test it out:
+
+```console
+cljs.user=> (js/alert "Hello, browser!")
+```
+
+If all's well, you should see an alert box appear in the browser.
+
 ## Technical Design
 
 Documentation of the technical design is [here](./docs/TECHNICAL_DESIGN.md).

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ boot repl -c
 At this point, you can start a weasel server to connect to the browser window:
 
 ```console
-cljs.user=> (start-repl)
+boot.user=> (start-repl)
 ```
 
 If the REPL doesn't connect to the browser window, refresh the page in the browser.

--- a/build.boot
+++ b/build.boot
@@ -26,7 +26,7 @@
     [rum "0.11.2" :exclusions [cljsjs/react]] ; https://github.com/tonsky/rum
     [org.martinklepsch/derivatives "0.3.1-alpha"] ; Chains of derived data https://github.com/martinklepsch/derivatives
     [cljs-flux "0.1.2"] ; Flux implementation for Om https://github.com/kgann/cljs-flux
-    
+
     ;; ClojureScript libraries
     [cljs-http "0.1.44"] ; HTTP for cljs https://github.com/r0man/cljs-http
     [secretary "2.0.0.1-260a59"] ; Client-side router https://github.com/gf3/secretary
@@ -67,11 +67,11 @@
 
     ;; ------- Deps for project repl ------------------
     ;; The following dependencies are from: https://github.com/adzerk-oss/boot-cljs-repl
-    [adzerk/boot-cljs-repl   "0.3.3"] ;; latest release
-    [com.cemerick/piggieback "0.2.2"  :scope "test"]
-    [weasel                  "0.7.0"  :scope "test"]
-    [org.clojure/tools.nrepl "0.2.13" :scope "test"]
-    [cljsjs/babel-polyfill "6.20.0-2" :scope "test"]
+    [adzerk/boot-cljs-repl   "0.4.0"]
+    [cider/piggieback        "0.3.9"]
+    [weasel                  "0.7.0"]
+    [nrepl                   "0.4.5"]
+    ;; [cljsjs/babel-polyfill "6.20.0-2" :scope "test"]
     ;; ------------------------------------------------
 
 ])
@@ -210,7 +210,7 @@
                                  :parallel-build true
                                  :preloads '[devtools.preload]})))
 
-(deftask dev-advanced 
+(deftask dev-advanced
   "Advanced build to be used in development to find compilation/externs errors."
   []
   (set-env! :dependencies #(into % '[[binaryage/devtools "0.9.8"]]))

--- a/build.boot
+++ b/build.boot
@@ -71,7 +71,6 @@
     [cider/piggieback        "0.3.9"]
     [weasel                  "0.7.0"]
     [nrepl                   "0.4.5"]
-    ;; [cljsjs/babel-polyfill "6.20.0-2" :scope "test"]
     ;; ------------------------------------------------
 
 ])


### PR DESCRIPTION
Steps to test:

- Follow the instructions in the "Project REPL" section of the readme to be sure that launching the REPL from the terminal still works
- Test to make sure that _your_ preferred workflow has been left intact.
- (optional) If you have emacs+cider set up, test out the "Cider" subsection instructions documented in the readme 

Trello: https://trello.com/c/gRexhJ74