### PR TITLE
Fullstory fixes

### DIFF
--- a/src/oc/web/components/expanded_post.cljs
+++ b/src/oc/web/components/expanded_post.cljs
@@ -150,10 +150,12 @@
                           :video-image (:video-image activity-data)
                           :video-processed (:video-processed activity-data)})])
       [:div.expanded-post-headline
+        {:class utils/hide-class}
         (:headline activity-data)]
       [:div.expanded-post-author.group
         (user-avatar-image publisher)
         [:div.expanded-post-author-inner
+          {:class utils/hide-class}
           (str (:name publisher) " in "
                (:board-name activity-data) " on "
                (utils/date-string (utils/js-date (:published-at activity-data)) [:year]))
@@ -161,9 +163,11 @@
             [:div.must-see-tag])]]
       (when (seq (:abstract activity-data))
         [:div.expanded-post-abstract
+          {:class utils/hide-class}
           (:abstract activity-data)])
       [:div.expanded-post-body.oc-mentions.oc-mentions-hover
         {:ref "post-body"
+         :class utils/hide-class
          :dangerouslySetInnerHTML {:__html (:body activity-data)}}]
       (stream-attachments (:attachments activity-data))
       [:div.expanded-post-footer.group

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -184,15 +184,13 @@
                                         utils/hide-class true})}
               [:div.stream-item-headline.ap-seen-item-headline
                 {:ref "activity-headline"
-                 :class utils/hide-class
                  :data-itemuuid (:uuid activity-data)
                  :dangerouslySetInnerHTML (utils/emojify (:headline activity-data))}]
               (let [has-abstract (seq (:abstract activity-data))]
                 [:div.stream-item-body
                   {:class (utils/class-set {:no-abstract (not has-abstract)
                                             :item-ready @(::item-ready s)
-                                            :truncated truncated?
-                                            utils/hide-class true})
+                                            :truncated truncated?})
                    :data-itemuuid (:uuid activity-data)
                    :ref :abstract
                    :dangerouslySetInnerHTML {:__html (if has-abstract

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -184,13 +184,15 @@
                                         utils/hide-class true})}
               [:div.stream-item-headline.ap-seen-item-headline
                 {:ref "activity-headline"
+                 :class utils/hide-class
                  :data-itemuuid (:uuid activity-data)
                  :dangerouslySetInnerHTML (utils/emojify (:headline activity-data))}]
               (let [has-abstract (seq (:abstract activity-data))]
                 [:div.stream-item-body
                   {:class (utils/class-set {:no-abstract (not has-abstract)
                                             :item-ready @(::item-ready s)
-                                            :truncated truncated?})
+                                            :truncated truncated?
+                                            utils/hide-class true})
                    :data-itemuuid (:uuid activity-data)
                    :ref :abstract
                    :dangerouslySetInnerHTML {:__html (if has-abstract

--- a/src/oc/web/components/ui/comments_summary.cljs
+++ b/src/oc/web/components/ui/comments_summary.cljs
@@ -68,8 +68,7 @@
         ; Comments count
         [:div.is-comments-summary
           {:class (utils/class-set {(str "comments-count-" (:uuid entry-data)) true
-                                    :add-a-comment (not (pos? comments-count))
-                                    utils/hide-class true})}
+                                    :add-a-comment (not (pos? comments-count))})}
           (if (pos? comments-count)
             (str comments-count
               (when-not short-label?

--- a/src/oc/web/components/ui/stream_attachments.cljs
+++ b/src/oc/web/components/ui/stream_attachments.cljs
@@ -40,7 +40,9 @@
                 [:div.attachment-info
                   {:class (when editable? "editable")}
                   [:div.attachment-icon]
-                  [:span.attachment-name file-name]
+                  [:span.attachment-name
+                    {:class utils/hide-class}
+                    file-name]
                   [:span.attachment-description subtitle]
                   (when editable?
                     [:button.mlb-reset.remove-attachment-bt


### PR DESCRIPTION
Right now we show the whole post in the expanded view in FS.

This is already on staging but we have FS disabled by default there. To test you can turn to `true` [this line](https://github.com/belucid/open-company-infrastructure/blob/master/ansible/group_vars/staging#L138) and deploy with it

To test:
- go [here](https://app.fullstory.com/ui/BSJZW/segments/iacopo@carrot.io:5629499534213120/people/0)
- nav to staging with another window
- expand a post with attachments and some body/abstract
- check that you can't see any of the post parts