### PR TITLE
DnD spinner and upload percentage

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -78,6 +78,8 @@ MediaPicker.addChart = function(){};
 MediaPicker.addAttachment = function(){};
 MediaPicker.saveSelection = function(){};
 MediaPicker.removeSelection = function(){};
+MediaPicker.togglePicker = function(){};
+MediaPicker.hide = function(){};
 // MediumEditorFileDragging
 var CarrotFileDragging = function(){};
 CarrotFileDragging.insertImageFile = function(){};

--- a/resources/public/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js
@@ -100,8 +100,14 @@ var CarrotFileDragging = MediumEditor.Extension.extend({
                 addImageElement.dataset.thumbnail = photoThumbnail;
             }
             MediumEditor.util.insertHTMLCommand(that.document, addImageElement.outerHTML);
+            that.insertNewParagraph();
         };
         addImageElement.src = imageURL;
+    },
+
+    insertNewParagraph: function() {
+        console.log("DBG insertNewParagraph");
+        this.base.execAction('insertparagraph');
     }
 });
 

--- a/scss/partials/_add_comment.scss
+++ b/scss/partials/_add_comment.scss
@@ -88,9 +88,25 @@ div.add-comment-box-container {
     width: 100%;
     margin-top: 16px;
 
-
     &.hide-footer * {
       display: none;
+    }
+
+    div.upload-progress {
+      float: right;
+      margin-right: 16px;
+      margin-top: 6px;
+
+      div.small-loading {
+        float: left;
+      }
+
+      span.attachment-uploading {
+        @include OC_Body_Book();
+        font-size: 14px;
+        color: $deep_navy;
+        float: left;
+      }
     }
 
     button.close-reply-bt {

--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -44,6 +44,7 @@ div.cmail-outer {
 
               div.rich-body-editor {
                 margin-top: 0;
+                min-height: 24px;
               }
             }
           }

--- a/scss/partials/_stream_attachments.scss
+++ b/scss/partials/_stream_attachments.scss
@@ -30,6 +30,17 @@ div.stream-attachments {
     div.stream-attachments-item {
       max-width: 100%;
 
+      div.small-loading {
+        float: left;
+      }
+
+      span.attachment-uploading {
+        @include OC_Body_Book();
+        font-size: 14px;
+        color: $deep_navy;
+        float: left;
+      }
+
       div.attachment-info {
         margin-top: 8px;
 

--- a/scss/partials/_stream_comments.scss
+++ b/scss/partials/_stream_comments.scss
@@ -260,6 +260,12 @@ div.stream-comments {
               bottom: unset;
               left: unset;
             }
+
+            div.emoji-picker-container {
+              button.close-bt {
+                display: none;
+              }
+            }
           }
 
           // Change Bootstrap tooltip style

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -768,8 +768,9 @@
                                :cmail-key (:key cmail-state)
                                :attachments-enabled true})
             ; Attachments
-            (stream-attachments (:attachments cmail-data) nil
-             #(activity-actions/remove-attachment :cmail-data %))]]
+            (when-not (:collapsed cmail-state)
+              (stream-attachments (:attachments cmail-data) nil
+               #(activity-actions/remove-attachment :cmail-data %)))]]
       (when (and follow-up?
                  (not is-mobile?)
                  (not is-fullscreen?))

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -18,6 +18,7 @@
             [oc.web.actions.notifications :as notification-actions]
             [oc.web.components.ui.emoji-picker :refer (emoji-picker)]
             [oc.web.components.ui.giphy-picker :refer (giphy-picker)]
+            [oc.web.components.ui.small-loading :refer (small-loading)]
             [oc.web.components.ui.user-avatar :refer (user-avatar-image)]
             [oc.web.components.ui.media-video-modal :refer (media-video-modal)]
             [oc.web.actions.activity :as activity-actions]
@@ -85,9 +86,10 @@
                                       (utils/link-for (:links follow-up) "mark-complete" "POST"))]
         (activity-actions/complete-follow-up activity-data follow-up)))))
 
-(defn me-options [reply-comment?]
+(defn me-options [parent-uuid]
   {:media-config ["gif" "photo" "video"]
-   :placeholder (if reply-comment? "Reply…" "Add a comment…")
+   :comment-parent-uuid parent-uuid
+   :placeholder (if parent-uuid "Reply…" "Add a comment…")
    :use-inline-media-picker true
    :media-picker-initially-visible false})
 
@@ -128,6 +130,7 @@
                          (drv/drv :add-comment-data)
                          (drv/drv :team-roster)
                          (drv/drv :current-user-data)
+                         (drv/drv :attachment-uploading)
                          ;; Locals
                          (rum/local true ::add-button-disabled)
                          (rum/local "" ::initial-add-comment)
@@ -216,7 +219,10 @@
         show-follow-up-button? (and follow-up
                                     (not (:completed? follow-up))
                                     complete-follow-up-link
-                                    (not parent-comment-uuid))]
+                                    (not parent-comment-uuid))
+        attachment-uploading (drv/react s :attachment-uploading)
+        uploading? (and attachment-uploading
+                        (= (:comment-parent-uuid attachment-uploading) parent-comment-uuid))]
     [:div.add-comment-box-container
       {:class container-class}
       [:div.add-comment-box
@@ -307,4 +313,9 @@
                            (utils/event-stop %)
                            (swap! (::complete-follow-up s) not))}
               (carrot-checkbox {:selected @(::complete-follow-up s)})
