### PR TITLE
Remove NUX message from expanded post

### DIFF
--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -188,6 +188,7 @@
                                            "decisions to keep you and your team pulling in the same direction.")
                     is-second-user (= add-post-tooltip :is-second-user)]
                 (when (and (not is-drafts-board)
+                           (not current-activity-id)
                            add-post-tooltip)
                   [:div.add-post-tooltip-container.group
                     [:button.mlb-reset.add-post-tooltip-dismiss
@@ -219,7 +220,7 @@
                 (zero? (count (:boards org-data)))
                 (empty-org)
                 ;; Expanded post
-                (router/current-activity-id)
+                current-activity-id
                 (expanded-post)
                 ;; Empty board
                 empty-board?


### PR DESCRIPTION
Card:

To test:
- onboard a new org
- [ ] do you see the welcome NUX message?
- do not dismiss it
- click on a post
- [ ] do you NOT see the NUX message in the expanded post view?
- go back to AP
- [ ] do you still see it here?