### PR TITLE
WST viewed opacity

### DIFF
--- a/src/oc/web/components/ui/wrt.cljs
+++ b/src/oc/web/components/ui/wrt.cljs
@@ -197,7 +197,7 @@
                                                 ", marked for follow-up")]]
                 [:div.wrt-popup-list-row
                   {:key (str "wrt-popup-row-" (:user-id u))
-                   :class (utils/class-set {:seen (:seen u)
+                   :class (utils/class-set {:seen (and (:seen u) (= @list-view :all))
                                             :sent user-sending-notice})}
                   [:div.wrt-popup-list-row-avatar
                     {:class (when (:seen u) "seen")}


### PR DESCRIPTION
Card: https://trello.com/c/X1bhze1r

To test:
- open WST of a post
- [x] viewed users have some opacity?
- now change the dropdown to viewed
- [x] viewed users have NO opacity?
- change to Unopened
- [x] viewed users have NO opacity?
- go back to Everyone
- [x] viewed users have some opacity?