### PR TITLE
Scroll back to top when opening a post.

### DIFF
--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -132,7 +132,8 @@
                                   (not (utils/button-clicked? e))
                                   ;; No input field clicked
                                   (not (utils/input-clicked? e)))
-                         (routing-actions/open-post-modal activity-data)))))
+                         (routing-actions/open-post-modal activity-data)
+                         (utils/scroll-to-y 0)))))
        :id dom-element-id}
       [:div.stream-item-inner
         [:div.stream-item-header.group


### PR DESCRIPTION
Problem: https://www.loom.com/share/8d823315660d497499c8a0b9214e04b0

To test:
- scroll at the bottom of section/AP
- click on last post
- [x] now you are at the top of the post? Good
- click Back to...
- now back to the section?
- repeat the above test
