### PR TITLE
Fix WST section manage button

### DIFF
--- a/src/oc/web/actions/nav_sidebar.cljs
+++ b/src/oc/web/actions/nav_sidebar.cljs
@@ -72,7 +72,8 @@
 
 ;; Section settings
 
-(defn show-section-editor []
+(defn show-section-editor [section-slug]
+  (section-actions/setup-section-editing section-slug)
   (push-panel :section-edit))
 
 (defn hide-section-editor []

--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -284,3 +284,7 @@
 (defn section-more [more-link direction]
   (api/load-more-items more-link direction (partial section-more-finish direction))
   (dispatcher/dispatch! [:section-more (router/current-org-slug) (router/current-board-slug) (router/current-sort-type)]))
+
+(defn setup-section-editing [section-slug]
+  (when-let [board-data (dispatcher/board-data (router/current-org-slug) section-slug)]
+    (dispatcher/dispatch! [:setup-section-editing board-data])))

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -188,7 +188,7 @@
                          :data-placement "top"
                          :data-container "body"
                          :title (str (:name board-data) " settings")
-                         :on-click #(nav-actions/show-section-editor)}]])]
+                         :on-click #(nav-actions/show-section-editor (:slug board-data))}]])]
                 (when (not= (router/current-board-slug) utils/default-drafts-board-slug)
                   (let [default-sort (= board-sort dis/default-sort-type)]
                     [:div.board-sort.group

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -89,6 +89,7 @@
                 org-data
                 jwt
                 board-data
+                initial-section-editing
                 container-data
                 posts-data
                 is-sharing-activity
@@ -211,7 +212,7 @@
           (edit-recurring-update-modal)
           ;; Mobile create a new section
           show-section-editor
-          (section-editor board-data
+          (section-editor initial-section-editing
            (fn [sec-data note dismiss-action]
             (if sec-data
               (section-actions/section-save sec-data note dismiss-action)

--- a/src/oc/web/components/ui/wrt.cljs
+++ b/src/oc/web/components/ui/wrt.cljs
@@ -3,6 +3,7 @@
             [cuerdas.core :as string]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.lib.jwt :as jwt]
+            [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.mixins.ui :as mixins]
@@ -151,9 +152,10 @@
                    (when (:private-access? read-data)
                      "private ")
                    "post."))
-                (when (:private-access? read-data)
+                (when (and (:private-access? read-data)
+                           (dis/board-data (router/current-org-slug) (:board-slug activity-data)))
                   [:button.mlb-reset.manage-section-bt
-                    {:on-click #(nav-actions/show-section-editor)}
+                    {:on-click #(nav-actions/show-section-editor (:board-slug activity-data))}
                     "Manage section members?"])]]
             [:div.wrt-popup-tabs
               {:ref :wrt-pop-up-tabs}

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -375,6 +375,7 @@
                                :org-data org-data
                                :container-data container-data
                                :board-data board-data
+                               :initial-section-editing (:initial-section-editing base)
                                :posts-data posts-data
                                :panel-stack (:panel-stack base)
                                :is-sharing-activity (boolean (:activity-share base))

--- a/src/oc/web/stores/section.cljs
+++ b/src/oc/web/stores/section.cljs
@@ -249,3 +249,7 @@
         (assoc-in container-key new-container-data)
         (assoc-in posts-data-key new-items-map)))
     db))
+
+(defmethod dispatcher/action :setup-section-editing
+  [db [_ board-data]]
+  (assoc db :initial-section-editing board-data))


### PR DESCRIPTION
BUG: go to AP, find a post of a private section, click on WST, click on manage section settings: the section settings is empty.

To test:
- add a private section
- add a post to it
- go to AP
- click on WST of the post you added
- click on manage section settings
- [x] can you edit the values?

NB: there is another PR to fix the issue of the users not displayed properly (only seens are shown, not unseens).