### PR TITLE
Expand images from post body

### DIFF
--- a/scss/partials/_expanded_post.scss
+++ b/scss/partials/_expanded_post.scss
@@ -132,10 +132,10 @@ div.expanded-post {
     @include activity-body(18, 24, $deep_navy);
     margin-top: 16px;
 
-    .interactable-image {
+    .interactive-image {
       cursor: zoom-in;
 
-      img:hover {
+      &:hover {
           opacity: 0.9;
       }
     }

--- a/scss/partials/_expanded_post.scss
+++ b/scss/partials/_expanded_post.scss
@@ -136,7 +136,7 @@ div.expanded-post {
       cursor: zoom-in;
 
       &:hover {
-          opacity: 0.9;
+          opacity: 0.7;
       }
     }
   }

--- a/scss/partials/_image_modal.scss
+++ b/scss/partials/_image_modal.scss
@@ -16,9 +16,14 @@
   .image-modal-content {
     margin: auto;
     display: block;
+    max-width: 700px;
     max-height: 100%;
     animation-name: zoom;
     animation-duration: 0.6s;
+
+    @include mobile() {
+      max-width: 100%;
+    }
   }
 
   @keyframes zoom {

--- a/scss/partials/_image_modal.scss
+++ b/scss/partials/_image_modal.scss
@@ -1,0 +1,47 @@
+.image-modal-container {
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0, 0, 0); // fallback color
+  background-color: rgba(0, 0, 0, 0.9);
+
+  .image-modal-content {
+    margin: auto;
+    display: block;
+    width: 80%;
+    max-width: 700px;
+    animation-name: zoom;
+    animation-duration: 0.6s;
+
+    // full-width images on mobile
+    @include mobile() {
+      width: 100%;
+    }
+  }
+
+  @keyframes zoom {
+    from {transform:scale(0.7)}
+    to {transform:scale(1)}
+  }
+
+
+  .image-modal-close {
+    position: absolute;
+    top: 15px;
+    right: 35px;
+    color: #f1f1f1;
+    font-size: 40px;
+    font-weight: bold;
+    transition: 0.5s;
+
+    &:hover, &:focus {
+      cursor: pointer;
+      text-decoration: none;
+      color: #bbb;
+    }
+  }
+}

--- a/scss/partials/_image_modal.scss
+++ b/scss/partials/_image_modal.scss
@@ -27,7 +27,6 @@
 
     @include mobile() {
       max-width: 100%;
-      touch-action: auto;
     }
   }
 

--- a/scss/partials/_image_modal.scss
+++ b/scss/partials/_image_modal.scss
@@ -10,8 +10,12 @@
   height: 100%;
   overflow: auto;
   background-color: rgb(0, 0, 0); // fallback color
-  background-color: rgba(0, 0, 0, 0.9);
+  background-color: rgba(0, 0, 0, 0.8);
   padding: 10% 0;
+
+  @include mobile {
+    background-color: $oc_gray_8;
+  }
 
   .image-modal-content {
     margin: auto;
@@ -34,17 +38,20 @@
 
   .image-modal-close {
     position: absolute;
-    top: 15px;
-    right: 35px;
-    color: #f1f1f1;
-    font-size: 40px;
-    font-weight: bold;
-    transition: 0.5s;
+    top: 2%;
+    right: 2%;
+    width: 30px;
+    height: 30px;
+    background-size: 30px 30px;
+    background-image: cdnUrl("/img/ML/white_close.svg");
+    background-repeat: no-repeat;
+
+    @include mobile() {
+      background-image: cdnUrl("/img/ML/black_close.svg");
+    }
 
     &:hover, &:focus {
       cursor: pointer;
-      text-decoration: none;
-      color: #bbb;
     }
   }
 }

--- a/scss/partials/_image_modal.scss
+++ b/scss/partials/_image_modal.scss
@@ -27,6 +27,7 @@
 
     @include mobile() {
       max-width: 100%;
+      touch-action: auto;
     }
   }
 

--- a/scss/partials/_image_modal.scss
+++ b/scss/partials/_image_modal.scss
@@ -1,4 +1,7 @@
 .image-modal-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   position: fixed;
   z-index: 1000;
   left: 0;
@@ -8,19 +11,14 @@
   overflow: auto;
   background-color: rgb(0, 0, 0); // fallback color
   background-color: rgba(0, 0, 0, 0.9);
