### PR TITLE
Fix stream items background color

### DIFF
--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -178,7 +178,7 @@ div.dashboard-layout {
 
     div.board-container {
       width: #{$board_container_width}px;
-      background-color: $grey_num_2;;
+      background-color: $grey_num_2;
       position: relative;
       margin: 0 auto;
       padding: 24px 0 0;

--- a/scss/partials/_expanded_post.scss
+++ b/scss/partials/_expanded_post.scss
@@ -261,8 +261,8 @@ div.expanded-post {
 
       div.is-comments-authors.show-border {
         div.is-comments-author {
-          background-color: $oc_gray_8;
-          border: 2px solid $oc_gray_8;
+          background-color: $grey_num_2;
+          border: 2px solid $grey_num_2;
 
           @include mobile(){
             background-color: white;

--- a/scss/partials/_org_dashboard.scss
+++ b/scss/partials/_org_dashboard.scss
@@ -117,7 +117,7 @@ div.add-more-tooltip {
 
 div.org-dashboard div.org-dashboard-inner {
   padding-bottom: 20px;
-  background-color: $oc_gray_8;
+  background-color: $grey_num_2;
 
   @include big_web(){
     min-height: 100vh;

--- a/scss/partials/_paginated_stream.scss
+++ b/scss/partials/_paginated_stream.scss
@@ -38,7 +38,7 @@ div.paginated-stream {
         height: calc(100vh - 50px);
         width: #{$board_container_width}px;
         margin-left: -244px;
-        background-color: $oc_gray_8;
+        background-color: $grey_num_2;
         text-align: center;
 
         @include mobile() {

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -485,8 +485,8 @@ div.stream-item {
         div.is-comments {
           div.is-comments-authors.show-border {
             div.is-comments-author {
-              background-color: $oc_gray_8;
-              border: 2px solid $oc_gray_8;
+              background-color: $grey_num_2;
+              border: 2px solid $grey_num_2;
 
               @include mobile() {
                 background-color: $grey_num_4;


### PR DESCRIPTION
Bug: right now the read posts in the stream have a background color that is close but not the same of the rest of the page. The page uses #FBFAF9 where the posts use #FBFAF7. That's why it seems a slightly different color.

To test:
- on desktop
- [x] check with Digital Color Meter that read posts have the same bg color of the page
- now pick a post with comments from at least 2 different users
- [x] check the border around the user icons on FoC are the same color of the FoC and the page
- on mobile
- [x] check with Digital Color Meter that read posts have white background