### PR TITLE
Change target to nsis, create windows prod boot task, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,11 +366,16 @@ will sense the new update, and automatically install it in the background.
 boot prod-electron-windows
 cd target/
 yarn install
-npx electron-builder --win --publish always"
+npx electron-builder --win --publish always
 ```
 
 This will build, sign, and publish an EXE to GitHub Releases alongside any existing Mac builds with the same version. This EXE
 is an installer, and is completely self-contained.
+
+To produce a test build without releasing it replace the last command with:
+```
+npx electron-builder --win
+```
 
 ## Participation
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Because this is a development build in Apple's eyes, _it is only runnable by the
 not publish this build in the GitHub Release panel, and instead should distribute it to testers manually.
 
 
-#### Production Release
+#### Production Release (Mac)
 
 ```
 # Bump the version in resources/package.json to X.Y.Z (drop the build number)
@@ -359,6 +359,18 @@ Keep in mind that this can take a while (~10 minutes) due to requiring Apple's s
 This will build, sign, notarize, and publish a tagged draft release to [GitHub Releases](https://github.com/open-company/open-company-web/releases).
 Navigate your way there, and if you're ready to roll the release out to customers, you can Publish the draft. Existing client installations
 will sense the new update, and automatically install it in the background.
+
+#### Production Release (Windows)
+
+```
+boot prod-electron-windows
+cd target/
+yarn install
+npx electron-builder --win --publish always"
+```
+
+This will build, sign, and publish an EXE to GitHub Releases alongside any existing Mac builds with the same version. This EXE
+is an installer, and is completely self-contained.
 
 ## Participation
 

--- a/build.boot
+++ b/build.boot
@@ -317,3 +317,14 @@
                                                    'oc.electron.main/web-origin  "https://carrot.io"
                                                    'oc.electron.main/auth-origin "https://beta-auth.carrot.io"}})
         (target)))
+
+(deftask prod-electron-windows
+  "Carrot electron app loading production carrot.io"
+  []
+  (set-env! :dependencies #(into % '[[binaryage/devtools "0.9.8"]]))
+  (comp (cljs :ids #{"electron\\main"}
+              :optimizations :simple
+              :compiler-options {:closure-defines {'oc.electron.main/dev?        false
+                                                   'oc.electron.main/web-origin  "https://carrot.io"
+                                                   'oc.electron.main/auth-origin "https://beta-auth.carrot.io"}})
+        (target)))

--- a/build.boot
+++ b/build.boot
@@ -307,6 +307,17 @@
                                                    'oc.electron.main/auth-origin "https://staging-auth.carrot.io"}})
         (target)))
 
+(deftask staging-electron-windows
+  "Carrot electron app loading staging.carrot.io"
+  []
+  (set-env! :dependencies #(into % '[[binaryage/devtools "0.9.8"]]))
+  (comp (cljs :ids #{"electron\\main"}
+              :optimizations :simple
+              :compiler-options {:closure-defines {'oc.electron.main/dev?        false
+                                                   'oc.electron.main/web-origin  "https://staging.carrot.io"
+                                                   'oc.electron.main/auth-origin "https://staging-auth.carrot.io"}})
+        (target)))
+
 (deftask prod-electron
   "Carrot electron app loading production carrot.io"
   []

--- a/build.boot
+++ b/build.boot
@@ -287,8 +287,6 @@
   (set-env! :dependencies #(into % '[[binaryage/devtools "0.9.8"]]))
   (comp (from-jars)
         (watch)
-        ;; double backslash necessary for building on Windows
-        ;; https://github.com/boot-clj/boot-cljs/pull/118
         (cljs :ids #{"electron/main"}
               :optimizations :simple
               :compiler-options {:closure-defines {'oc.electron.main/dev?        true
@@ -311,7 +309,9 @@
   "Carrot electron app loading staging.carrot.io"
   []
   (set-env! :dependencies #(into % '[[binaryage/devtools "0.9.8"]]))
-  (comp (cljs :ids #{"electron\\main"}
+  (comp ;; double backslash necessary for building on Windows
+        ;; https://github.com/boot-clj/boot-cljs/pull/118
+        (cljs :ids #{"electron\\main"}
               :optimizations :simple
               :compiler-options {:closure-defines {'oc.electron.main/dev?        false
                                                    'oc.electron.main/web-origin  "https://staging.carrot.io"
@@ -333,7 +333,9 @@
   "Carrot electron app loading production carrot.io"
   []
   (set-env! :dependencies #(into % '[[binaryage/devtools "0.9.8"]]))
-  (comp (cljs :ids #{"electron\\main"}
+  (comp ;; double backslash necessary for building on Windows
+        ;; https://github.com/boot-clj/boot-cljs/pull/118
+        (cljs :ids #{"electron\\main"}
               :optimizations :simple
               :compiler-options {:closure-defines {'oc.electron.main/dev?        false
                                                    'oc.electron.main/web-origin  "https://carrot.io"

--- a/resources/electron-builder.example.env
+++ b/resources/electron-builder.example.env
@@ -1,3 +1,7 @@
 GH_TOKEN="your-github-token-for-publishing-releases"
+
 APPLEID="your-apple-id"
 APPLEIDPASS="your-apple-id-password"
+
+WIN_CSC_LINK="C:\path\to\DeveloperSigningCert.pfx"
+WIN_CSC_KEY_PASSWORD="signing-cert-private-key-password"

--- a/resources/package.json
+++ b/resources/package.json
@@ -27,7 +27,7 @@
       "sign": false
     },
     "win": {
-      "target": ["appx"],
+      "target": ["nsis"],
       "icon": "carrot.iconset/icon.ico"
     },
     "afterSign": "electron/notarize.js",


### PR DESCRIPTION
Very small tweaks to Windows production desktop builds.

- Target changed to NSIS from AppX (this is much simpler)
- Boot has some [issues with paths on Windows](https://github.com/boot-clj/boot-cljs/pull/118) and so there's now a new boot task with a trivial configuration difference to make it work on Windows.
- Updated readme with Windows-specific build instructions

There aren't really any explicit test instructions for this. If you're feeling so inclined and have a Windows box laying around, please try producing a Windows production artifact locally and make sure the instructions are clear. To do this without publishing the build to GitHub Releases, use this:

```
boot prod-electron-windows
cd target/
yarn install
npx electron-builder --win
```

The resulting EXE should then be located in the `dist` folder.