### PR TITLE
Fix viewer contributor access

### DIFF
--- a/src/oc/web/components/ui/empty_board.cljs
+++ b/src/oc/web/components/ui/empty_board.cljs
@@ -43,7 +43,9 @@
            is-must-see? "When someone marks a post as “must see” everyone will see it here."
            is-drafts-board? "Keep a private draft until you're ready to share it with your team."
            :else (when is-author? (str "Looks like there aren’t any posts in " (:name board-data) ".")))]
-        (when (pos? (count editable-boards))
+        (when (or (and (or is-all-posts? is-must-see? is-drafts-board?)
+                       (pos? (count editable-boards)))
+                  (not (:read-only board-data)))
           [:button.mlb-reset.create-new-post-bt
             {:on-click #(activity-actions/activity-edit)}
             "Create a new post"])]]))


### PR DESCRIPTION
Following a comment on this PR: https://github.com/open-company/open-company-storage/pull/201
> As viewer user B I get the "Create a new post" button in empty sections that I'm not a contributor in.

This fix is intended to show the new post button on empty board only when needed.

To test:
- create a new org (is better to create since you'll have to delete all the posts later)
- invite a user to your org as viewer
- add a new private section and make the viewer an author on that section
- delete all the posts from the org
- switch account and login as the viewer
- go to AP
- [x] do you see a create post button?
- go to Drafts
- [x] do you see a create post button?
- go to a team section (General for example)
- [x] do you NOT see a create post button?
- go to the private section
- [x] do you see a create post button?
- now go back to the admin account and change the viewer to be a viewer also on the private section
- [x] do you NOT see the create post button in any board?