### PR TITLE
Simplify comments summary on mobile

### DIFF
--- a/src/oc/web/components/ui/comments_summary.cljs
+++ b/src/oc/web/components/ui/comments_summary.cljs
@@ -50,8 +50,7 @@
                          (count comments-data)
                          (:count comments-link))
         face-pile-count (min max-face-pile (count comments-authors))
-        short-label? (and (responsive/is-mobile-size?)
-                          (> (count (:reactions entry-data)) 1))
+        short-label? (responsive/is-mobile-size?)
         faces-to-render (take max-face-pile comments-authors)]
     (when (and comments-count
                (or show-zero-comments?


### PR DESCRIPTION
Before we were changing the label of the comments summary depending on the number of reactions (to have enough space for the viewers).

We decided that changing copy from one post to another was weird so we simplified:
- always show only the number of comments if there are any (instead of `x comment(s)` like on big web)
- show only `Comment` if there are 0 posts (instead of `Add a comment` like on big web)

To test:
- add a post
- [ ] does it shows `Add a comment` on big web?
- [ ] does it shows `Comment` on mobile?
- add a comment
- [ ] does it shows `1 comment` on big web?
- [ ] does it shows `1` on mobile?
- add another comment
- [ ] does it shows `1 comments` on big web?
- [ ] does it shows `2` on mobile?
- add a reaction
- [ ] still the same on both?
- add another reaction
- [ ] still the same on both?