### PR TITLE
Edge: avoid dotdotdot truncation

### DIFF
--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -435,6 +435,10 @@ div.stream-item {
         white-space: pre-wrap;
         word-break: break-word;
 
+        &.no-abstract {
+          max-height: #{24 * 3}px;
+        }
+
         @include mobile() {
           margin-top: 4px;
         }

--- a/site/oc/core.clj
+++ b/site/oc/core.clj
@@ -36,8 +36,8 @@
     ;; Favicon
     [:link {:rel "icon" :type "image/png" :href (pages/cdn "/img/carrot_logo.png") :sizes "64x64"}]
     ;; jQuery needed by Bootstrap JavaScript
-    pages/ie-jquery-fix
     pages/jquery
+    pages/ie-jquery-fix
     ;; Static js files
     [:script {:src (pages/cdn "/js/static-js.js")}]
     ;; Intercom (Support chat)

--- a/site/oc/pages.clj
+++ b/site/oc/pages.clj
@@ -1231,8 +1231,8 @@
           [:script {:type "text/javascript" :src "/lib/autotrack/google-analytics.js"}]
           (google-analytics-init)
           ;; jQuery needed by Bootstrap JavaScript
-          ie-jquery-fix
           jquery
+          ie-jquery-fix
           ;; Truncate html string
           [:script {:type "text/javascript" :src "/lib/truncate/jquery.dotdotdot.js"}]
           ;; Rangy
@@ -1300,8 +1300,8 @@
           ;; App single CSS
           [:link {:type "text/css" :rel "stylesheet" :href (cdn "/main.css")}]
           ;; jQuery needed by Bootstrap JavaScript
-          ie-jquery-fix
           jquery
+          ie-jquery-fix
           ;; Automatically load the needed polyfill depending on
           ;; the browser user agent and the available features
           [:script {:src "https://cdn.polyfill.io/v2/polyfill.min.js"}]

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -56,7 +56,8 @@
                          (rum/local 0 ::mobile-video-height)
                          ;; Mixins
                          (ui-mixins/render-on-resize calc-video-height)
-                         (am/truncate-element-mixin "div.stream-item-body.no-abstract" (* 24 3))
+                         (when-not (js/isEdge)
+                           (am/truncate-element-mixin "div.stream-item-body.no-abstract" (* 24 3)))
                          (mention-mixins/oc-mentions-hover)
                          {:will-mount (fn [s]
                            (calc-video-height s)


### PR DESCRIPTION
BUG: still having some white pages when going back to section from an expanded post on Edge browsers.

Solution: the stack trace is always mentioning dotdotdot library and jquery so with this we avoid using that library to truncate the FoC text, it just cut to 3 lines using the css's overflow property.

To test:
- open some posts from different sections in Edge
- [ ] go back using the Back to section button
- [ ] go back using the browser back button
- [ ] no errors? Good