### PR TITLE
Fix drafts count

### DIFF
--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -564,7 +564,7 @@
   ([org-slug]
     (draft-posts-data @app-state org-slug))
   ([data org-slug]
-    (filtered-posts-data data org-slug utils/default-drafts-board-slug)))
+    (filtered-posts-data data org-slug utils/default-drafts-board-slug :recently-posted)))
 
 (defn activity-data
   "Get activity data."


### PR DESCRIPTION
BUG: drafts count is only visible when the draft board is selected, it should always be

To test:
- on mainline
- nav to AP
- nav to a section
- switch section
- [x] do you NOT see drafts count? Bad but good
- switch to this branch
- [x] do you see the count now? Good
- now add a post with quick post
- [x] do you see drafts count incremented once the initial draft is saved? Good
- delete the draft
- [x] do you see the count decrement? Good
- now nav to drafts board
- [x] do you see the count?
- delete a draft
- [x] count still right? Good