### PR TITLE
Fix quick post NUX

### DIFF
--- a/scss/partials/_expanded_post.scss
+++ b/scss/partials/_expanded_post.scss
@@ -203,49 +203,6 @@ div.expanded-post {
       @include mobile() {
         margin-top: 0;
       }
-
-      div.post-added-tooltip-container {
-        position: absolute;
-        bottom: 40px;
-        left: 0;
-        width: 320px;
-        padding: 16px;
-        border-radius: 4px;
-        background-color: $deep_navy;
-
-        &:after {
-          content: " ";
-          position: absolute;
-          left: 24px;
-          bottom: -3px;
-          width: 6px;
-          height: 6px;
-          transform: rotate(-45deg);
-          background-color: $deep_navy;
-        }
-
-        div.post-added-tooltip-title {
-          color: white;
-          @include OC_Body_Bold();
-          font-size: 16px;
-        }
-
-        div.post-added-tooltip {
-          margin-top: 8px;
-          color: white;
-          @include OC_Body_Book();
-          font-size: 14px;
-        }
-
-        button.post-added-tooltip-bt {
-          @include OC_Body_Bold();
-          font-size: 14px;
-          color: $carrot_green;
-          margin-top: 8px;
-          padding: 0;
-          display: block;
-        }
-      }
     }
   }
 

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -661,6 +661,49 @@ div.stream-item {
           margin-left: 2px;
           margin-top: 0;
         }
+
+        div.post-added-tooltip-container {
+          position: absolute;
+          bottom: 30px;
+          left: 0;
+          width: 320px;
+          padding: 16px;
+          border-radius: 4px;
+          background-color: $deep_navy;
+
+          &:after {
+            content: " ";
+            position: absolute;
+            left: 24px;
+            bottom: -3px;
+            width: 6px;
+            height: 6px;
+            transform: rotate(-45deg);
+            background-color: $deep_navy;
+          }
+
+          div.post-added-tooltip-title {
+            color: white;
+            @include OC_Body_Bold();
+            font-size: 16px;
+          }
+
+          div.post-added-tooltip {
+            margin-top: 8px;
+            color: white;
+            @include OC_Body_Book();
+            font-size: 14px;
+          }
+
+          button.post-added-tooltip-bt {
+            @include OC_Body_Bold();
+            font-size: 14px;
+            color: $carrot_green;
+            margin-top: 8px;
+            padding: 0;
+            display: block;
+          }
+        }
       }
 
       div.time-since {

--- a/src/oc/web/actions/nav_sidebar.cljs
+++ b/src/oc/web/actions/nav_sidebar.cljs
@@ -3,6 +3,7 @@
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
             [oc.web.utils.dom :as dom-utils]
+            [oc.web.actions.nux :as nux-actions]
             [oc.web.lib.responsive :as responsive]
             [oc.web.actions.user :as user-actions]
             [oc.web.actions.cmail :as cmail-actions]
@@ -30,6 +31,7 @@
              (.-preventDefault e))
     (.preventDefault e))
   (cmail-actions/cmail-hide)
+  (nux-actions/dismiss-post-added-tooltip)
   (dis/dispatch! [:reset-ap-initial-at (router/current-org-slug)])
   (let [current-path (str (.. js/window -location -pathname) (.. js/window -location -search))]
     (if (= current-path url)

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -317,7 +317,8 @@
                                              (if (seq (:headline cmail-data))
                                                (:headline cmail-data)
                                                ""))]
-                      (when-not (seq (:uuid cmail-data))
+                      (when (and (not (seq (:uuid cmail-data)))
+                                 (not (:collapsed cmail-state)))
                         (nux-actions/dismiss-add-post-tooltip))
                       (reset! (::initial-body s) initial-body)
                       (reset! (::initial-headline s) initial-headline)
@@ -344,7 +345,8 @@
                                                    (if (seq (:headline cmail-data))
                                                      (:headline cmail-data)
                                                      ""))]
-                            (when-not (seq (:uuid cmail-data))
+                            (when (and (not (seq (:uuid cmail-data)))
+                                       (not (:collapsed cmail-state)))
                               (nux-actions/dismiss-add-post-tooltip))
                             (reset! (::initial-body s) initial-body)
                             (reset! (::initial-headline s) initial-headline)
@@ -444,6 +446,7 @@
       {:class (utils/class-set {:fullscreen is-fullscreen?
                                 :quick-post-collapsed (:collapsed cmail-state)})
        :on-click #(when (:collapsed cmail-state)
+                    (nux-actions/dismiss-add-post-tooltip)
                     (cmail-actions/cmail-show (cmail-actions/get-board-for-edit) {:collapsed false
                                                                                   :fullscreen false
                                                                                   :key (:key cmail-state)}))}

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -646,7 +646,8 @@
                                   (and (.-metaKey e)
                                        (= "Enter" (.-key e)))
                                   (post-clicked s)))}]]
