### PR TITLE
Fix comment share copy

### DIFF
--- a/scss/partials/_stream_comments.scss
+++ b/scss/partials/_stream_comments.scss
@@ -53,7 +53,7 @@ div.stream-comments {
             }
 
             ul.more-menu-list {
-              width: 78px;
+              width: 94px;
               top: 20px;
               right: 13px;
               left: unset;
@@ -153,7 +153,7 @@ div.stream-comments {
               }
 
               ul.more-menu-list {
-                width: 78px;
+                width: 94px;
                 top: 20px;
                 right: 0;
                 left: unset;
@@ -215,7 +215,7 @@ div.stream-comments {
             width: 84px;
 
             div.stream-comment-floating-buttons-more-menu {
-              Width: 86px;
+              Width: 94px;
               position: absolute;
               top: 28px;
               left: -24px;
@@ -228,7 +228,7 @@ div.stream-comments {
               z-index: 2;
 
               button {
-                width: 84px;
+                width: 100%;
                 height: 34px;
                 padding: 8px 16px;
                 background-color: white;

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -263,7 +263,7 @@
                                   "Delete"])
                               [:button.mlb-reset.share-bt
                                 {:on-click #(share-clicked comment-data)}
-                                "Share"]])
+                                "Copy link"]])
                           ;; More menu button or share button (depends if user is author of the comment)
                           (if (or can-show-edit-bt?
                                   can-show-delete-bt?)
@@ -282,7 +282,7 @@
                                                                                      :expire 3
                                                                                      :id (keyword (str "comment-url-copied-"
                                                                                       (:uuid comment-data)))}))
-                               :title "Share"}])
+                               :title "Copy url"}])
                           ;; Reply to comment
                           (when (:reply-parent comment-data)
                             [:button.mlb-reset.floating-bt.reply-bt

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -282,7 +282,7 @@
                                                                                      :expire 3
                                                                                      :id (keyword (str "comment-url-copied-"
                                                                                       (:uuid comment-data)))}))
-                               :title "Copy url"}])
+                               :title "Copy link"}])
                           ;; Reply to comment
                           (when (:reply-parent comment-data)
                             [:button.mlb-reset.floating-bt.reply-bt

--- a/src/oc/web/components/ui/more_menu.cljs
+++ b/src/oc/web/components/ui/more_menu.cljs
@@ -203,7 +203,7 @@
                                 (will-close))
                               (when (fn? comment-share-cb)
                                 (comment-share-cb)))}
-                "Share"])])
+                "Copy link"])])
         (when (and external-share
                    share-link)
           [:button.mlb-reset.more-menu-share-bt


### PR DESCRIPTION
Card: https://trello.com/c/zFoDf27L

To test:
- open a post with a comment from another user
- add a comment
- [x] on your comment does it say: Copy link?
- [x] on the comment from the other users tooltip says Copy link?
- [x] on mobile the menu says Copy link?
- [x] the copy fit on one line in all cases?