### PR TITLE
Fix follow-up copy.

### DIFF
--- a/scss/partials/_follow_ups_picker.scss
+++ b/scss/partials/_follow_ups_picker.scss
@@ -131,6 +131,18 @@ div.follow-ups-picker {
           line-height: 22px;
           color: $light_navy;
           float: left;
+
+          button.section-memeber-bt {
+            padding: 0;
+            margin: 0;
+            display: inline-block;
+            @include OC_Body_Book();
+            font-size: 14px;
+            line-height: 22px;
+            color: $light_navy;
+            text-decoration: underline;
+            cursor: pointer;
+          }
         }
 
         div.follow-ups-users-bt {

--- a/scss/partials/_more_menu.scss
+++ b/scss/partials/_more_menu.scss
@@ -149,22 +149,26 @@ div.more-menu {
     list-style-type: none;
 
     &.has-create-follow-up {
-      left: calc(100% - 146px);
+      left: unset;
+      right: 0;
       width: 144px;
 
       @include mobile() {
-        left: calc(100% - 108px);
-        width: 74px;
+        left: unset;
+        right: 0;
+        width: 128px;
       }
     }
 
     &.has-complete-follow-up {
-      left: calc(100% - 126px);
+      left: unset;
+      right: 0;
       width: 162px;
 
       @include mobile() {
-        left: calc(100% - 108px);
-        width: 74px;
+        left: unset;
+        right: 0;
+        width: 162px;
       }
     }
 

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -319,9 +319,7 @@
         (when (and published-entry?
                    (seq completed-follow-ups))
           (str " (" (count completed-follow-ups) " completed)"))
-        " in the “"
-        (:board-name cmail-data)
-        "” section."]
+        "."]
       (when can-toggle-follow-ups?
         (if is-mobile?
           [:div.mobile-follow-ups-remove-menu-container
@@ -641,7 +639,7 @@
             [:div.cmail-header-right-buttons
               (when-not follow-up?
                 [:button.mlb-reset.follow-up-button
-                  {:title "Request follow up"
+                  {:title "Request follow-up"
                    :data-toggle "tooltip"
                    :data-placement "bottom"
                    :data-container "body"
@@ -800,7 +798,7 @@
             (when (and (not follow-up?)
                        (not is-fullscreen?))
               [:button.mlb-reset.follow-up-button
-                {:title "Request follow up"
+                {:title "Request follow-up"
                  :data-toggle "tooltip"
                  :data-placement "top"
                  :data-container "body"

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -641,7 +641,7 @@
             [:div.cmail-header-right-buttons
               (when-not follow-up?
                 [:button.mlb-reset.follow-up-button
-                  {:title "Create follow-ups"
+                  {:title "Request follow up"
                    :data-toggle "tooltip"
                    :data-placement "bottom"
                    :data-container "body"
@@ -800,7 +800,7 @@
             (when (and (not follow-up?)
                        (not is-fullscreen?))
               [:button.mlb-reset.follow-up-button
-                {:title "Create follow-ups"
+                {:title "Request follow up"
                  :data-toggle "tooltip"
                  :data-placement "top"
                  :data-container "body"

--- a/src/oc/web/components/ui/more_menu.cljs
+++ b/src/oc/web/components/ui/more_menu.cljs
@@ -176,7 +176,7 @@
                                   (when (fn? will-close)
                                     (will-close))
                                   (activity-actions/create-self-follow-up entity-data create-follow-up-link))}
-                    "Create follow-up"])))
+                    "Follow up later"])))
             (when can-react?
               [:li.react
                 {:on-click #(do

--- a/src/oc/web/components/ui/more_menu.cljs
+++ b/src/oc/web/components/ui/more_menu.cljs
@@ -176,7 +176,7 @@
                                   (when (fn? will-close)
                                     (will-close))
                                   (activity-actions/create-self-follow-up entity-data create-follow-up-link))}
-                    "Follow up later"])))
+                    "Follow-up later"])))
             (when can-react?
               [:li.react
                 {:on-click #(do
@@ -244,4 +244,4 @@
                               (activity-actions/create-self-follow-up entity-data create-follow-up-link))
                  :data-toggle (if is-mobile? "" "tooltip")
                  :data-placement (or tooltip-position "top")
-                 :title "Create follow-up"}])))])))
+                 :title "Follow up later"}])))])))


### PR DESCRIPTION
Card: https://trello.com/c/1FVeoZOu

To test:
- open AP on desktop
- [x] button tooltip says _Follow up later_?
- now expand QP
- [x] tooltip on the follow-up button says: _Request follow up_
- enter FP
- [x] tooltip on the follow-up button says: Request follow up (this is a different button in the code so you need to check both)
- now click the follow-up button
- [x] blue bar has not more the section name in it?
- click the blue bar
- [x] copy says _x of y section members_?
- [x] is section members clickable with _{section-name} settings_ tooltip only if you are admin?
- [x] does it open the currently section settings for the section selected in cmail (no matter if you are in another section)?
- now open AP on mobile (you can just resize the win and refresh)
- expand a post
- [x] can still complete/create follow-ups with the button at the top
- now enter editing
- click follow-ups button
- click the blue bar
- [x] no underline on _section members_ copy?
- [x] tapping it doesn't do anything?