### PR TITLE
File upload size

### DIFF
--- a/resources/public/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js
+++ b/resources/public/lib/MediumEditorExtensions/MediumEditorFileDragging/filedragging.js
@@ -25,6 +25,8 @@ var CarrotFileDragging = MediumEditor.Extension.extend({
 
     allowedTypes: ['.*'],
 
+    _lastSelection: undefined,
+
     options: undefined,
 
     constructor: function (options) {
@@ -56,6 +58,26 @@ var CarrotFileDragging = MediumEditor.Extension.extend({
                 target.classList.add(CLASS_DRAG_OVER);
             }
         }
+    },
+
+    internalRemoveSelection: function() {
+      // Remove the previous saved selection markers if any
+      if (this._lastSelection) {
+        rangy.removeMarkers(this._lastSelection);
+        this._lastSelection = undefined;
+      }
+    },
+
+    saveSelection: function() {
+        // Remove the previous selection to avoid leaving
+        // markers in the body that are not needed
+        this.internalRemoveSelection();
+        // Save the current selection
+        this._lastSelection = rangy.saveSelection();
+        // Unfocus the field
+        this.getEditorElements().forEach(function(el){
+            el.blur();
+        });
     },
 
     handleDrop: function (event) {
@@ -99,6 +121,12 @@ var CarrotFileDragging = MediumEditor.Extension.extend({
             if (thumbnailURL) {
                 addImageElement.dataset.thumbnail = photoThumbnail;
             }
+            if (that._lastSelection) {
+                rangy.restoreSelection(that._lastSelection);
+                that._lastSelection = undefined;
+            } else {
+                that.getEditorElements()[0].focus();
+            }
             MediumEditor.util.insertHTMLCommand(that.document, addImageElement.outerHTML);
             that.insertNewParagraph();
         };
@@ -107,6 +135,10 @@ var CarrotFileDragging = MediumEditor.Extension.extend({
 
     insertNewParagraph: function() {
         this.base.execAction('insertparagraph');
+    },
+
+    destroy: function() {
+        this.internalRemoveSelection();
     }
 });
 

--- a/src/oc/web/lib/image_upload.cljs
+++ b/src/oc/web/lib/image_upload.cljs
@@ -24,7 +24,7 @@
                         ["local_file_system" "imagesearch" "googledrive" "dropbox" "onedrive" "box"]
                         ["local_file_system" "googledrive" "dropbox" "onedrive" "box"])
         base-config   {:maxFiles 1
-                       :maxSize (* 20 1024 1024) ; Limit the uploaded file to be at most 20MB
+                       :maxSize ls/file-upload-size ; Limit the uploaded file to be at most 20MB
                        :storeTo store-to
                        :transformations {
                          :crop {:circle true}

--- a/src/oc/web/local_settings.cljs
+++ b/src/oc/web/local_settings.cljs
@@ -71,3 +71,6 @@
 
 ;; Giphy
 (def giphy-api-key "M2FfNXledXWbpa7FZkg2vvUD8kHMTQVF")
+
+;; Image upload limit
+(def file-upload-size (* 20 1024 1024))

--- a/src/oc/web/utils/medium_editor_media.cljs
+++ b/src/oc/web/utils/medium_editor_media.cljs
@@ -12,6 +12,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.utils.activity :as au]
+            [oc.web.local-settings :as ls]
             [oc.web.lib.image-upload :as iu]
             [oc.web.lib.responsive :as responsive]
             [oc.web.actions.cmail :as cmail-actions]
@@ -259,7 +260,7 @@
 ;; DND
 
 (defn file-dnd-handler [s options editor-ext file]
-  (if (< (oget file :size) (* 20 1024 1024))
+  (if (< (oget file :size) ls/file-upload-size)
     (let [cmail-state (:cmail-state @dis/app-state)]
       ;; If Quick Post is still collapsed expand it
       (when (:collapsed cmail-state)


### PR DESCRIPTION
Make sure we are using the same size for files uploaded via FileStack picker and via DnD.

Review with: https://github.com/belucid/open-company-infrastructure/pull/116

To test:
- new post
- click image button
- pick an image that is > 5MB
- [x] did it work?
- now try with a file that is > 20MB
- [x] did it NOT work?
- now do the same via DnD
- now do the same via DnD in a comment