### PR TITLE
Fix private section creation for contributor

### DIFF
--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -151,6 +151,7 @@
         show-slack-channels? (pos? (apply + (map #(-> % :channels count) slack-teams)))
         channel-name (when @(::editing-existing-section s) (:channel-name (:slack-mirror section-data)))
         roster (drv/react s :team-roster)
+        all-users-data (if team-data (:users team-data) (:users roster))
         slack-orgs (:slack-orgs team-data)
         cur-user-data (drv/react s :current-user-data)
         slack-users (:slack-users cur-user-data)
@@ -274,6 +275,7 @@
                               (dis/dispatch! [:update [:section-editing]
                                               #(merge % {:access "private"
                                                          :has-changes true
+                                                         :viewers (conj (set (:viewers section-editing)) current-user-id)
                                                          :slack-mirror (if show-slack-channels?
                                                                          nil
                                                                          (:slack-mirror section-editor))})]))}
@@ -390,7 +392,7 @@
                     user-type (if (utils/in? (:viewers section-editing) user-id)
                                 :viewer
                                 :author)
-                    team-user (some #(when (= (:user-id %) user-id) %) (:users team-data))]
+                    team-user (some #(when (= (:user-id %) user-id) %) all-users-data)]
                 [:div.section-editor-add-private-users-dropdown-container
                   {:style {:top (str (+ @(::show-edit-user-top s) -114) "px")
                            :display (if @(::show-edit-user-dropdown s) "block" "none")}}
@@ -411,8 +413,8 @@
                  :ref "edit-users-scroll"}
                 (let [author-ids (set (:authors section-editing))
                       viewer-ids (set (:viewers section-editing))
-                      authors (filter (comp author-ids :user-id) (:users team-data))
-                      viewers (filter (comp viewer-ids :user-id) (:users team-data))
+                      authors (filter (comp author-ids :user-id) all-users-data)
+                      viewers (filter (comp viewer-ids :user-id) all-users-data)
                       complete-authors (map
                                         #(merge % {:type :author :display-name (utils/name-or-email %)})
                                         authors)
@@ -420,7 +422,9 @@
                                         #(merge % {:type :viewer :display-name (utils/name-or-email %)})
                                         viewers)
                       all-users (concat complete-authors complete-viewers)
-                      sorted-users (sort compare-users all-users)]
+                      self-user (first (filter #(= (:user-id %) current-user-id) all-users))
+                      rest-users (filter #(not= (:user-id %) current-user-id) all-users)
+                      sorted-users (concat [self-user] (sort compare-users rest-users))]
                   (for [user sorted-users
                         :let [user-type (:type user)
                               self (= (:user-id user) current-user-id)
@@ -438,7 +442,9 @@
                                       (reset! (::show-edit-user-dropdown s) next-user-id)))}
                       (user-avatar-image user)
                       [:div.name
-                        (utils/name-or-email user)]
+                        (utils/name-or-email user)
+                        (when (= (:user-id user) current-user-id)
+                          " (you)")]
                       (if self
                         (if (and (seq (:slug section-editing))
                                  (> (count (:authors section-data)) 1))

--- a/src/oc/web/stores/section.cljs
+++ b/src/oc/web/stores/section.cljs
@@ -111,7 +111,7 @@
                                        (:private-notifications section-data))
         current-authors (filterv #(not= % (:user-id user)) (:authors section-data))
         current-viewers (filterv #(not= % (:user-id user)) (:viewers section-data))
-        next-authors (if (= user-type :author)
+        next-authors (if (#{:admin :author} user-type)
                        (vec (conj current-authors (:user-id user)))
                        current-authors)
         next-viewers (if (= user-type :viewer)


### PR DESCRIPTION
[Trello](https://trello.com/c/ImVp5xwe)

Bug: contributor don't have access to the team users so the list of users when creating a private section fails.

Solution: switched to the roster only for them

To test:
- add a private section as author
- add a private section as admin
- edit a private section as author (change the users list)
- edit a private section as admin (change the users list)