### PR TITLE
Fix NEW comments badge

### DIFF
--- a/src/oc/web/stores/activity.cljs
+++ b/src/oc/web/stores/activity.cljs
@@ -336,12 +336,15 @@
         all-ids         (set (map :user-id filtered-users))
         unseen-ids      (clojure.set/difference all-ids seen-ids)
         unseen-users    (vec (map (fn [user-id]
-                         (first (filter #(= (:user-id %) user-id) team-users))) unseen-ids))]
+                         (first (filter #(= (:user-id %) user-id) team-users))) unseen-ids))
+        current-user-id (j/user-id)
+        current-user-reads (filterv #(= (:user-id %) current-user-id) read-data)]
     (assoc-in db (conj dispatcher/activities-read-key item-id) {:count read-data-count
                                                                 :reads fixed-read-data
                                                                 :item-id item-id
                                                                 :unreads unseen-users
-                                                                :last-read-at (:read-at (last (sort-by :read-at read-data)))
+                                                                :last-read-at (:read-at (last (sort-by :read-at
+                                                                               current-user-reads)))
                                                                 :private-access? private-access?})))
 
 (defmethod dispatcher/action :must-see-get/finish


### PR DESCRIPTION
Bug: flow is:
- add a post with user A
- open the post with user B
- go back to AP with user B
- user A enter the post and leave a comment
- user B sees NEW comment badge
- user A go back to AP
- user A go back into post view
- 💥 user B NEW badge disappear

This fix make sure we consider only the current user reads data when checking for the last read at of a post. Before we were using all users data so when someone entered a post view the NEW badge was disappearing because the client interpreted it as a view for the current user.

To test:
- repeat the flow above
- [x] NEW badge still visible for user B?