### PR TITLE
Fix secure activity

### DIFF
--- a/scss/partials/_secure_activity.scss
+++ b/scss/partials/_secure_activity.scss
@@ -241,28 +241,6 @@ div.secure-activity-container {
 
       div.add-comment-box-container {
         margin-top: 24px;
-
-        div.add-comment-box {
-          div.user-avatar-img-container {
-            bottom: unset;
-            top: 8px;
-          }
-
-          div.add-comment-internal {
-            div.add-comment {
-              background-color: white;
-              border-radius: 4px;
-              border: 1px solid $mid_light_grey;
-              padding: 6px 14px;
-
-              @include tablet() {
-                border: none;
-                padding: 0;
-                border-radius: 0;
-              }
-            }
-          }
-        }
       }
     }
 

--- a/src/oc/web/components/secure_activity.cljs
+++ b/src/oc/web/components/secure_activity.cljs
@@ -29,6 +29,11 @@
   (or (.-clientWidth (.-documentElement js/document))
       (.-innerWidth js/window)))
 
+(defn- maybe-load-comments [s]
+  (let [activity-data @(drv/get-ref s :secure-activity-data)
+        comments-data @(drv/get-ref s :comments-data)]
+    (comment-utils/get-comments-if-needed activity-data comments-data)))
+
 (rum/defcs secure-activity < rum/reactive
                              ;; Derivatives
                              (drv/drv :secure-activity-data)
@@ -40,9 +45,10 @@
                              (mention-mixins/oc-mentions-hover)
                              ui-mixins/refresh-tooltips-mixin
                              {:did-mount (fn [s]
-                               (let [activity-data @(drv/get-ref s :secure-activity-data)
-                                     comments-data @(drv/get-ref s :comments-data)]
-                                (comment-utils/get-comments-if-needed activity-data comments-data))
+                               (maybe-load-comments s)
+                               s)
+                              :will-update (fn [s]
+                               (maybe-load-comments s)
                                s)
                               :after-render (fn [s]
                                ;; Delay to make sure the change socket was initialized
@@ -132,7 +138,7 @@
                       (:can-comment activity-data))
               [:div.comments-separator])
             (when comments-data
-              (stream-comments activity-data comments-data true))
+              (stream-comments activity-data comments-data))
             (when (:can-comment activity-data)
               (rum/with-key (add-comment activity-data) (str "add-comment-" (:uuid activity-data))))]
             [:div.secure-activity-footer

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -166,7 +166,8 @@
                              :did-remount (fn [o s]
                               (when (not= (count (second (:rum/args o))) (count (second (:rum/args s))))
                                  (reset! (::replying-to s) #{}))
-                              (let [new-added-comment (nth (:rum/args s) 2)]
+                              (let [args (vec (:rum/args s))
+                                    new-added-comment (get args 2)]
                                 (when new-added-comment
                                   (utils/after 180 #(highlight-comment s new-added-comment false))
                                   (comment-actions/add-comment-highlight-reset)))

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -168,7 +168,6 @@
                              (when (and follow-up
                                         (not (:completed? follow-up)))
                                (reset! (::complete-follow-up s) true)))
-
                            (me-media-utils/setup-editor s add-comment-did-change (me-options (second (:rum/args s))))
                            (let [add-comment-node (rum/ref-node s "editor-node")]
                              (when (should-focus-field? s)
@@ -177,10 +176,8 @@
                                 #(utils/to-end-of-content-editable add-comment-node))))
                            (utils/after 2500 #(js/emojiAutocomplete))
                            s)
-                          :did-remount (fn [_ s]
-                           (me-media-utils/setup-editor s add-comment-did-change (me-options (second (:rum/args s))))
-                           s)
                           :will-update (fn [s]
+                           (me-media-utils/setup-editor s add-comment-did-change (me-options (second (:rum/args s))))
                            (let [data @(drv/get-ref s :media-input)
                                  video-data (:media-video data)]
                               (when (and @(:me/media-video s)

--- a/src/oc/web/stores/comment.cljs
+++ b/src/oc/web/stores/comment.cljs
@@ -88,9 +88,11 @@
     (assoc-in db (vec (conj pre-comments-key :loading)) true)))
 
 (defmethod dispatcher/action :comments-get/finish
-  [db [_ {:keys [success error comments-key body activity-uuid]}]]
+  [db [_ {:keys [success error comments-key body secure-activity-uuid activity-uuid]}]]
   (let [org-data (dispatcher/org-data db)
-        activity-data (dispatcher/activity-data (:slug org-data) activity-uuid db)
+        activity-data (if secure-activity-uuid
+                        (dispatcher/secure-activity-data (:slug org-data) secure-activity-uuid db)
+                        (dispatcher/activity-data (:slug org-data) activity-uuid db))
         cleaned-comments (map #(parse-comment org-data activity-data %) (:items (:collection body)))
         sorted-comments (comment-utils/sort-comments cleaned-comments)
         pre-comments-key (vec (butlast comments-key))]

--- a/src/oc/web/utils/comment.cljs
+++ b/src/oc/web/utils/comment.cljs
@@ -66,13 +66,13 @@
   [comment-data]
   (= (jwt/user-id) (:user-id (:author comment-data))))
 
-(defn get-comments-finished
-  [comments-key activity-data {:keys [status success body]}]
+(defn get-comments-finished [comments-key activity-data {:keys [status success body]}]
   (dis/dispatch! [:comments-get/finish {:success success
                                         :error (when-not success body)
                                         :comments-key comments-key
                                         :body (when (seq body) (json->cljs body))
-                                        :activity-uuid (:uuid activity-data)}]))
+                                        :activity-uuid (:uuid activity-data)
+                                        :secure-activity-uuid (router/current-secure-activity-id)}]))
 
 (defn get-comments [activity-data]
   (when activity-data


### PR DESCRIPTION
BUG: if you open a link you get from email or Slack notifications (with id-token auth) in an anonymous window you see that the comments are not loaded.

To test:
- open AP
- find a post with some comments
- expand the post
- make sure you see the list of comments
- send add a comment with a mention for a user that has email or Slack notifications to that post
- copy the link sent to that user via email or Slack
- open it in incognito
- make sure the comments are loaded
- make sure you can react to the post
- make sure you can react to a comment
- make sure you can comment on the post