### PR TITLE
Comment reaction authors

### DIFF
--- a/src/oc/web/actions/reaction.cljs
+++ b/src/oc/web/actions/reaction.cljs
@@ -62,10 +62,11 @@
         entry-data (dis/activity-data org-slug activity-uuid)
         reaction-data (:interaction interaction-data)
         is-current-user (= (jwt/get-key :user-id) (:user-id (:author reaction-data)))]
-    (if (and entry-data (seq (:reactions entry-data)))
-      (when is-current-user
-        (activity-actions/get-entry entry-data))
-      (router/nav! (oc-urls/board (router/current-org-slug) board-slug)))))
+    ;; Refresh entry if necessary
+    (when (and entry-data
+             (seq (:reactions entry-data))
+             is-current-user)
+      (activity-actions/get-entry entry-data))))
 
 (defn ws-interaction-reaction-add [interaction-data]
   (let [org-slug (router/current-org-slug)

--- a/src/oc/web/components/reactions.cljs
+++ b/src/oc/web/components/reactions.cljs
@@ -17,16 +17,22 @@
 
 (def default-reaction-number 5)
 
+(defn- setup-tooltips [s]
+  (when-not (responsive/is-tablet-or-mobile?)
+    (doto (js/$ "[data-toggle=\"tooltip\"]" (rum/dom-node s))
+      (.tooltip "fixTitle")
+      (.tooltip "hide"))))
+
 (rum/defcs reactions < (rum/local false ::show-picker)
                        (on-window-click-mixin (fn [s e]
                         (when-not (utils/event-inside? e (rum/dom-node s))
                           (reset! (::show-picker s) false))))
-                       {:did-remount (fn [_ s]
-                        (when-not (responsive/is-tablet-or-mobile?)
-                          (doto (js/$ "[data-toggle=\"tooltip\"]" (rum/dom-node s))
-                            (.tooltip "fixTitle")
-                            (.tooltip "hide")))
-                        s)}
+                       {:did-mount (fn [s]
+                         (setup-tooltips s)
+                         s)
+                        :did-remount (fn [_ s]
+                         (setup-tooltips s)
+                         s)}
   [s entity-data hide-last-reaction? optional-activity-data]
   ;; optional-activity-data: is passed only when rendering the list of reactions for a comment
   ;; in that case entity-data is the comment-data. When optional-activity-data is nil it means

--- a/src/oc/web/stores/reaction.cljs
+++ b/src/oc/web/stores/reaction.cljs
@@ -84,15 +84,19 @@
           old-reaction-data (when reaction-found
                              (get reactions-data reaction-idx))
           is-current-user (= (jwt/get-key :user-id) (:user-id (:author reaction-data)))
+          authors-fn (if add-event? conj utils/vec-dissoc)
+          with-authors (-> reaction-data
+                        (assoc :authors (authors-fn (:authors old-reaction-data) (:name (:author reaction-data))))
+                        (assoc :author-ids (authors-fn (:author-ids old-reaction-data) (:user-id (:author reaction-data)))))
           with-reacted (if is-current-user
                          ;; If the reaction is from the current user we need to
                          ;; update the reacted, the links are the one coming with
                          ;; the WS message
-                         (assoc reaction-data :reacted add-event?)
+                         (assoc with-authors :reacted add-event?)
                          ;; If it's a reaction from another user we need to
                          ;; survive the reacted and the links from the reactions
                          ;; we already have
-                         (assoc reaction-data :reacted (if old-reaction-data (:reacted old-reaction-data) false)))
+                         (assoc with-authors :reacted (if old-reaction-data (:reacted old-reaction-data) false)))
           new-reactions-data (if reactions-data
                                (assoc reactions-data (if reaction-found reaction-idx
                                                       (count reactions-data)) with-reacted)
@@ -141,9 +145,16 @@
                               ;; and is an add interaction
                               {:reacted (when is-current-user
                                           add-event?)
+                               :authors []
+                               :author-ids []
                                :links (:links reaction-data)})
+          authors-fn (if add-event? conj utils/vec-dissoc)
           with-reacted (merge reaction-data {:count (:count interaction-data)
                                              :reacted (:reacted old-reaction-data)
+                                             :authors (authors-fn (:authors old-reaction-data)
+                                                       (:name (:author reaction-data)))
+                                             :author-ids (authors-fn (:author-ids old-reaction-data)
+                                                          (:user-id (:author reaction-data)))
                                              :links (:links old-reaction-data)})
           new-reactions-data (if reaction-idx
                                (assoc reactions-data reaction-idx with-reacted)


### PR DESCRIPTION
From: https://trello.com/c/Svdv1puR

Review with: https://github.com/open-company/open-company-interaction/pull/34

Item:
> Add hover tip that shows you who left reactions on comments (just like it works for reactions left on posts)

To test:
- add a reaction to a post with user A
- with user A and B check the tooltip
- react with B too
- with user A and B check the tooltip
- remove reaction with A
- with user A and B check the tooltip
- repeat for a comment