### PR TITLE
Fix login redirect

### DIFF
--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -105,6 +105,7 @@
 (defn maybe-save-login-redirect []
   (let [url-pathname (.. js/window -location -pathname)
         is-login-route? (or (= url-pathname oc-urls/login-wall)
+                            (= url-pathname oc-urls/login)
                             (= url-pathname oc-urls/desktop-login))]
     (cond
       (and is-login-route?


### PR DESCRIPTION
Bug: right now we save as a redirect place every path the login is happening from except /login/desktop and /login-wall, we should check also /login.
This makes so there is a redirect to /login after Slack and Google auth, no big deal, but this should fix it.

To test:
- try logging in from Electron app with Slack
- [x] do you NOT see a redirect to /login? Good
- [x] did it work?
- try logging in from Electron app with Google
- [x] do you NOT see a redirect to /login? Good
- [x] did it work?
- try logging in from Electron app with Email
- [x] do you NOT see a redirect to /login? Good
- [x] did it work?
- [x] signup from electron app (just to make sure)
- try logging in from web app with Slack
- [x] do you NOT see a redirect to /login? Good
- [x] did it work?
- try logging in from web app with Google
- [x] do you NOT see a redirect to /login? Good
- [x] did it work?
- try logging in from web app with email
- [x] do you NOT see a redirect to /login? Good
- [x] did it work?
- [x] signup from web app (just to make sure)