### PR TITLE
Remove profile url

### DIFF
--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -240,7 +240,7 @@
         (entry-point-get-finished success body)
         (let [orgs (:items (:collection body))
               to-org (utils/get-default-org orgs)]
-          (router/redirect! (if to-org (oc-urls/all-posts (:slug to-org)) oc-urls/user-profile)))))))
+          (router/redirect! (if to-org (oc-urls/all-posts (:slug to-org)) oc-urls/sign-up-profile)))))))
   (when (= token-type :password-reset)
     (cook/set-cookie! :show-login-overlay "collect-password"))
   (dis/dispatch! [:auth-with-token/success jwt]))

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -949,12 +949,13 @@
         "Thanks for verifying"
         [:button.mlb-reset.continue
           {:on-click #(let [org (utils/get-default-org orgs)]
-                        (if org
-                          (if (and (empty? (jwt/get-key :first-name))
-                                   (empty? (jwt/get-key :last-name)))
-                            (router/nav! oc-urls/confirm-invitation-profile)
-                            (router/nav! (oc-urls/org (:slug org))))
-                          (router/nav! oc-urls/login)))
+                        (router/nav!
+                         (if org
+                           (if (and (empty? (jwt/get-key :first-name))
+                                    (empty? (jwt/get-key :last-name)))
+                             oc-urls/confirm-invitation-profile
+                             (oc-urls/org (:slug org)))
+                          oc-urls/sign-up-profile)))
            :on-touch-start identity}
           "Get Started"]]
       :else

--- a/src/oc/web/urls.cljs
+++ b/src/oc/web/urls.cljs
@@ -92,11 +92,6 @@
 
 (def login-wall "/login-wall")
 
-;; User
-
-(def user-profile "/profile")
-(def user-notifications "/profile/notifications")
-
 ;; Organizations
 
 (defn org


### PR DESCRIPTION
Bug: we still have the /profile url used in some places of the app. We need to remove them

Review with:
- [Email](https://github.com/open-company/open-company-email/pull/52)

To test:
- signup with email
- wait the verification email
- click the link in the email
- [x] are you redirected to the user and team setup page instead of a 404 (was /profile)? 
- now invite another user
- accept the invitation
- create a reminder for that user
- check the reminder created email
- [x] the footer link saying Carrot redirect you to AP with the notifications panel open (not to /profile/notifications)? Good