### PR TITLE
Add app version in menu

### DIFF
--- a/resources/electron/renderer.js
+++ b/resources/electron/renderer.js
@@ -2,6 +2,7 @@
 // https://electronjs.org/docs/tutorial/application-architecture#main-and-renderer-processes
 var electron = require('electron');
 var ipcRenderer = electron.ipcRenderer;
+var package = require('../package.json');
 
 console.log("Carrot desktop engage!");
 
@@ -28,3 +29,8 @@ window.OCCarrotDesktop.windowHasFocus = function() {
   console.log("Determining focus state of desktop window");
   return ipcRenderer.sendSync('window-has-focus?');
 };
+
+window.OCCarrotDesktop.getElectronAppVersion = function() {
+  console.log("DBG Get electorn app version");
+  return package.version;
+}

--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -196,3 +196,4 @@ var OCCarrotDesktop = function(){};
 OCCarrotDesktop.showDesktopWindow = function() {};
 OCCarrotDesktop.setBadgeCount = function() {};
 OCCarrotDesktop.windowHasFocus = function() {};
+OCCarrotDesktop.getElectronAppVersion = function() {};

--- a/scss/partials/_menu.scss
+++ b/scss/partials/_menu.scss
@@ -156,7 +156,7 @@ div.menu {
       background-color: transparent;
       padding: 0px;
       @include OC_Body_Book();
-      font-size: 14px;
+      font-size: 16px;
       line-height: 18px;
       color: $light_navy;
       text-align: left;
@@ -165,6 +165,14 @@ div.menu {
       @include big_web() {
         &:hover {
           opacity: 1;
+        }
+      }
+
+      &.app-version {
+        cursor: default;
+
+        div.oc-menu-item {
+          color: rgba($deep_navy, 0.5);
         }
       }
     }
@@ -180,11 +188,23 @@ div.menu {
       padding: 0;
       position: relative;
       @include OC_Body_Book();
-      font-size: 14px;
+      font-size: 16px;
 
       @include mobile() {
         font-size: 16px;
         line-height: 24px;
+      }
+
+      &.app-version {
+        display: block;
+        background-color: transparent;
+        padding: 0px;
+        @include OC_Body_Book();
+        font-size: 14px;
+        line-height: 18px;
+        color: rgba($light_navy, 0.5);
+        text-align: left;
+        margin: 16px 0;
       }
 
       &.whats-new {

--- a/src/oc/web/components/ui/menu.cljs
+++ b/src/oc/web/components/ui/menu.cljs
@@ -2,6 +2,7 @@
   (:require [rum.core :as rum]
             [org.martinklepsch.derivatives :as drv]
             [dommy.core :as dommy :refer-macros (sel sel1)]
+            [oc.web.expo :as expo]
             [oc.web.lib.jwt :as jwt]
             [oc.web.urls :as oc-urls]
             [oc.web.lib.chat :as chat]
@@ -96,7 +97,12 @@
         is-admin-or-author? (#{:admin :author} user-role)
         show-invite-people? (and org-slug
                                  is-admin-or-author?)
-        desktop-app-data (detect-desktop-app)]
+        desktop-app-data (detect-desktop-app)
+        build-version (if (seq ls/deploy-key) ls/deploy-key "local")
+        app-version (cond
+                      ua/mobile-app? [:span "Version " (expo/get-app-version) " Build " [:i build-version]]
+                      ua/desktop-app? [:span "Version " (.getElectronAppVersion js/OCCarrotDesktop) " Build " [:i build-version]]
+                      :else [:span "Version " [:i build-version]])]
     [:div.menu
       {:class (utils/class-set {:expanded-user-menu expanded-user-menu})
        :on-click #(when-not (utils/event-inside? % (rum/ref-node s :menu-container))
@@ -203,4 +209,7 @@
               "Sign out"]]
           [:a {:href "" :on-click (partial sign-in-sign-up-click s)}
             [:div.oc-menu-item
-              "Sign in / Sign up"]])]]))
+              "Sign in / Sign up"]])
+        [:div.oc-menu-separator]
+        [:div.oc-menu-item.app-version
+           app-version]]]))

--- a/src/oc/web/components/ui/menu.cljs
+++ b/src/oc/web/components/ui/menu.cljs
@@ -98,11 +98,10 @@
         show-invite-people? (and org-slug
                                  is-admin-or-author?)
         desktop-app-data (detect-desktop-app)
-        build-version (if (seq ls/deploy-key) ls/deploy-key "local")
         app-version (cond
-                      ua/mobile-app? [:span "Version " (expo/get-app-version) " Build " [:i build-version]]
-                      ua/desktop-app? [:span "Version " (.getElectronAppVersion js/OCCarrotDesktop) " Build " [:i build-version]]
-                      :else [:span "Version " [:i build-version]])]
+                      ua/mobile-app? (str "Version " (expo/get-app-version))
+                      ua/desktop-app? (str "Version " (.getElectronAppVersion js/OCCarrotDesktop))
+                      :else "")]
     [:div.menu
       {:class (utils/class-set {:expanded-user-menu expanded-user-menu})
        :on-click #(when-not (utils/event-inside? % (rum/ref-node s :menu-container))
@@ -210,6 +209,8 @@
           [:a {:href "" :on-click (partial sign-in-sign-up-click s)}
             [:div.oc-menu-item
               "Sign in / Sign up"]])
-        [:div.oc-menu-separator]
-        [:div.oc-menu-item.app-version
-           app-version]]]))
+        (when ua/pseudo-native?
+          [:div.oc-menu-separator])
+        (when ua/pseudo-native?
+          [:div.oc-menu-item.app-version
+             app-version])]]))

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -658,7 +658,8 @@
   (user-actions/recall-expo-push-token)
   ;; Get the mobile app deep link origin if we're on mobile
   (when ua/mobile-app?
-    (expo/bridge-get-deep-link-origin))
+    (expo/bridge-get-deep-link-origin)
+    (expo/bridge-get-app-version))
 
   ;; Subscribe to websocket client events
   (aa/ws-change-subscribe)

--- a/src/oc/web/expo.cljs
+++ b/src/oc/web/expo.cljs
@@ -86,3 +86,25 @@
   (when-let [origin (parse-bridge-data json-str)]
     (bridge-log! origin)
     (reset! deep-link-origin origin)))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Grabbing the app version from the expo wrapper
+
+(def ^:private app-version (atom nil))
+
+(defn get-app-version
+  []
+  @app-version)
+
+(defn bridge-get-app-version
+  ""
+  []
+  (bridge-call! "get-app-version" nil))
+
+(defn- ^:export on-app-version
+  ""
+  [av]
+  (when av
+    (bridge-log! (str "on-app-version " av))
+    (reset! app-version av)))


### PR DESCRIPTION
Card: https://trello.com/c/vytHl8Gd

Review with: https://github.com/open-company/open-company-mobile/pull/4

To test:
- start the Expo app
- [ ] do you see the version in the menu?
- start the Electron app
- [ ] do you see the version in the menu?
- start the site
- [ ] do you see the build version in the menu?
