### PR TITLE
Mobile sections list dismiss

### DIFF
--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -94,6 +94,7 @@ nav.oc-navbar {
             left: 0;
             background-color: transparent;
             display: block;
+            z-index: #{$navbar_zindex + 10};
 
             div.mobile-sections-list-inner {
               display: block;

--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -86,125 +86,136 @@ nav.oc-navbar {
           display: none;
 
           @include mobile() {
-            display: block;
-            width: calc(100vw - 64px - 80px);
-            max-height: 60vh;
+            width: 100vw;
+            height: 100vh;
             position: absolute;
-            top: 48px;
+            position: fixed;
+            top: 0;
             left: 0;
-            border-radius: 4px;
-            background-color: white;
-            padding: 8px 0 0;
-            overflow-x: hidden;
-            overflow-y: auto;
-            border: 1px solid $mid_light_grey;
-            box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.07);
+            background-color: transparent;
+            display: block;
 
-            button.mobile-section-item {
+            div.mobile-sections-list-inner {
               display: block;
-              width: 100%;
-              height: 34px;
-              padding: 8px 16px;
-              @include OC_Body_Book();
-              color: rgba($light_navy, 0.5);
-              font-size: 14px;
-              line-height: 18px;
-              text-align: left;
-              max-width: 100%;
-              overflow: hidden;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-              position: relative;
+              width: calc(100vw - 64px - 80px);
+              max-height: 60vh;
+              position: absolute;
+              top: 64px;
+              left: 72px;
+              border-radius: 4px;
+              background-color: white;
+              padding: 8px 0 0;
+              overflow-x: hidden;
+              overflow-y: auto;
+              border: 1px solid $mid_light_grey;
+              box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.07);
 
-              &.compose {
-                padding-left: 39px;
-                &:before {
-                  content: " ";
+              button.mobile-section-item {
+                display: block;
+                width: 100%;
+                height: 34px;
+                padding: 8px 16px;
+                @include OC_Body_Book();
+                color: rgba($light_navy, 0.5);
+                font-size: 14px;
+                line-height: 18px;
+                text-align: left;
+                max-width: 100%;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                position: relative;
+
+                &.compose {
+                  padding-left: 39px;
+                  &:before {
+                    content: " ";
+                    width: 12px;
+                    height: 12px;
+                    position: absolute;
+                    top: 11px;
+                    left: 18px;
+                    background-image: cdnUrl("/img/ML/compose_icon_grey.svg");
+                    background-size: 12px 12px;
+                    background-repeat: no-repeat;
+                    background-position: center;
+                    opacity: 0.5;
+                  }
+                }
+
+                &.all-posts {
+                  padding-left: 39px;
+                  &:before {
+                    content: " ";
+                    width: 16px;
+                    height: 16px;
+                    position: absolute;
+                    top: 9px;
+                    left: 16px;
+                    background-image: cdnUrl("/img/ML/digest_icon_grey.svg");
+                    background-size: 16px 16px;
+                    background-repeat: no-repeat;
+                    background-position: center;
+                    opacity: 0.5;
+                  }
+                }
+
+                &.drafts {
+                  padding-left: 39px;
+                  &:before {
+                    content: " ";
+                    width: 12px;
+                    height: 16px;
+                    position: absolute;
+                    top: 9px;
+                    left: 18px;
+                    background-image: cdnUrl("/img/ML/drafts_icon_grey.svg");
+                    background-size: 12px 16px;
+                    background-repeat: no-repeat;
+                    background-position: center;
+                    opacity: 0.5;
+                  }
+                }
+
+                &.active {
+                  background-color: $ultra_light_grey;
+                  color: $light_navy;
+
+                  &.all-posts:before, &.drafts:before {
+                    opacity: 1;
+                  }
+                }
+              }
+
+              button.mobile-section-item-compose {
+                border-radius: 6px;
+                background-color: $carrot_green;
+                margin: 8px;
+                text-align: center;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                height: 40px;
+                width: calc(100% - 16px);
+                opacity: 1;
+
+                span.compose-green-icon {
                   width: 12px;
-                  height: 12px;
-                  position: absolute;
-                  top: 11px;
-                  left: 18px;
-                  background-image: cdnUrl("/img/ML/compose_icon_grey.svg");
+                  height: 22px;
+                  background-image: cdnUrl("/img/ML/white_pen.svg");
                   background-size: 12px 12px;
-                  background-repeat: no-repeat;
                   background-position: center;
-                  opacity: 0.5;
-                }
-              }
-
-              &.all-posts {
-                padding-left: 39px;
-                &:before {
-                  content: " ";
-                  width: 16px;
-                  height: 16px;
-                  position: absolute;
-                  top: 9px;
-                  left: 16px;
-                  background-image: cdnUrl("/img/ML/digest_icon_grey.svg");
-                  background-size: 16px 16px;
                   background-repeat: no-repeat;
-                  background-position: center;
-                  opacity: 0.5;
                 }
-              }
 
-              &.drafts {
-                padding-left: 39px;
-                &:before {
-                  content: " ";
-                  width: 12px;
-                  height: 16px;
-                  position: absolute;
-                  top: 9px;
-                  left: 18px;
-                  background-image: cdnUrl("/img/ML/drafts_icon_grey.svg");
-                  background-size: 12px 16px;
-                  background-repeat: no-repeat;
-                  background-position: center;
-                  opacity: 0.5;
+                span.compose-green-label {
+                  @include OC_Body_Bold();
+                  font-size: 16px;
+                  line-height: 22px;
+                  color: white;
+                  margin-left: 8px;
+                  margin-top: 1px;
                 }
-              }
-
-              &.active {
-                background-color: $ultra_light_grey;
-                color: $light_navy;
-
-                &.all-posts:before, &.drafts:before {
-                  opacity: 1;
-                }
-              }
-            }
-
-            button.mobile-section-item-compose {
-              border-radius: 6px;
-              background-color: $carrot_green;
-              margin: 8px;
-              text-align: center;
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              height: 40px;
-              width: calc(100% - 16px);
-              opacity: 1;
-
-              span.compose-green-icon {
-                width: 12px;
-                height: 22px;
-                background-image: cdnUrl("/img/ML/white_pen.svg");
-                background-size: 12px 12px;
-                background-position: center;
-                background-repeat: no-repeat;
-              }
-
-              span.compose-green-label {
-                @include OC_Body_Bold();
-                font-size: 16px;
-                line-height: 22px;
-                color: white;
-                margin-left: 8px;
-                margin-top: 1px;
               }
             }
           }

--- a/scss/partials/_navbar.scss
+++ b/scss/partials/_navbar.scss
@@ -177,9 +177,10 @@ nav.oc-navbar {
                   }
                 }
 
-                &.active {
+                &.active, &:focus, &:active {
                   background-color: $ultra_light_grey;
                   color: $light_navy;
+                  -webkit-tap-highlight-color: $ultra_light_grey;
 
                   &.all-posts:before, &.drafts:before {
                     opacity: 1;
@@ -265,6 +266,14 @@ nav.oc-navbar {
 
         div.orgs-dropdown {
           float: left;
+
+          button.orgs-dropdown-btn {
+            div.org-avatar-container {
+              span.org-name {
+                font-size: 18px;
+              }
+            }
+          }
 
           @include mobile(){
             height: 40px;

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -32,10 +32,6 @@
                     (drv/drv :show-add-post-tooltip)
                     (ui-mixins/render-on-resize nil)
                     (rum/local false ::show-sections-list)
-                    (ui-mixins/on-window-click-mixin (fn [s e]
-                      (when (and @(::show-sections-list s)
-                                 (not (utils/event-inside? e (rum/ref-node s :mobile-board-button))))
-                        (reset! (::show-sections-list s) false))))
                     {:did-mount (fn [s]
                      (when-not (utils/is-test-env?)
                        (when-not (responsive/is-tablet-or-mobile?)
@@ -106,27 +102,31 @@
                 section-name]
               (when @(::show-sections-list s)
                 [:div.mobile-sections-list
-                  (when show-all-posts
-                    [:button.mlb-reset.mobile-section-item.all-posts
-                      {:class (when (= (router/current-board-slug) "all-posts") "active")
-                       :on-click #(mobile-nav! % "all-posts")}
-                      "All Posts"])
-                  (when drafts-link
-                    [:button.mlb-reset.mobile-section-item.drafts
-                      {:class (when (= (router/current-board-slug) utils/default-drafts-board-slug) "active")
-                       :on-click #(mobile-nav! % utils/default-drafts-board-slug)}
-                      "Drafts"])
-                  (for [board sorted-boards]
-                    [:button.mlb-reset.mobile-section-item
-                      {:key (str "mobile-section-" (:slug board))
-                       :class (when (= (router/current-board-slug) (:slug board)) "active")
-                       :on-click #(mobile-nav! % (:slug board))}
-                      (:name board)])
-                  (when can-compose?
-                    [:button.mlb-reset.mobile-section-item-compose
-                      {:on-click #(ui-compose @(drv/get-ref s :show-add-post-tooltip))}
-                      [:span.compose-green-icon]
-                      [:span.compose-green-label "New post"]])])]
+                  {:on-click #(reset! (::show-sections-list s) false)}
+                  [:div.mobile-sections-list-inner
+                    (when show-all-posts
+                      [:button.mlb-reset.mobile-section-item.all-posts
+                        {:class (when (= (router/current-board-slug) "all-posts") "active")
+                         :on-click #(mobile-nav! % "all-posts")}
+                        "All Posts"])
+                    (when drafts-link
+                      [:button.mlb-reset.mobile-section-item.drafts
+                        {:class (when (= (router/current-board-slug) utils/default-drafts-board-slug) "active")
+                         :on-click #(mobile-nav! % utils/default-drafts-board-slug)}
+                        "Drafts"])
+                    (for [board sorted-boards]
+                      [:button.mlb-reset.mobile-section-item
+                        {:key (str "mobile-section-" (:slug board))
+                         :class (when (= (router/current-board-slug) (:slug board)) "active")
+                         :on-click #(mobile-nav! % (:slug board))}
+                        (:name board)])
+                    (when can-compose?
+                      [:button.mlb-reset.mobile-section-item-compose
+                        {:on-click (fn [e]
+                                      (utils/event-stop e)
+                                      (ui-compose @(drv/get-ref s :show-add-post-tooltip)))}
+                        [:span.compose-green-icon]
+                        [:span.compose-green-label "New post"]])]])]
             [:div.navbar-center
               {:class (when search-active "search-active")}
               (search-box)])

--- a/src/oc/web/components/ui/navbar.cljs
+++ b/src/oc/web/components/ui/navbar.cljs
@@ -24,7 +24,6 @@
             [oc.web.components.ui.user-avatar :refer (user-avatar)]))
 
 (defn- mobile-nav! [e board-slug]
-  (utils/event-stop e)
   (router/nav! (oc-urls/board board-slug)))
 
 (rum/defcs navbar < rum/reactive
@@ -122,9 +121,7 @@
                         (:name board)])
                     (when can-compose?
                       [:button.mlb-reset.mobile-section-item-compose
-                        {:on-click (fn [e]
-                                      (utils/event-stop e)
-                                      (ui-compose @(drv/get-ref s :show-add-post-tooltip)))}
+                        {:on-click #(ui-compose @(drv/get-ref s :show-add-post-tooltip))}
                         [:span.compose-green-icon]
                         [:span.compose-green-label "New post"]])]])]
             [:div.navbar-center


### PR DESCRIPTION
Replace of #904 

From [QA doc](https://paper.dropbox.com/doc/Post-beta-bugs-and-comments--AeU_GqSGUBWtqpEBVWd04VhzAg-SPQWk76sbpqMUySRddhEm)
Item:
> Mobile: when sections dropdown is open don’t open a post on click, just dismiss the sections list

This is sort of a hack, i had to delay the closing of the sections list to let the other components check if that's open and block the action in case. I really don't like it, it slows down things and it's a bit hard to track down if you don't know but it's the only thing i could think of.

To test:
- on desktop open AP
- [ ] can you expand a post?
- [ ] can you click on the comments summary to expand it?
- [ ] can you open the ... menu?
- now go on mobile
- [ ] can you expand a post?
- [ ] can you click on the comments summary to expand it?
- [ ] can you open the ... menu?
- now click on sections list button and while open
- [ ] if you click on a post body or headline does it closes the list and nothing else?
- expand the sections list again
- [ ] if you click on the comments summary does it closes the list and nothing else?
- expand the sections list again
- [ ] if you click on the more menu does it closes the list and nothing else?