### PR TITLE
Better image handling

### DIFF
--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -350,11 +350,6 @@ $h2_top_margin: 24;
       height: auto;
       max-width: 100%;
       max-height: 400px;
-      cursor: zoom-in;
-
-      &:hover {
-        opacity: 0.9;
-      }
   }
 
   iframe {

--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -327,11 +327,6 @@ $h2_top_margin: 24;
     text-decoration: underline;
   }
 
-  img {
-    max-width: 100%;
-    height: auto;
-  }
-
   .emojione {
     @include emoji-size($font-size - 2);
   }
@@ -348,14 +343,23 @@ $h2_top_margin: 24;
     margin-bottom: 0px;
   }
 
-  iframe, img {
+  img {
+      display: block;
+      margin: 0 auto;
+      width: auto;
+      height: auto;
+      max-width: 100%;
+      max-height: 400px;
+  }
+
+  iframe {
     margin: 0 auto;
     display: block;
     width: 100% !important;
   }
 
   @include tablet() {
-    iframe.carrot-no-preview, img.carrot-no-preview {
+    iframe.carrot-no-preview {
       width: calc(100% + 32px) !important;
       margin: 0 0 0 -16px;
       max-width: calc(100% + 32px);

--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -343,13 +343,18 @@ $h2_top_margin: 24;
     margin-bottom: 0px;
   }
 
-  img {
+  img, a > img {
       display: block;
       margin: 0 auto;
       width: auto;
       height: auto;
       max-width: 100%;
       max-height: 400px;
+      cursor: zoom-in;
+
+      &:hover {
+        opacity: 0.9;
+      }
   }
 
   iframe {

--- a/scss/partials/_expanded_post.scss
+++ b/scss/partials/_expanded_post.scss
@@ -99,7 +99,7 @@ div.expanded-post {
     .interactable-image {
       cursor: zoom-in;
 
-      & img:hover {
+      img:hover {
           opacity: 0.9;
       }
     }

--- a/scss/partials/_expanded_post.scss
+++ b/scss/partials/_expanded_post.scss
@@ -94,6 +94,15 @@ div.expanded-post {
   div.expanded-post-body {
     @include activity-body(18, 24, 24, $deep_navy);
     margin-top: 16px;
+
+
+    .interactable-image {
+      cursor: zoom-in;
+
+      & img:hover {
+          opacity: 0.9;
+      }
+    }
   }
 
   div.expanded-post-footer {

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -333,51 +333,6 @@ div.stream-item {
           .carrot-no-preview {
               display: none;
           }
-
-          // This appears to be dead code! Please review!
-
-          // &.expanded {
-          //   div.stream-item-body-inner.to-truncate {
-          //     display: none;
-          //   }
-
-          //   div.stream-item-body-inner.no-truncate {
-          //     display: block;
-          //   }
-          // }
-
-          // div.stream-item-body-inner {
-          //   margin-top: 8px;
-
-          //   &.to-truncate{
-          //     @include activity-body(18, 24, 24, $deep_navy);
-          //     color: $deep_navy;
-          //     @include OC_Body_Book();
-          //     line-height: 24px;
-
-          //     &.hide-images {
-          //       img {
-          //         display: none;
-          //       }
-          //     }
-          //   }
-
-          //   &.no-truncate {
-          //     @include activity-body(18, 24, 24, $deep_navy);
-          //     color: $deep_navy;
-          //     @include OC_Body_Book();
-          //     line-height: 24px;
-          //     display: none;
-          //   }
-
-          //   &>*:first-child {
-          //     margin-top: 0px;
-          //   }
-
-          //   div.carrot-no-preview, a.carrot-no-preview {
-          //     display: none;
-          //   }
-          // }
         }
       }
     }

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -335,48 +335,54 @@ div.stream-item {
 
         div.stream-item-body {
 
-          &.expanded {
-            div.stream-item-body-inner.to-truncate {
+          .carrot-no-preview {
               display: none;
-            }
-
-            div.stream-item-body-inner.no-truncate {
-              display: block;
-            }
           }
 
-          div.stream-item-body-inner {
-            margin-top: 8px;
+          // This appears to be dead code! Please review!
 
-            &.to-truncate{
-              @include activity-body(18, 24, 24, $deep_navy);
-              color: $deep_navy;
-              @include OC_Body_Book();
-              line-height: 24px;
+          // &.expanded {
+          //   div.stream-item-body-inner.to-truncate {
+          //     display: none;
+          //   }
 
-              &.hide-images {
-                img {
-                  display: none;
-                }
-              }
-            }
+          //   div.stream-item-body-inner.no-truncate {
+          //     display: block;
+          //   }
+          // }
 
-            &.no-truncate {
-              @include activity-body(18, 24, 24, $deep_navy);
-              color: $deep_navy;
-              @include OC_Body_Book();
-              line-height: 24px;
-              display: none;
-            }
+          // div.stream-item-body-inner {
+          //   margin-top: 8px;
 
-            &>*:first-child {
-              margin-top: 0px;
-            }
+          //   &.to-truncate{
+          //     @include activity-body(18, 24, 24, $deep_navy);
+          //     color: $deep_navy;
+          //     @include OC_Body_Book();
+          //     line-height: 24px;
 
-            div.carrot-no-preview, a.carrot-no-preview {
-              display: none;
-            }
-          }
+          //     &.hide-images {
+          //       img {
+          //         display: none;
+          //       }
+          //     }
+          //   }
+
+          //   &.no-truncate {
+          //     @include activity-body(18, 24, 24, $deep_navy);
+          //     color: $deep_navy;
+          //     @include OC_Body_Book();
+          //     line-height: 24px;
+          //     display: none;
+          //   }
+
+          //   &>*:first-child {
+          //     margin-top: 0px;
+          //   }
+
+          //   div.carrot-no-preview, a.carrot-no-preview {
+          //     display: none;
+          //   }
+          // }
         }
       }
     }

--- a/src/oc/web/components/expanded_post.cljs
+++ b/src/oc/web/components/expanded_post.cljs
@@ -46,6 +46,7 @@
             :let [anchor (dom/create-element "a")
                   href   (.-src img)]]
       (dom/set-attr! anchor :href href :target "_blank")
+      (dom/add-class! anchor :interactable-image)
       (dom/insert-before! anchor img)
       (dom/remove! img)
       (dom/replace-contents! anchor img))

--- a/src/oc/web/components/expanded_post.cljs
+++ b/src/oc/web/components/expanded_post.cljs
@@ -24,7 +24,7 @@
 (defn close-expanded-post []
   (routing-actions/dismiss-post-modal))
 
-(defn save-fixed-comment-height [s]
+(defn save-fixed-comment-height! [s]
   (let [cur-height (.outerHeight (js/$ (rum/ref-node s :expanded-post-fixed-add-comment)))]
     (when-not (= @(::comment-height s) cur-height)
       (reset! (::comment-height s) cur-height))))
@@ -33,7 +33,7 @@
   (or (.-clientWidth (.-documentElement js/document))
       (.-innerWidth js/window)))
 
-(defn calc-video-height [s]
+(defn set-mobile-video-height! [s]
   (when (responsive/is-tablet-or-mobile?)
     (reset! (::mobile-video-height s) (utils/calc-video-height (win-width)))))
 
@@ -68,7 +68,7 @@
   (mention-mixins/oc-mentions-hover)
   interactable-images-mixin
   {:did-mount (fn [s]
-                (save-fixed-comment-height s)
+                (save-fixed-comment-height! s)
                 s)}
   [s]
   (let [activity-data (drv/react s :activity-data)
@@ -139,5 +139,5 @@
      [:div.expanded-post-fixed-add-comment
       {:ref :expanded-post-fixed-add-comment}
       [:div.expanded-post-fixed-add-comment-inner
-       (rum/with-key (add-comment activity-data (utils/debounced-fn #(save-fixed-comment-height s) 300))
+       (rum/with-key (add-comment activity-data (utils/debounced-fn #(save-fixed-comment-height! s) 300))
          (str "expanded-post-fixed-add-comment-" (:uuid activity-data)))]]]))


### PR DESCRIPTION
Trello card: https://trello.com/c/BIkEHLrq/2004-better-image-handling

Attached are 3 test images for use in the following QA steps.

### QA steps

- Create a new post and attach the `Carrot_small.png` image. Expand the post, and ensure that _no scaling_ occurs for this image, and that the image is centered horizontally within the post.
- Create a new post and attach the `carrot_tall.png` image. Expand the post, and ensure that the image does **not** exceed 400px in height, retains its proper aspect ratio (no warping), and is centered horizontally within the post.
- Create a new post and attach the `carrot_large.png` image. Expand the post, and ensure that the image is _scaled down_ to fit the width of the post, and that no warping occurs.
- Create a new post and attach _all 3 images_ to it. Expand the post, and ensure that scaling invariants still hold for each image respectively. 
- Ensure that no images other than thumbnails are displayed in the stream view. When I first began this work, there was an issue in which attached images were incorrectly being displayed in the AP view.
- Repeat the test posts above, but this time add in [lorem ipsum](https://www.lipsum.com/feed/html) text surrounding the images in various ways. Ensure that image invariants hold.
- Repeat the test posts above, but try embedding video alongside both images and text. CSS styling of iframes and images was somewhat linked, and so ensure that no regressions have taken place. 
- For all previous test posts, expand the post, and then ensure that you can click images to expand them in a new tab. Also ensure that opacity is set to 0.9 on hover.
- Choose a test post above, and edit it. Ensure that image hover styling does not take place in the modal editor (no opacity shift, no cursor styling, etc).
- **Think of other ways that this might screw up and let this carrot n00b know**

### Known Issues

- There appears to be an issue on smaller screen sizes (below about 640px in width) in which the stream views and expanded post views do not fit on screen. This issue appears to be orthogonal to the work in this PR.

**carrot_small.png**
![Carrot_small](https://user-images.githubusercontent.com/2013873/57255556-1c72df00-7022-11e9-8b6b-c65c95b7b24a.png)
**carrot_tall.png**
![carrot_tall](https://user-images.githubusercontent.com/2013873/57255563-1ed53900-7022-11e9-8bd4-b33e76bb6de8.png)
**carrot_large.png**
![carrot_large](https://user-images.githubusercontent.com/2013873/57255566-21d02980-7022-11e9-8992-6c3dcf2beded.jpg)