+  padding: 10% 0;
 
   .image-modal-content {
     margin: auto;
     display: block;
-    width: 80%;
-    max-width: 700px;
+    max-height: 100%;
     animation-name: zoom;
     animation-duration: 0.6s;
-
-    // full-width images on mobile
-    @include mobile() {
-      width: 100%;
-    }
   }
 
   @keyframes zoom {

--- a/scss/public/css/app.main.scss
+++ b/scss/public/css/app.main.scss
@@ -96,3 +96,4 @@
 @import "partials/_whats_new";
 @import "partials/_lazy_stream";
 @import "partials/_electron";
+@import "partials/_image_modal";

--- a/src/oc/web/components/expanded_post.cljs
+++ b/src/oc/web/components/expanded_post.cljs
@@ -54,7 +54,8 @@
 
 (def interactive-images-mixin
   {:did-mount make-images-interactive!
-   :did-remount make-images-interactive!})
+   :did-remount (fn [_ new-state]
+                  (make-images-interactive! new-state))})
 
 (defn- load-comments [s]
   (let [activity-data @(drv/get-ref s :activity-data)]

--- a/src/oc/web/components/expanded_post.cljs
+++ b/src/oc/web/components/expanded_post.cljs
@@ -16,6 +16,7 @@
             [oc.web.components.ui.wrt :refer (wrt-count)]
             [oc.web.actions.activity :as activity-actions]
             [oc.web.components.reactions :refer (reactions)]
+            [oc.web.components.ui.image-modal :as image-modal]
             [oc.web.components.ui.more-menu :refer (more-menu)]
             [oc.web.components.ui.ziggeo :refer (ziggeo-player)]
             [oc.web.components.ui.add-comment :refer (add-comment)]
@@ -40,23 +41,20 @@
   (when (responsive/is-tablet-or-mobile?)
     (reset! (::mobile-video-height s) (utils/calc-video-height (win-width)))))
 
-(defn wrap-img-tags-in-anchors!
-  "Wraps all `img` tags within the post's body in anchor tags to allow for opening in a new tab."
+(defn make-images-interactive!
+  "Attaches classes and click handlers to `img` tags to allow for expanding full-screen images"
   [s]
   (let [body (rum/ref s "post-body")
         imgs (dom/sel body "img")]
     (doseq [img  imgs
-            :let [anchor (dom/create-element "a")
-                  href   (.-src img)]]
-      (dom/set-attr! anchor :href href :target "_blank")
-      (dom/add-class! anchor :interactable-image)
-      (dom/insert-before! anchor img)
-      (dom/remove! img)
-      (dom/replace-contents! anchor img))
+            :let [href (.-src img)]]
+      (dom/add-class! img :interactive-image)
+      (dom/listen! img :click #(reset! (::image-modal-src s) href)))
     s))
 
-(def interactable-images-mixin
-  {:did-mount wrap-img-tags-in-anchors!})
+(def interactive-images-mixin
+  {:did-mount make-images-interactive!
+   :did-remount make-images-interactive!})
 
 (defn- load-comments [s]
   (let [activity-data @(drv/get-ref s :activity-data)]
@@ -74,9 +72,10 @@
   (rum/local nil ::wh)
   (rum/local nil ::comment-height)
   (rum/local 0 ::mobile-video-height)
+  (rum/local nil ::image-modal-src)
   ;; Mixins
   (mention-mixins/oc-mentions-hover)
-  interactable-images-mixin
+  interactive-images-mixin
   {:did-mount (fn [s]
     (save-fixed-comment-height! s)
     (activity-actions/send-item-read (:uuid @(drv/get-ref s :activity-data)))
@@ -118,6 +117,8 @@
       {:class dom-node-class
        :id dom-element-id
        :style {:padding-bottom (str @(::comment-height s) "px")}}
+      (image-modal/image-modal {:src @(::image-modal-src s)
+                                :on-close #(reset! (::image-modal-src s) nil)})
       [:div.activity-share-container]
       [:div.expanded-post-header.group
         [:button.mlb-reset.back-to-board

--- a/src/oc/web/components/ui/image_modal.cljs
+++ b/src/oc/web/components/ui/image_modal.cljs
@@ -7,8 +7,7 @@
     [:div.image-modal-container
       {:on-click on-close}
       [:span.image-modal-close
-        {:on-click on-close}
-        "X"]
+        {:on-click on-close}]
       [:img.image-modal-content
         {:src src}]
       ]))

--- a/src/oc/web/components/ui/image_modal.cljs
+++ b/src/oc/web/components/ui/image_modal.cljs
@@ -1,0 +1,14 @@
+(ns oc.web.components.ui.image-modal
+  (:require [rum.core :as rum]))
+
+(rum/defc image-modal
+  [{:keys [src on-close]}]
+  (when src
+    [:div.image-modal-container
+      {:on-click on-close}
+      [:span.image-modal-close
+        {:on-click on-close}
+        "X"]
+      [:img.image-modal-content
+        {:src src}]
+      ]))


### PR DESCRIPTION
Trello: https://trello.com/c/W1vKv8Cl/2151-expand-images-in-app-instead-of-in-a-new-tab

## Tests

- Make a post with:
    - A large square image
    - A small square image
    - A tall image
    - A wide image
- [x] On web, do they all expand in an acceptable manner when clicked?
- [x] On mobile, do they all expand in an acceptable manner when touched?

#### Mobile links

**iOS**: use `v1.0.3` on TestFlight for testing
**Android (internal link)**: https://play.google.com/apps/test/RQVqwuOCEjI/ahAAvZMmgZEXMGrgoeAfuBfoTUJGae1vBo9Fxb5E5y5hYJEoeuUm67nR6r5xKD8wOERTAQ-8IWWMo1ezOvG-XEWW2G