### PR TITLE
Fix private WST

### DIFF
--- a/src/oc/web/stores/activity.cljs
+++ b/src/oc/web/stores/activity.cljs
@@ -322,13 +322,14 @@
 (defmethod dispatcher/action :activity-reads
   [db [_ org-slug item-id read-data-count read-data team-roster]]
   (let [activity-data   (dispatcher/activity-data org-slug item-id db)
-        board-data      (dispatcher/board-data db org-slug (:board-slug activity-data))
+        org-data        (dispatcher/org-data db org-slug)
+        board-data      (first (filter #(= (:slug %) (:board-slug activity-data)) (:boards org-data)))
         fixed-read-data (vec (map #(assoc % :seen true) read-data))
         team-users      (filterv #(#{"active" "unverified"} (:status %)) (:users team-roster))
         seen-ids        (set (map :user-id read-data))
         private-access? (= (:access board-data) "private")
         all-private-users (when private-access?
-                            (set (concat (map :user-id (:authors board-data)) (map :user-id (:viewers board-data)))))
+                            (set (concat (:authors board-data) (:viewers board-data))))
         filtered-users  (if private-access?
                           (filterv #(all-private-users (:user-id %)) team-users)
                           team-users)


### PR DESCRIPTION
Review with: https://github.com/open-company/open-company-storage/pull/214

BUG: add a private section, add a post to it, go to AP, show WST of the post: you see only the seen, no unseens.

The issue is caused by the delayed load of the boards data, we used the board data to get the list of users that have access to the private board but since they are delayed sometime we don't have those data available.

To test:
- add a private section
- add a post
- to to AP
- click on WST of that post
- [x] do you see the unseen users?
- now check the WST of posts of other sections