### PR TITLE
Fix notifications click

### DIFF
--- a/src/oc/web/actions/nux.cljs
+++ b/src/oc/web/actions/nux.cljs
@@ -5,7 +5,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
-            [oc.web.utils.user :as user-utils]
+            [oc.web.utils.org :as org-utils]
             [oc.web.lib.json :refer (json->cljs cljs->json)]))
 
 (defn get-nux-cookie
@@ -61,7 +61,7 @@
   []
   (when-let* [nv (get-nux-cookie)
               org-data (dis/org-data)]
-    (let [is-org-creator (user-utils/is-org-creator? org-data)
+    (let [is-org-creator (org-utils/is-org-creator? org-data)
           team-data (dis/team-data)
           can-edit? (utils/is-admin-or-author? org-data)
           is-admin? (jwt/is-admin? (:team-id org-data))

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -469,7 +469,12 @@
          {:title (:title fixed-notification)
           :mention true
           :dismiss true
-          :click #(router/nav! (oc-urls/entry (:board-slug fixed-notification) (:uuid fixed-notification)))
+          :click (fn []
+                   (if (:reminder? fixed-notification)
+                     (oc.web.actions.nav-sidebar/show-reminders)
+                     (when (and (:board-slug fixed-notification)
+                                (:uuid fixed-notification))
+                      (router/nav! (oc-urls/entry (:board-slug fixed-notification) (:uuid fixed-notification))))))
           :mention-author (:author fixed-notification)
           :description (:body fixed-notification)
           :id (str "notif-" (:created-at fixed-notification))

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -469,12 +469,7 @@
          {:title (:title fixed-notification)
           :mention true
           :dismiss true
-          :click (fn []
-                   (if (:reminder? fixed-notification)
-                     (oc.web.actions.nav-sidebar/show-reminders)
-                     (when (and (:board-slug fixed-notification)
-                                (:uuid fixed-notification))
-                      (router/nav! (oc-urls/entry (:board-slug fixed-notification) (:uuid fixed-notification))))))
+          :click (:click fixed-notification)
           :mention-author (:author fixed-notification)
           :description (:body fixed-notification)
           :id (str "notif-" (:created-at fixed-notification))

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -10,7 +10,7 @@
             [oc.web.utils.activity :as au]
             [oc.web.mixins.activity :as am]
             [oc.web.mixins.ui :as ui-mixins]
-            [oc.web.utils.user :as user-utils]
+            [oc.web.utils.org :as org-utils]
             [oc.web.actions.nux :as nux-actions]
             [oc.web.utils.draft :as draft-utils]
             [oc.web.lib.responsive :as responsive]
@@ -225,7 +225,7 @@
                           {:on-click #(nux-actions/dismiss-post-added-tooltip)}]
                         [:div.post-added-tooltips
                           [:div.post-added-tooltip
-                            (if (user-utils/is-org-creator? org-data)
+                            (if (org-utils/is-org-creator? org-data)
                               "After you invite your team, you'll know who saw this post."
                               "Here's where you'll know who saw this post.")]
                           [:button.mlb-reset.post-added-bt

--- a/src/oc/web/components/user_notifications.cljs
+++ b/src/oc/web/components/user_notifications.cljs
@@ -84,17 +84,8 @@
               [:div.user-notification.group
                 {:class (utils/class-set {:unread (:unread n)})
                  :on-click (fn [e]
-                             (cond
-                               (and reminder?
-                                    (= notification-type "reminder-alert"))
-                               (ui-compose @(drv/get-ref s :show-add-post-tooltip))
-                               (and reminder?
-                                    (= notification-type "reminder-notification"))
-                               (nav-actions/show-reminders)
-                               (and entry-uuid
-                                    board-slug
-                                    (not (utils/event-inside? e (rum/ref-node s :read-bt))))
-                               (router/nav! (oc-urls/entry board-slug entry-uuid)))
+                             (when (fn? (:click n))
+                               ((:click n)))
                              (user-actions/hide-mobile-user-notifications))
                  :key children-key}
                 (user-avatar-image (:author n))

--- a/src/oc/web/lib/fullstory.cljs
+++ b/src/oc/web/lib/fullstory.cljs
@@ -1,7 +1,5 @@
 (ns oc.web.lib.fullstory
-  (:require [oc.web.lib.jwt :as jwt]
-            [oc.web.dispatcher :as dis]
-            [oc.web.stores.user :as user-store]))
+  (:require [oc.web.lib.jwt :as jwt]))
 
 (defn identify []
   (when (and (exists? js/FS)
@@ -22,7 +20,10 @@
     (.setUserVars js/FS
      (clj->js {:org (:name org-data)
                :org_slug (:slug org-data)
-               :role (user-store/user-role org-data (dis/current-user-data))}))))
+               ;; FIXME: add back user role here if we start using FS seriously
+               ;; removed for circular dependency problem
+               ;; (user-store/user-role org-data (dis/current-user-data))
+               :role "-"}))))
 
 (defn session-url []
   (when (and (exists? js/FS)

--- a/src/oc/web/utils/org.cljs
+++ b/src/oc/web/utils/org.cljs
@@ -1,4 +1,5 @@
-(ns oc.web.utils.org)
+(ns oc.web.utils.org
+  (:require [oc.web.lib.jwt :as jwt]))
 
 (def org-avatar-filestack-config
   {:accept "image/*"
@@ -25,3 +26,6 @@
       (if (.startsWith no-beginning-https "www.")
         (subs no-beginning-https 4)
         no-beginning-https))))
+
+(defn is-org-creator? [org-data]
+  (= (:user-id (:author org-data)) (jwt/user-id)))

--- a/src/oc/web/utils/user.cljs
+++ b/src/oc/web/utils/user.cljs
@@ -3,6 +3,7 @@
             [oc.web.urls :as oc-urls]
             [oc.web.router :as router]
             [oc.web.utils.ui :refer (ui-compose)]
+            [oc.web.lib.responsive :as responsive]
             [oc.web.utils.activity :as activity-utils]))
 
 (def user-avatar-filestack-config
@@ -79,10 +80,11 @@
        :title title
        :author (:author notification)
        :click (if reminder?
-                (if (and reminder-data
-                         (= (:notification-type reminder-data) "reminder-notification"))
-                  #(oc.web.actions.nav-sidebar/show-reminders)
-                  #(ui-compose))
+                (when-not (responsive/is-mobile-size?)
+                  (if (and reminder-data
+                           (= (:notification-type reminder-data) "reminder-notification"))
+                    #(oc.web.actions.nav-sidebar/show-reminders)
+                    #(ui-compose)))
                 (when (and (:slug board-data)
                            entry-uuid)
                   #(router/nav! (oc-urls/entry (:slug board-data) entry-uuid))))})))

--- a/src/oc/web/utils/user.cljs
+++ b/src/oc/web/utils/user.cljs
@@ -78,15 +78,14 @@
        :body (notification-content notification)
        :title title
        :author (:author notification)
-       :click (fn []
-               (if reminder?
-                 (if (and reminder-data
-                          (= (:notification-type reminder-data) "reminder-notification"))
-                   (oc.web.actions.nav-sidebar/show-reminders)
-                   (ui-compose))
-                 (when (and (:slug board-data)
-                            entry-uuid)
-                   (router/nav! (oc-urls/entry (:slug board-data) entry-uuid)))))})))
+       :click (if reminder?
+                (if (and reminder-data
+                         (= (:notification-type reminder-data) "reminder-notification"))
+                  #(oc.web.actions.nav-sidebar/show-reminders)
+                  #(ui-compose))
+                (when (and (:slug board-data)
+                           entry-uuid)
+                  #(router/nav! (oc-urls/entry (:slug board-data) entry-uuid))))})))
 
 (defn sorted-notifications [notifications]
   (vec (reverse (sort-by :created-at notifications))))


### PR DESCRIPTION
No Trello card

Ryan said he was having trouble when clicking the notifications since the action was not performed.
Some/most notifications have no actions at all, but these have, check that they work:
- reminder added notification: should open the reminders list
- reminder alert (when the reminder is due): should open Cmail
- mention on a  post: should nav to post page
- mention on a comment: should nav to post page

NB: you can find instructions on how to trigger a reminder alert here https://github.com/open-company/open-company-reminder/pull/1