### PR TITLE
Ms edge fixes 2

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -128,6 +128,7 @@ var OCStaticStartFixFixedPositioning = function(){};
 var OnPaste_StripFormatting = function(){};
 var isSafari = function(){};
 var isIE = function(){};
+var isEdge = function(){};
 // Rangy
 var rangy = function(){};
 rangy.createClassApplier = function(){};

--- a/site/oc/core.clj
+++ b/site/oc/core.clj
@@ -36,7 +36,8 @@
     ;; Favicon
     [:link {:rel "icon" :type "image/png" :href (pages/cdn "/img/carrot_logo.png") :sizes "64x64"}]
     ;; jQuery needed by Bootstrap JavaScript
-    [:script {:src "//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js" :type "text/javascript"}]
+    pages/ie-jquery-fix
+    pages/jquery
     ;; Static js files
     [:script {:src (pages/cdn "/js/static-js.js")}]
     ;; Intercom (Support chat)

--- a/site/oc/pages.clj
+++ b/site/oc/pages.clj
@@ -28,6 +28,13 @@
     {:rel "stylesheet"
      :href "//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css"}])
 
+(def ie-jquery-fix
+  ;; From https://stackoverflow.com/questions/5087549/access-denied-to-jquery-script-on-ie
+  ;; Github: https://github.com/MoonScript/jQuery-ajaxTransport-XDomainRequest
+  [:script
+    {:src "//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.4/jquery.xdomainrequest.min.js"
+     :crossorigin "anonymous"}])
+
 (def jquery
   [:script
     {:src "//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"
@@ -1224,6 +1231,7 @@
           [:script {:type "text/javascript" :src "/lib/autotrack/google-analytics.js"}]
           (google-analytics-init)
           ;; jQuery needed by Bootstrap JavaScript
+          ie-jquery-fix
           jquery
           ;; Truncate html string
           [:script {:type "text/javascript" :src "/lib/truncate/jquery.dotdotdot.js"}]
@@ -1292,6 +1300,7 @@
           ;; App single CSS
           [:link {:type "text/css" :rel "stylesheet" :href (cdn "/main.css")}]
           ;; jQuery needed by Bootstrap JavaScript
+          ie-jquery-fix
           jquery
           ;; Automatically load the needed polyfill depending on
           ;; the browser user agent and the available features

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -591,7 +591,9 @@
       (when-not (.-isNavigation e)
         ;; in this case, we're setting it so
         ;; let's scroll to the top to simulate a navigation
-        (js/window.scrollTo 0 0))
+        (if (js/isEdge)
+          (aset (.. js/document -scrollingElement -scrollTop) 0)
+          (js/window.scrollTo 0 0)))
       ;; dispatch on the token
       (secretary/dispatch! (router/get-token))
       ; remove all the tooltips

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -592,7 +592,7 @@
         ;; in this case, we're setting it so
         ;; let's scroll to the top to simulate a navigation
         (if (js/isEdge)
-          (aset (.. js/document -scrollingElement -scrollTop) 0)
+          (set! (.. js/document -scrollingElement -scrollTop) 0)
           (js/window.scrollTo 0 0)))
       ;; dispatch on the token
       (secretary/dispatch! (router/get-token))

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -190,7 +190,9 @@
 
 (defn scroll-to-y [scroll-y & [duration]]
   (if (and duration (zero? duration))
-    (.scrollTo (.-scrollingElement js/document) 0 scroll-y)
+    (if (js/isEdge)
+      (aset (.. js/document -scrollingElement -scrollTop) scroll-y)
+      (.scrollTo (.-scrollingElement js/document) 0 scroll-y))
     (.play
       (new Scroll
            (.-scrollingElement js/document)

--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -191,7 +191,7 @@
 (defn scroll-to-y [scroll-y & [duration]]
   (if (and duration (zero? duration))
     (if (js/isEdge)
-      (aset (.. js/document -scrollingElement -scrollTop) scroll-y)
+      (set! (.. js/document -scrollingElement -scrollTop) scroll-y)
       (.scrollTo (.-scrollingElement js/document) 0 scroll-y))
     (.play
       (new Scroll


### PR DESCRIPTION
Bug: Microsoft Edge has a [known bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15534521/) on scrollTo function, i replaced all those calls with `(set! (.. js/document -scrollingElement -scrollTop) scroll-to-y)` only for this browser.

To test:
- load this branch with Chrome
- scroll down the stream
- click on a post
- [ ] do you see the top of the expanded post without having to scroll back up? Good
- no click the back to AP (or section name) button
- [ ] are you at the same scroll point where you left? Good
- repeat on Edge to make sure it works