### PR TITLE
Settings data refresh

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -592,8 +592,8 @@
     (api/get-auth-settings (fn [body]
       (when body
         (when-let [user-link (utils/link-for (:links body) "user" "GET")]
-          (api/get-user user-link (fn [data]
-            (dis/dispatch! [:user-data (json->cljs data)]))))
+          (api/get-user user-link (fn [success data]
+            (dis/dispatch! [:user-data (when success (json->cljs data))]))))
         (dis/dispatch! [:auth-settings body])
         (api/get-entry-point org-slug
           (fn [success body]

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -185,6 +185,16 @@
        (when success
         (dis/dispatch! [:user-data (json->cljs body)]))))))
 
+;; Get user
+
+(defn get-user [user-link]
+  (let [fixed-user-link (or user-link (utils/link-for (:links (dis/auth-settings)) "user" "GET"))]
+    (api/get-user user-link (fn [data]
+     (let [user-map (json->cljs data)]
+       (dis/dispatch! [:user-data user-map])
+       (utils/after 100 nux-actions/check-nux)
+       (patch-timezone-if-needed user-map))))))
+
 ;; Auth
 
 (defn auth-settings-get
@@ -194,11 +204,7 @@
     (when body
       ;; auth settings loaded
       (when-let [user-link (utils/link-for (:links body) "user" "GET")]
-        (api/get-user user-link (fn [data]
-          (let [user-map (json->cljs data)]
-            (dis/dispatch! [:user-data user-map])
-            (utils/after 100 nux-actions/check-nux)
-            (patch-timezone-if-needed user-map)))))
+        (get-user user-link))
       (dis/dispatch! [:auth-settings body])
       (check-user-walls)
       ;; Start teams retrieve if we have a link

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -188,7 +188,7 @@
 ;; Get user
 
 (defn get-user [user-link]
-  (let [fixed-user-link (or user-link (utils/link-for (:links (dis/auth-settings)) "user" "GET"))]
+  (when-let [fixed-user-link (or user-link (utils/link-for (:links (dis/auth-settings)) "user" "GET"))]
     (api/get-user user-link (fn [data]
      (let [user-map (json->cljs data)]
        (dis/dispatch! [:user-data user-map])

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -189,8 +189,8 @@
 
 (defn get-user [user-link]
   (when-let [fixed-user-link (or user-link (utils/link-for (:links (dis/auth-settings)) "user" "GET"))]
-    (api/get-user fixed-user-link (fn [data]
-     (let [user-map (json->cljs data)]
+    (api/get-user fixed-user-link (fn [success data]
+     (let [user-map (when success (json->cljs data))]
        (dis/dispatch! [:user-data user-map])
        (utils/after 100 nux-actions/check-nux)
        (patch-timezone-if-needed user-map))))))

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -189,7 +189,7 @@
 
 (defn get-user [user-link]
   (when-let [fixed-user-link (or user-link (utils/link-for (:links (dis/auth-settings)) "user" "GET"))]
-    (api/get-user user-link (fn [data]
+    (api/get-user fixed-user-link (fn [data]
      (let [user-map (json->cljs data)]
        (dis/dispatch! [:user-data user-map])
        (utils/after 100 nux-actions/check-nux)

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -574,7 +574,7 @@
     (auth-http (method-for-link user-link) (relative-href user-link)
       {:headers (headers-for-link user-link)}
       (fn [{:keys [status body success]}]
-        (callback body)))
+        (callback success body)))
     (handle-missing-link "get-user" user-link callback)))
 
 (defn patch-user [patch-user-link new-user-data callback]

--- a/src/oc/web/components/integrations_settings_modal.cljs
+++ b/src/oc/web/components/integrations_settings_modal.cljs
@@ -20,6 +20,11 @@
   (drv/drv :current-user-data)
   ;; Locals
   (rum/local false ::saving)
+  {:will-mount (fn [s]
+    (let [org-data @(drv/get-ref s :org-data)]
+        (org-actions/get-org org-data)
+        (team-actions/force-team-refresh (:team-id org-data)))
+    s)}
   [s]
   (let [org-data (drv/react s :org-data)
         team-data (drv/react s :team-data)

--- a/src/oc/web/components/invite_settings_modal.cljs
+++ b/src/oc/web/components/invite_settings_modal.cljs
@@ -106,6 +106,9 @@
   {:will-mount (fn [s]
                  (setup-initial-rows s)
                  (nux-actions/dismiss-post-added-tooltip)
+                 (let [org-data @(drv/get-ref s :org-data)]
+                   (org-actions/get-org org-data)
+                   (team-actions/force-team-refresh (:team-id org-data)))
                 s)
    :after-render (fn [s]
                    (doto (js/$ "[data-toggle=\"tooltip\"]")

--- a/src/oc/web/components/org_settings_modal.cljs
+++ b/src/oc/web/components/org_settings_modal.cljs
@@ -118,8 +118,7 @@
   (rum/local false ::show-advanced-settings)
   {:will-mount (fn [s]
     (let [org-data @(drv/get-ref s :org-data)]
-      (org-actions/get-org org-data)
-      (team-actions/force-team-refresh (:team-id org-data)))
+      (org-actions/get-org org-data))
     (reset-form s)
     (let [content-visibility-data (:content-visibility @(drv/get-ref s :org-data))]
       (reset! (::show-advanced-settings s) (some #(content-visibility-data %) (keys content-visibility-data))))

--- a/src/oc/web/components/team_management_modal.cljs
+++ b/src/oc/web/components/team_management_modal.cljs
@@ -5,6 +5,7 @@
             [oc.web.lib.jwt :as jwt]
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
+            [oc.web.actions.org :as org-actions]
             [oc.web.actions.team :as team-actions]
             [oc.web.actions.nav-sidebar :as nav-actions]
             [oc.web.components.ui.alert-modal :as alert-modal]
@@ -45,7 +46,12 @@
   (rum/local false ::resending-invite)
   (rum/local "" ::query)
   (rum/local #{} ::removing)
-  {:after-render (fn [s]
+  {:will-mount (fn [s]
+    (let [org-data @(drv/get-ref s :org-data)]
+        (org-actions/get-org org-data)
+        (team-actions/force-team-refresh (:team-id org-data)))
+    s)
+   :after-render (fn [s]
     (doto (js/$ "[data-toggle=\"tooltip\"]")
      (.tooltip "fixTitle")
      (.tooltip "hide"))

--- a/src/oc/web/components/user_notifications.cljs
+++ b/src/oc/web/components/user_notifications.cljs
@@ -26,9 +26,6 @@
                                 (on-window-click-mixin (fn [s e]
                                  (when-not (utils/event-inside? e (rum/ref-node s :read-bt))
                                    (close-tray s))))
-                                {:will-mount (fn [s]
-                                  (user-actions/get-user nil)
-                                  s)}
   [s]
   (let [user-notifications-data (drv/react s :user-notifications)
         has-new-content (has-new-content? user-notifications-data)

--- a/src/oc/web/components/user_notifications.cljs
+++ b/src/oc/web/components/user_notifications.cljs
@@ -26,6 +26,9 @@
                                 (on-window-click-mixin (fn [s e]
                                  (when-not (utils/event-inside? e (rum/ref-node s :read-bt))
                                    (close-tray s))))
+                                {:will-mount (fn [s]
+                                  (user-actions/get-user nil)
+                                  s)}
   [s]
   (let [user-notifications-data (drv/react s :user-notifications)
         has-new-content (has-new-content? user-notifications-data)

--- a/src/oc/web/components/user_notifications_modal.cljs
+++ b/src/oc/web/components/user_notifications_modal.cljs
@@ -51,7 +51,10 @@
   ;; Locals
   (rum/local false ::loading)
   (rum/local false ::show-success)
-  {:after-render (fn [s]
+  {:will-mount (fn [s]
+   (user-actions/get-user nil)
+   s)
+   :after-render (fn [s]
    (when-not (utils/is-test-env?)
      (doto (js/$ "[data-toggle=\"tooltip\"]")
        (.tooltip "fixTitle")

--- a/src/oc/web/components/user_profile_modal.cljs
+++ b/src/oc/web/components/user_profile_modal.cljs
@@ -125,7 +125,10 @@
   (rum/local false ::email-error)
   (rum/local false ::password-error)
   (rum/local false ::current-password-error)
-  {:after-render (fn [s]
+  {:will-mount (fn [s]
+    (user-actions/get-user nil)
+    s)
+   :after-render (fn [s]
     (when-not (utils/is-test-env?)
       (doto (js/$ "[data-toggle=\"tooltip\"]")
         (.tooltip "fixTitle")


### PR DESCRIPTION
Bug: we lost data refresh when opening a setting panel

To test:
- open org settings
- [x] do you see org data and team data refresh? Good
- open team management
- [x] do you see org data and team data refresh? Good
- open invite panel
- [x] do you see org data and team data refresh? Good
- open integrations
- [x] do you see org data and team data refresh? Good
- open user profile
- [x] do you see user data refresh? Good
- open user notifications panel
- [ ] do you see user data refresh? Good