-              "Complete follow-up"])]]]))
+              "Complete follow-up"])
+          (when uploading?
+            [:div.upload-progress
+              (small-loading)
+              [:span.attachment-uploading
+                (str "Uploading " (or (:progress attachment-uploading) 0) "%...")]])]]]))

--- a/src/oc/web/dispatcher.cljs
+++ b/src/oc/web/dispatcher.cljs
@@ -191,6 +191,7 @@
    :mobile-navigation-sidebar [[:base] (fn [base] (:mobile-navigation-sidebar base))]
    :mobile-user-notifications [[:base] (fn [base] (:mobile-user-notifications base))]
    :expand-image-src    [[:base] (fn [base] (:expand-image-src base))]
+   :attachment-uploading [[:base] (fn [base] (:attachment-uploading base))]
    :add-comment-data    [[:base :org-slug] (fn [base org-slug]
                           (get-in base (add-comment-key org-slug)))]
    :email-verification  [[:base :auth-settings]

--- a/src/oc/web/lib/image_upload.cljs
+++ b/src/oc/web/lib/image_upload.cljs
@@ -62,11 +62,11 @@
           (when (= (count files-uploaded)1)
             (success-cb (get files-uploaded 0))))))))
 
-(defn upload-file! [file success-cb & [error-cb]]
+(defn upload-file! [file success-cb & [error-cb progress-cb]]
   (try
     (let [fs-client (init-filestack)]
       (.then
-        (.upload fs-client file #js {})
+        (.upload fs-client file #js {:onProgress #(when (fn? progress-cb) (progress-cb (.-totalPercent %)))})
         (fn [res]
           (let [url (gobj/get res "url")]
             (when (fn? success-cb)

--- a/src/oc/web/utils/medium_editor_media.cljs
+++ b/src/oc/web/utils/medium_editor_media.cljs
@@ -14,6 +14,7 @@
             [oc.web.utils.activity :as au]
             [oc.web.lib.image-upload :as iu]
             [oc.web.lib.responsive :as responsive]
+            [oc.web.actions.cmail :as cmail-actions]
             [oc.web.utils.mention :as mention-utils]
             [oc.web.actions.activity :as activity-actions]
             [oc.web.components.ui.alert-modal :as alert-modal]))
@@ -259,53 +260,59 @@
 
 (defn file-dnd-handler [s options editor-ext file]
   (if (< (oget file :size) (* 5 1000 1000))
-    (if (.match (.-type file) "image")
-      (do
-        (.hide @(:me/media-picker-ext s))
-        (dis/dispatch! [:input [:attachment-uploading]
-         {:progress "0"
-          :comment-parent-uuid (:comment-parent-uuid options)}])
-        (iu/upload-file! file
-          (fn [url]
-            (.insertImageFile editor-ext file url nil)
-            (utils/after 500
-             (fn []
-               (dis/dispatch! [:input [:attachment-uploading] nil])
-               (utils/to-end-of-content-editable (rum/ref-node s "editor-node"))
-               (utils/after 500 #(.togglePicker @(:me/media-picker-ext s))))))
-          (fn []
-           (dis/dispatch! [:input [:attachment-uploading] nil]))
-          (fn [progress-percentage]
-           (dis/dispatch! [:input [:attachment-uploading]
-            {:progress progress-percentage
-             :comment-parent-uuid (:comment-parent-uuid options)}]))))
-      (when (:attachments-enabled options)
+    (let [cmail-state (:cmail-state @dis/app-state)]
+      ;; If Quick Post is still collapsed expand it
+      (when (:collapsed cmail-state)
+        (cmail-actions/cmail-show (cmail-actions/get-board-for-edit) {:collapsed false
+                                                                      :fullscreen false
+                                                                      :key (:key cmail-state)}))
+      (if (.match (.-type file) "image")
         (do
+          (.hide @(:me/media-picker-ext s))
           (dis/dispatch! [:input [:attachment-uploading]
            {:progress "0"
             :comment-parent-uuid (:comment-parent-uuid options)}])
           (iu/upload-file! file
             (fn [url]
-              (let [size (oget file :size)
-                    mimetype (oget file :type)
-                    filename (oget file :name)
-                    createdat (utils/js-date)
-                    prefix (str "Uploaded by " (jwt/get-key :name) " on " (utils/date-string createdat [:year]) " - ")
-                    subtitle (str prefix (filesize size :binary false :format "%.2f" ))
-                    icon (au/icon-for-mimetype mimetype)
-                    attachment-data {:file-name filename
-                                     :file-type mimetype
-                                     :file-size size
-                                     :file-url url}
-                    dispatch-input-key (:dispatch-input-key options)]
-                (activity-actions/add-attachment dispatch-input-key attachment-data)
-                (dis/dispatch! [:input [:attachment-uploading] nil])))
+              (.insertImageFile editor-ext file url nil)
+              (utils/after 500
+               (fn []
+                 (dis/dispatch! [:input [:attachment-uploading] nil])
+                 (utils/to-end-of-content-editable (rum/ref-node s "editor-node"))
+                 (utils/after 500 #(.togglePicker @(:me/media-picker-ext s))))))
             (fn []
              (dis/dispatch! [:input [:attachment-uploading] nil]))
             (fn [progress-percentage]
              (dis/dispatch! [:input [:attachment-uploading]
               {:progress progress-percentage
-               :comment-parent-uuid (:comment-parent-uuid options)}]))))))
+               :comment-parent-uuid (:comment-parent-uuid options)}]))))
+        (when (:attachments-enabled options)
+          (do
+            (dis/dispatch! [:input [:attachment-uploading]
+             {:progress "0"
+              :comment-parent-uuid (:comment-parent-uuid options)}])
+            (iu/upload-file! file
+              (fn [url]
+                (let [size (oget file :size)
+                      mimetype (oget file :type)
+                      filename (oget file :name)
+                      createdat (utils/js-date)
+                      prefix (str "Uploaded by " (jwt/get-key :name) " on " (utils/date-string createdat [:year]) " - ")
+                      subtitle (str prefix (filesize size :binary false :format "%.2f" ))
+                      icon (au/icon-for-mimetype mimetype)
+                      attachment-data {:file-name filename
+                                       :file-type mimetype
+                                       :file-size size
+                                       :file-url url}
+                      dispatch-input-key (:dispatch-input-key options)]
+                  (activity-actions/add-attachment dispatch-input-key attachment-data)
+                  (dis/dispatch! [:input [:attachment-uploading] nil])))
+              (fn []
+               (dis/dispatch! [:input [:attachment-uploading] nil]))
+              (fn [progress-percentage]
+               (dis/dispatch! [:input [:attachment-uploading]
+                {:progress progress-percentage
+                 :comment-parent-uuid (:comment-parent-uuid options)}])))))))
     (let [alert-data {:icon "/img/ML/error_icon.png"
                     :action "dnd-file-too-big"
                     :title "Sorry!"

--- a/src/oc/web/utils/medium_editor_media.cljs
+++ b/src/oc/web/utils/medium_editor_media.cljs
@@ -261,6 +261,7 @@
   (if (< (oget file :size) (* 5 1000 1000))
     (if (.match (.-type file) "image")
       (do
+        (.hide @(:me/media-picker-ext s))
         (dis/dispatch! [:input [:attachment-uploading]
          {:progress "0"
           :comment-parent-uuid (:comment-parent-uuid options)}])
@@ -268,10 +269,12 @@
           (fn [url]
             (.insertImageFile editor-ext file url nil)
             (utils/after 500
-             #(do
+             (fn []
+               (dis/dispatch! [:input [:attachment-uploading] nil])
                (utils/to-end-of-content-editable (rum/ref-node s "editor-node"))
-               (dis/dispatch! [:input [:attachment-uploading] nil]))))
-          nil
+               (utils/after 500 #(.togglePicker @(:me/media-picker-ext s))))))
+          (fn []
+           (dis/dispatch! [:input [:attachment-uploading] nil]))
           (fn [progress-percentage]
            (dis/dispatch! [:input [:attachment-uploading]
             {:progress progress-percentage
@@ -297,7 +300,8 @@
                     dispatch-input-key (:dispatch-input-key options)]
                 (activity-actions/add-attachment dispatch-input-key attachment-data)
                 (dis/dispatch! [:input [:attachment-uploading] nil])))
-            nil
+            (fn []
+             (dis/dispatch! [:input [:attachment-uploading] nil]))
             (fn [progress-percentage]
              (dis/dispatch! [:input [:attachment-uploading]
               {:progress progress-percentage


### PR DESCRIPTION
Card: https://trello.com/c/QTz6OynM

This should fix DnD on body and comment fields that is currently broken plus add some functionality to signal the user the app is uploading after the drop happens.

To test:
- DnD an image in the cmail field
- [x] do you see a spinner?
- [x] do you see the upload progress?
- [x] do you see the image appear?
- [x] is the cursor on a new line below the image once the upload finishes?
- now DnD another type of file (not an image: html or sketch or whatever)
- [x] do you see a spinner?
- [x] do you see the upload progress?
- [x] do you see the file being added to the attachments list at the bottom?
- now expand a post
- DnD an image into a comment field
- [x] do you see a spinner?
- [x] do you see the upload progress?
- [x] do you see the image appear?
- [x] is the cursor on a new line below the image once the upload finishes?
- now DnD another type of file into a comment (not an image: HTML or sketch or whatever)
- [x] nothing happens? Good
- now close the editing
- refresh
- DnD a file into the Quick Post view still collapsed
- [x] did it work?
- [x] do you see the Quick Post view expanding when you drop the file?
- [x] do you see the spinner and the uploading percentage?