-            (when show-edit-tooltip
+            (when (and show-edit-tooltip
+                       is-fullscreen?)
               [:div.edit-tooltip-outer-container
                 [:div.edit-tooltip-container.group
                   [:div.edit-tooltip-title

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -112,9 +112,6 @@
           ;; Show the board always on desktop except when there is an expanded post and
           ;; on mobile only when the navigation menu is not visible
           [:div.board-container.group
-            (when (and (not is-mobile?)
-                       can-compose?)
-              (cmail))
             (let [add-post-tooltip (drv/react s :show-add-post-tooltip)
                   non-admin-tooltip (str "Carrot is where you'll find key announcements, updates, and "
                                          "decisions to keep you and your team pulling in the same direction.")
@@ -144,6 +141,9 @@
                           "New post"])
                     [:div.add-post-tooltip-box.big-web-only
                       {:class (when is-second-user "second-user")}]]]))
+            (when (and (not is-mobile?)
+                       can-compose?)
+               (cmail))
             (when-not current-activity-id
               ;; Board name row: board name, settings button and say something button
               [:div.board-name-container.group

--- a/src/oc/web/components/expanded_post.cljs
+++ b/src/oc/web/components/expanded_post.cljs
@@ -70,7 +70,6 @@
   (drv/drv :hide-left-navbar)
   (drv/drv :add-comment-focus)
   (drv/drv :activities-read)
-  (drv/drv :show-post-added-tooltip)
   ;; Locals
   (rum/local nil ::wh)
   (rum/local nil ::comment-height)
@@ -85,9 +84,6 @@
     s)
    :did-remount (fn [_ s]
     (load-comments s)
-    s)
-   :will-unmount (fn [s]
-    (nux-actions/dismiss-post-added-tooltip)
     s)}
   [s]
   (let [activity-data (drv/react s :activity-data)
@@ -117,10 +113,7 @@
                         :height (utils/calc-video-height 638)}))
         user-is-part-of-the-team (jwt/user-is-part-of-the-team (:team-id (dis/org-data)))
         activities-read (drv/react s :activities-read)
-        reads-data (get activities-read (:uuid activity-data))
-        post-add-tooltip (drv/react s :show-post-added-tooltip)
-        should-show-post-added-tooltip? (and post-add-tooltip
-                                             (= post-add-tooltip (router/current-activity-id)))]
+        reads-data (get activities-read (:uuid activity-data))]
     [:div.expanded-post
       {:class dom-node-class
        :id dom-element-id
@@ -189,17 +182,6 @@
           (reactions activity-data))
         (when user-is-part-of-the-team
           [:div.expanded-post-wrt-container
-            (when should-show-post-added-tooltip?
-              [:div.post-added-tooltip-container
-                {:ref :post-added-tooltip}
-                [:div.post-added-tooltip-title
-                  "Post analytics"]
-                [:div.post-added-tooltip
-                  (str "Invite your team to Carrot so you can know who read your "
-                   "post and when. Click here to access your post analytics anytime.")]
-                [:button.mlb-reset.post-added-tooltip-bt
-                  {:on-click #(nux-actions/dismiss-post-added-tooltip)}
-                  "OK, got it"]])
             (wrt-count activity-data reads-data)])]
       [:div.expanded-post-comments.group
         (stream-comments activity-data comments-data)

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -52,6 +52,7 @@
                          (drv/drv :org-data)
                          (drv/drv :comments-data)
                          (drv/drv :activity-share-container)
+                         (drv/drv :show-post-added-tooltip)
                          ;; Locals
                          (rum/local 0 ::mobile-video-height)
                          ;; Mixins
@@ -100,7 +101,10 @@
                           (and (:new-at activity-data)
                                ;; and that's after the user last read
                                (< (.getTime (utils/js-date (:last-read-at read-data)))
-                                  (.getTime (utils/js-date (:new-at activity-data)))))]
+                                  (.getTime (utils/js-date (:new-at activity-data)))))
+        post-added-tooltip (drv/react s :show-post-added-tooltip)
+        show-post-added-tooltip? (and post-added-tooltip
+                                      (= post-added-tooltip (:uuid activity-data)))]
     [:div.stream-item
       {:class (utils/class-set {dom-node-class true
                                 :draft (not is-published?)
@@ -135,6 +139,7 @@
                                   (not (utils/input-clicked? e))
                                   ;; No body link was clicked
                                   (not (utils/anchor-clicked? e)))
+                         (nux-actions/dismiss-post-added-tooltip)
                          (routing-actions/open-post-modal activity-data false)))))
        :id dom-element-id}
       [:div.stream-item-inner
@@ -223,6 +228,17 @@
                 (when should-show-wrt
                   [:div.stream-item-wrt
                     {:ref :stream-item-wrt}
+                    (when show-post-added-tooltip?
+                      [:div.post-added-tooltip-container
+                        {:ref :post-added-tooltip}
+                        [:div.post-added-tooltip-title
+                          "Post analytics"]
+                        [:div.post-added-tooltip
+                          (str "Invite your team to Carrot so you can know who read your "
+                           "post and when. Click here to access your post analytics anytime.")]
+                        [:button.mlb-reset.post-added-tooltip-bt
+                          {:on-click #(nux-actions/dismiss-post-added-tooltip)}
+                          "OK, got it"]])
                     (wrt-count activity-data read-data)])
                 (when (seq activity-attachments)
                   [:div.stream-item-attachments

--- a/src/oc/web/utils/draft.cljs
+++ b/src/oc/web/utils/draft.cljs
@@ -12,6 +12,7 @@
                     :link-button-title "No"
                     :link-button-cb #(alert-modal/hide-alert)
                     :solid-button-title "Yes"
+                    :solid-button-style :red
                     :solid-button-cb #(do
                                        (activity-actions/activity-delete draft)
                                        (alert-modal/hide-alert))}]


### PR DESCRIPTION
Bug: abstract tooltip is currently shown

To test:
- signup
- do you see the welcome tooltip? Good
- click to expand quick post
- [x] tooltip goes away?
- now add a title
- switch to fullscreen
- [x] do you see the abstract tooltip?
- post
- [x] do you see the WST tooltip now on the newly added post? Good
- you can try dismissing it in 3 ways: nav to another section/AP, expand a post or dismiss with the tooltip button (ask if you think other dismiss should be added)