### PR TITLE
DnD images into comments

### DIFF
--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -673,7 +673,7 @@ $h2_top_margin: 24;
   a, span[data-auto-link] {
     text-decoration: none;
     color: $carrot_green;
-    background-color: transparent;
+    background-color: transparent !important;
   }
 
   a:hover {


### PR DESCRIPTION
To fix: there is no indication that a file is uploading, we need to address this in a later card since it's going to take a bit more.

To test:
- focus on a comment field
- drag in an image
- [ ] did it work?
- now drag in another file that is NOT an image
- [ ] did it NOT work?