### PR TITLE
EmojiMart auto focus search field

### DIFF
--- a/src/oc/web/components/reactions.cljs
+++ b/src/oc/web/components/reactions.cljs
@@ -105,6 +105,7 @@
            (when-not (utils/is-test-env?)
              (react-utils/build (.-Picker js/EmojiMart)
                {:native true
+                :autoFocus true
                 :onClick (fn [emoji event]
                            (when (reaction-utils/can-pick-reaction? (gobj/get emoji "native") reactions-data)
                              (if optional-activity-data

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -109,6 +109,7 @@
       "Cancel"]
     (react-utils/build (.-Picker js/EmojiMart)
       {:native true
+       :autoFocus true
        :onClick (fn [emoji event]
                   (add-emoji-cb emoji))})])
 

--- a/src/oc/web/components/ui/emoji_picker.cljs
+++ b/src/oc/web/components/ui/emoji_picker.cljs
@@ -172,6 +172,7 @@
          (when-not (utils/is-test-env?)
            (react-utils/build (.-Picker js/EmojiMart)
              {:native true
+              :autoFocus true
               :onClick (fn [emoji event]
                          (when (and default-field-selector
                                     (not @(::caret-pos s)))


### PR DESCRIPTION
Card: https://trello.com/c/LwX6B57Q

To test:
- open AP
- click on reaction picker to react to a post
- [x] search field is focused?
- expand a post
- [x] repeat the above
- now add a comment
- click to react to the comment
- [x] search field is focused?
- click new post
- click on the emoji picker button up top
- [x] search field is focused?