### PR TITLE
Fix abstract autoresize field

### DIFF
--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -630,7 +630,6 @@
               [:textarea.cmail-content-abstract.emoji-autocomplete.emojiable.group.oc-mentions.oc-mentions-hover
                 {:class utils/hide-class
                  :ref "abstract"
-                 :key (str "cmail-abstract-" (:key cmail-state))
                  :rows 1
                  :placeholder utils/default-abstract
                  :value (or (:abstract cmail-data) "")


### PR DESCRIPTION
Bug: abstract field is broken on production right now since it doesn't autoreszie.

To test:
- add a post in fullscreen mode
- [x] does abstract field autoresize?
- publish it
- now start a new post from quick post
- switch to fullscreen
- [x] abstract field is empty?
- type something in the abstract field
- [ ] abstract autoresizes?
- publish post again
- click New post
- [x] abstract is empty again?