### PR TITLE
Fix reads count when loading more items on AP and FU

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -90,7 +90,7 @@
 
 (defn follow-ups-more-finish [direction sort-type {:keys [success body]}]
   (when success
-    (request-reads-count (map :uuid (:items (json->cljs body)))))
+    (request-reads-count (map :uuid (:items (:collection (json->cljs body))))))
   (dis/dispatch! [:follow-ups-more/finish (router/current-org-slug) direction sort-type (when success (json->cljs body))]))
 
 (defn follow-ups-more [more-link direction]
@@ -136,7 +136,7 @@
 
 (defn all-posts-more-finish [direction sort-type {:keys [success body]}]
   (when success
-    (request-reads-count (map :uuid (:items (json->cljs body)))))
+    (request-reads-count (map :uuid (:items (:collection (json->cljs body))))))
   (dis/dispatch! [:all-posts-more/finish (router/current-org-slug) direction sort-type (when success (json->cljs body))]))
 
 (defn all-posts-more [more-link direction]
@@ -167,7 +167,7 @@
 
 (defn must-see-more-finish [direction sort-type {:keys [success body]}]
   (when success
-    (request-reads-count (map :uuid (:items (json->cljs body)))))
+    (request-reads-count (map :uuid (:items (:collection (json->cljs body))))))
   (dis/dispatch! [:must-see-more/finish (router/current-org-slug) direction sort-type (when success (json->cljs body))]))
 
 (defn must-see-more [more-link direction]

--- a/src/oc/web/components/paginated_stream.cljs
+++ b/src/oc/web/components/paginated_stream.cljs
@@ -43,8 +43,6 @@
         (activity-actions/all-posts-more @(::has-next s) :down)
         (= (router/current-board-slug) "must-see")
         (activity-actions/must-see-more @(::has-next s) :down)
-        (= (router/current-board-slug) "follow-ups")
-        (activity-actions/follow-ups-more @(::has-next s) :down)
         :else
         (section-actions/section-more @(::has-next s) :down)))
     ;; Save the last scrollTop value

--- a/src/oc/web/components/paginated_stream.cljs
+++ b/src/oc/web/components/paginated_stream.cljs
@@ -43,6 +43,8 @@
         (activity-actions/all-posts-more @(::has-next s) :down)
         (= (router/current-board-slug) "must-see")
         (activity-actions/must-see-more @(::has-next s) :down)
+        (= (router/current-board-slug) "follow-ups")
+        (activity-actions/follow-ups-more @(::has-next s) :down)
         :else
         (section-actions/section-more @(::has-next s) :down)))
     ;; Save the last scrollTop value


### PR DESCRIPTION
### Review after #980


BUG: right now when more items are loaded for AP and FU they have all 0 views. Problem is they don't get the list of items in the proper way.

To test:
- go to AP
- [x] do you see the reads count on the posts? Good
- scroll to the bottom
- wait for the next batch of items to be loaded
- [x] do you see the reads count on the new posts? Good
- no add at least 11 follow-up items for your user
- [x] repeat the test above