### PR TITLE
Publish redirect

### DIFF
--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -405,10 +405,11 @@
                             ;; Redirect to the publishing board if the slug is available
                             (if redirect?
                               (do
-                                (real-close)
-                                (utils/after
-                                 180
-                                 #(routing-actions/open-post-modal cmail-data)))
+                                (router/nav!
+                                 (if (= (router/current-board-slug) "all-posts")
+                                   (oc-urls/all-posts)
+                                   (oc-urls/board (:board-slug cmail-data))))
+                                (real-close))
                               (reset! (::disable-post s) false))))))
                     s)
                    :after-render (fn [s]


### PR DESCRIPTION
From QA doc:
> When post, go to stream.. not the full page view

To test:
- go to AP
- publish a post to section A
- [ ] are you still in AP?
- [ ] do you see the post?
- [ ] is it read?
- go to Section A
- publish a post to section A
- [ ] are you still Section A?
- [ ] do you see the post?
- [ ] is it read?
- publish a post to section B
- [ ] are you redirected to Section B?
- [ ] do you see the post?
- [ ] is it read?
- [ ] no weird jumps, never?
