### PR TITLE
All top right green buttons in modals should have 4 pixels radius.

### DIFF
--- a/scss/partials/_edit_recurring_update_modal.scss
+++ b/scss/partials/_edit_recurring_update_modal.scss
@@ -56,7 +56,7 @@ div.edit-recurring-update-modal-container {
         color: white;
         line-height: 18px;
         float: right;
-        border-radius: 6px;
+        border-radius: 4px;
 
         &.disabled {
           cursor: not-allowed;

--- a/scss/partials/_integrations_settings_modal.scss
+++ b/scss/partials/_integrations_settings_modal.scss
@@ -66,7 +66,7 @@ div.integrations-settings-modal {
         line-height: 18px;
         color: white;
         float: right;
-        border-radius: 6px; 
+        border-radius: 4px;
       }
     }
 

--- a/scss/partials/_invite_settings_modal.scss
+++ b/scss/partials/_invite_settings_modal.scss
@@ -69,7 +69,7 @@ div.invite-settings-modal {
         color: white;
         line-height: 18px;
         float: right;
-        border-radius: 6px;
+        border-radius: 4px;
       }
     }
 

--- a/scss/partials/_org_settings_modal.scss
+++ b/scss/partials/_org_settings_modal.scss
@@ -63,7 +63,7 @@ div.org-settings-modal {
         @include OC_Body_Bold();
         font-size: 14px;
         background-color: $carrot_green;
-        border-radius: 6px;
+        border-radius: 4px;
         color: white;
         line-height: 18px;
         float: right;

--- a/scss/partials/_recurring_updates_modal.scss
+++ b/scss/partials/_recurring_updates_modal.scss
@@ -56,7 +56,7 @@ div.recurring-updates-modal-container {
         color: white;
         float: right;
         line-height: 18px;
-        border-radius: 6px; 
+        border-radius: 4px; 
       }
 
       button.cancel-bt {

--- a/scss/partials/_section_editor.scss
+++ b/scss/partials/_section_editor.scss
@@ -67,7 +67,7 @@ div.section-editor-container {
         @include OC_Body_Bold();
         font-size: 14px;
         background-color: $carrot_green;
-        border-radius: 6px;
+        border-radius: 4px;
         color: white;
         line-height: 18px;
         float: right;

--- a/scss/partials/_team_management_modal.scss
+++ b/scss/partials/_team_management_modal.scss
@@ -65,7 +65,7 @@ div.team-management-modal {
         color: white;
         line-height: 18px;
         float: right;
-        border-radius: 6px; 
+        border-radius: 4px;
         margin-left: 8px;
       }
     }

--- a/scss/partials/_user_notifications_modal.scss
+++ b/scss/partials/_user_notifications_modal.scss
@@ -66,7 +66,7 @@ div.user-notifications-modal-container {
         color: white;
         line-height: 18px;
         float: right;
-        border-radius: 6px; 
+        border-radius: 4px;
       }
     }
 

--- a/scss/partials/_user_profile_modal.scss
+++ b/scss/partials/_user_profile_modal.scss
@@ -66,7 +66,7 @@ div.user-profile-modal-container {
         color: white;
         line-height: 18px;
         float: right;
-        border-radius: 6px; 
+        border-radius: 4px;
       }
     }
 


### PR DESCRIPTION
From Slack: Ryan asked that all the green solid buttons that are in the top right corner of the modals should have a 4 pixels border radius.

To test:
- [x] check the modals to see if they respect the radius