### PR TITLE
Section settings lose changes

### DIFF
--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -249,7 +249,8 @@
       (success-cb next-section-editing))))
 
 (defn pre-flight-check [section-slug section-name]
-  (dispatcher/dispatch! [:input [:section-editing :pre-flight-loading] true])
+  (dispatcher/dispatch! [:update [:section-editing] #(merge % {:has-changes true
+                                                               :pre-flight-loading true})])
   (let [org-data (dispatcher/org-data)
         pre-flight-link (utils/link-for (:links org-data) "pre-flight-create")]
     (api/pre-flight-section-check pre-flight-link section-slug section-name

--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -103,9 +103,6 @@
   (rum/local false ::pre-flight-ok)
   (rum/local nil ::section-name-check-timeout)
   (rum/local false ::saving)
-  (mixins/on-window-click-mixin (fn [s e]
-   (when-not (utils/event-inside? e (rum/dom-node s))
-     (nav-actions/hide-section-editor))))
   ;; Derivatives
   (drv/drv :org-data)
   (drv/drv :board-data)
@@ -144,7 +141,8 @@
    s)}
   [s initial-section-data on-change from-section-picker]
   (let [org-data (drv/react s :org-data)
-        no-drafts-boards (filter #(and (not (:draft %)) (not= (:slug %) utils/default-drafts-board-slug)) (:boards org-data))
+        no-drafts-boards (filter #(and (not (:draft %)) (not= (:slug %) utils/default-drafts-board-slug))
+                          (:boards org-data))
         section-editing (drv/react s :section-editing)
         section-data (if (seq (:slug section-editing)) (drv/react s :board-data) section-editing)
         team-data (drv/react s :team-data)
@@ -164,12 +162,26 @@
                        (jwt/is-admin? (:team-id org-data)))
         last-section-standing (= (count no-drafts-boards) 1)
         disallow-public-board? (and (:content-visibility org-data)
-                                    (:disallow-public-board (:content-visibility org-data)))]
+                                    (:disallow-public-board (:content-visibility org-data)))
+        wrapped-on-change (fn [exit-cb]
+                            (if (:has-changes @(drv/get-ref s :section-editing))
+                              (alert-modal/show-alert
+                               {:icon "/img/ML/trash.svg"
+                                :action "section-settings-unsaved-edits"
+                                :message "Leave without saving your changes?"
+                                :link-button-title "Stay"
+                                :link-button-cb #(alert-modal/hide-alert)
+                                :solid-button-style :red
+                                :solid-button-title "Lose changes"
+                                :solid-button-cb #(do
+                                                    (alert-modal/hide-alert)
+                                                    (on-change nil nil exit-cb))})
+                              (on-change nil nil exit-cb)))]
     [:div.section-editor-container
       {:on-click #(when-not (utils/event-inside? % (rum/ref-node s :section-editor))
-                    (on-change nil nil nav-actions/close-all-panels))}
+                    (wrapped-on-change nav-actions/close-all-panels))}
       [:button.mlb-reset.modal-close-bt
-        {:on-click #(on-change nil nil nav-actions/close-all-panels)}]
+        {:on-click #(wrapped-on-change nav-actions/close-all-panels)}]
       [:div.section-editor.group
         {:ref :section-editor
          :on-click (fn [e]
@@ -205,7 +217,7 @@
                :class (when disable-bt "disabled")}
               "Save"])
           [:button.mlb-reset.cancel-bt
-            {:on-click #(on-change nil nil nav-actions/hide-section-editor)}
+            {:on-click #(wrapped-on-change nav-actions/hide-section-editor)}
             "Back"]]
         [:div.section-editor-add
           [:div.section-editor-add-label
@@ -252,26 +264,32 @@
             [:div.section-editor-add-access-list
               {:ref "section-editor-add-access-list"}
               [:div.access-list-row
-                {:on-click #(do
-                              (utils/event-stop %)
-                              (reset! (::show-access-list s) false)
-                              (dis/dispatch! [:input [:section-editing :access] "team"]))}
+                {:on-click (fn [e]
+                             (utils/event-stop e)
+                             (reset! (::show-access-list s) false)
+                             (dis/dispatch! [:update [:section-editing] #(merge % {:access "team"
+                                                                                   :has-changes true})]))}
                 team-access]
               [:div.access-list-row
-                {:on-click #(do
-                              (utils/event-stop %)
+                {:on-click (fn [e]
+                              (utils/event-stop e)
                               (reset! (::show-access-list s) false)
                               (when show-slack-channels?
-                                (reset! (::slack-enabled s) false)
-                                (dis/dispatch! [:input [:section-editing :slack-mirror] nil]))
-                              (dis/dispatch! [:input [:section-editing :access] "private"]))}
+                                (reset! (::slack-enabled s) false))
+                              (dis/dispatch! [:update [:section-editing]
+                                              #(merge % {:access "private"
+                                                         :has-changes true
+                                                         :slack-mirror (if show-slack-channels?
+                                                                         nil
+                                                                         (:slack-mirror section-editor))})]))}
                 private-access]
               (when-not disallow-public-board?
                 [:div.access-list-row
-                  {:on-click #(do
-                                (utils/event-stop %)
+                  {:on-click (fn [e]
+                                (utils/event-stop e)
                                 (reset! (::show-access-list s) false)
-                                (dis/dispatch! [:input [:section-editing :access] "public"]))}
+                                (dis/dispatch! [:update [:section-editing] #(merge % {:access "public"
+                                                                                      :has-changes true})]))}
                   public-access])])
           (when show-slack-channels?
             [:div.section-editor-add-label.top-separator
@@ -280,24 +298,26 @@
                 [:span.info])
               (when show-slack-channels?
                 (carrot-switch {:selected @(::slack-enabled s)
-                                  :did-change-cb #(do
-                                                    (reset! (::slack-enabled s) %)
-                                                    (when-not %
-                                                      (dis/dispatch!
-                                                       [:input
-                                                        [:section-editing :slack-mirror]
-                                                        nil])))}))])
+                                :did-change-cb (fn [v]
+                                                 (reset! (::slack-enabled s) v)
+                                                  (when-not v
+                                                    (dis/dispatch! [:update [:section-editing]
+                                                     #(merge % {:slack-mirror nil
+                                                                :has-changes true})])))}))])
           (if show-slack-channels?
             [:div.section-editor-add-slack-channel.group
               {:class (when-not @(::slack-enabled s) "disabled")}
               (slack-channels-dropdown {:initial-value (when channel-name (str "#" channel-name))
                                         :on-change (fn [team channel]
                                                      (dis/dispatch!
-                                                      [:input
-                                                       [:section-editing :slack-mirror]
-                                                       {:channel-id (:id channel)
-                                                        :channel-name (:name channel)
-                                                        :slack-org-id (:slack-org-id team)}]))})]
+                                                      [:update
+                                                       [:section-editing]
+                                                       #(merge %
+                                                         {:slack-mirror
+                                                           {:channel-id (:id channel)
+                                                            :channel-name (:name channel)
+                                                            :slack-org-id (:slack-org-id team)}
+                                                          :has-changes true})]))})]
             ;; If they don't have bot installed already but have slack org associated to the team
             ;; and user has a slack user (if not they can't add the bot) let's prompt to add the bot
             (when (and (not (jwt/team-has-bot? (:team-id team-data)))
@@ -351,7 +371,9 @@
                               (utils/name-or-email user)]])
                         [:div.section-editor-private-users-result.no-more-invites
                           [:div.name
-                            "Looks like you'll need to invite more people to your team before you can add them. You can do that in "
+                            (str
+                             "Looks like you'll need to invite more people to your team before you can add them. "
+                             "You can do that in ")
                             [:a
                               {:on-click #(nav-actions/show-org-settings :invite)}
                               "Carrot team settings"]

--- a/src/oc/web/stores/section.cljs
+++ b/src/oc/web/stores/section.cljs
@@ -109,7 +109,8 @@
                        current-viewers)
         next-notifications (vec (conj current-notifications user))]
     (assoc db :section-editing
-           (merge section-data {:authors next-authors
+           (merge section-data {:has-changes true
+                                :authors next-authors
                                 :viewers next-viewers
                                 :private-notifications next-notifications}))))
 
@@ -121,7 +122,8 @@
         next-authors (filterv #(not= % (:user-id user)) (:authors section-data))
         next-viewers (filterv #(not= % (:user-id user)) (:viewers section-data))]
     (assoc db :section-editing
-           (merge section-data {:authors next-authors
+           (merge section-data {:has-changes true
+                                :authors next-authors
                                 :viewers next-viewers
                                 :private-notifications private-notifications}))))
 


### PR DESCRIPTION
From [QA doc]:
> If a user leaves section settings w/o saving a role change or user remove, we don’t warn that they are losing unsaved changes

To test:
- click + to add a section
- change name
- close panel
- [x] did you get a message about losing unsaved changes?
- click stay
- [x] panel still open?
- dismiss the panel
- click + to add a section
- change section security
- close panel
- [x] did you get a message about losing unsaved changes?
- click lose
- click + to add a section
- enable Slack share and pick a channel
- close panel
- [x] did you get a message about losing unsaved changes?
- click lose
- now nav to a section
- click the settings COG besides the section name
- change name (wait for preflight request to finish)
- close the panel
- [x] did you get a message about losing unsaved changes?
- now open a section settings and change it to be a private section
- save it
- open settings again
- add a user to the section
- dismiss the panel w/o saving
- [x] did you get the message?
- click stay
- save the change
- go back to section settings
- change the user role
- close without saving
- [x] did you get the message?
- merge
