### PR TITLE
Fix Follow-ups pagination

### DIFF
--- a/src/oc/web/components/paginated_stream.cljs
+++ b/src/oc/web/components/paginated_stream.cljs
@@ -43,6 +43,8 @@
         (activity-actions/all-posts-more @(::has-next s) :down)
         (= (router/current-board-slug) "must-see")
         (activity-actions/must-see-more @(::has-next s) :down)
+        (= (router/current-board-slug) "follow-ups")
+        (activity-actions/follow-ups-more @(::has-next s) :down)
         :else
         (section-actions/section-more @(::has-next s) :down)))
     ;; Save the last scrollTop value


### PR DESCRIPTION
Review with: https://github.com/open-company/open-company-storage/pull/215

BUG: follow-ups section has no pagination at the moment.

To test:
- add 21 follow-up items for your user
- go to follow-ups section
- scroll down
- [x] did it load more items? Good
- scroll to the bottom again
- [x] did it load more again? Good
- make sure AP is still working and loads all items (not only follow-ups)