### PR TITLE
Allow use of org and board UUIDs in URL path, which redirect to their respective slugs

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -146,9 +146,12 @@
 
       ; If there is a board slug let's load the board data
       (router/current-board-slug)
-      (if-let [board-data (first (filter #(= (:slug %) (router/current-board-slug)) boards))]
+      (if-let [board-data (first (filter #(or (= (:slug %) (router/current-board-slug))
+                                              (= (:uuid %) (router/current-board-slug))) boards))]
         ; Load the board data since there is a link to the board in the org data
         (do
+          (when (= (:uuid board-data) (router/current-board-slug))
+            (router/rewrite-board-uuid-as-slug (router/current-board-slug) (:slug board-data)))
           (when-let [board-link (utils/link-for (:links board-data) ["item" "self"] "GET")]
             (utils/maybe-after section-delay #(sa/section-get :recently-posted board-link)))
           (when-let [recent-board-link (utils/link-for (:links board-data) "activity" "GET")]

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -150,6 +150,7 @@
                                               (= (:uuid %) (router/current-board-slug))) boards))]
         ; Load the board data since there is a link to the board in the org data
         (do
+          ;; Rewrite the URL in case it's using the board UUID instead of the slug
           (when (= (:uuid board-data) (router/current-board-slug))
             (router/rewrite-board-uuid-as-slug (router/current-board-slug) (:slug board-data)))
           (when-let [board-link (utils/link-for (:links board-data) ["item" "self"] "GET")]

--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -274,15 +274,17 @@
          (section-save-error 409))
        (dispatcher/dispatch! [:input [:section-editing :pre-flight-loading] false])))))
 
-(defn section-more-finish [direction {:keys [success body]}]
+(defn section-more-finish [board-slug sort-type direction {:keys [success body]}]
   (when success
     (request-reads-count (json->cljs body)))
-  (dispatcher/dispatch! [:section-more/finish (router/current-org-slug) (router/current-board-slug)
-   direction (router/current-sort-type) (when success (json->cljs body))]))
+  (dispatcher/dispatch! [:section-more/finish (router/current-org-slug) board-slug
+   direction sort-type (when success (json->cljs body))]))
 
 (defn section-more [more-link direction]
-  (api/load-more-items more-link direction (partial section-more-finish direction))
-  (dispatcher/dispatch! [:section-more (router/current-org-slug) (router/current-board-slug) (router/current-sort-type)]))
+  (let [board-slug (router/current-board-slug)
+        sort-type (router/current-sort-type)]
+    (api/load-more-items more-link direction (partial section-more-finish board-slug sort-type direction))
+    (dispatcher/dispatch! [:section-more (router/current-org-slug) board-slug sort-type])))
 
 (defn setup-section-editing [section-slug]
   (when-let [board-data (dispatcher/board-data (router/current-org-slug) section-slug)]

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -75,9 +75,13 @@
      (entry-point-get-finished success body
        (fn [orgs collection]
          (if org-slug
-           (if-let [org-data (first (filter #(= (:slug %) org-slug) orgs))]
-             ;; We got the org we were looking for
-             (org-actions/get-org org-data)
+           (if-let [org-data (first (filter #(or (= (:slug %) org-slug)
+                                                 (= (:uuid %) org-slug)) orgs))]
+             ;; We got the org we were looking for. Possibly redirect if the client
+             ;; used org uuid in token.
+             (if (= (:uuid org-data) org-slug)
+               (router/rewrite-org-uuid-as-slug org-slug (:slug org-data))
+               (org-actions/get-org org-data))
              (if (router/current-secure-activity-id)
                (activity-actions/secure-activity-get
                 #(comment-utils/get-comments-if-needed (dis/secure-activity-data) (dis/comments-data)))

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -141,8 +141,7 @@
                              (or ;; the post is not present in the posts list
                                  (not ((set (keys posts-data)) (router/current-activity-id)))
                                  ;; the board of the post is wrong (with slug and uuid)
-                                 (and (not= (:board-slug (get posts-data (router/current-activity-id)) (router/current-board-slug)))
-                                      (not= (:board-uuid (get posts-data (router/current-activity-id)) (router/current-board-slug))))))
+                                 (not= (:board-slug (get posts-data (router/current-activity-id)) (router/current-board-slug)))))
         show-login-wall (and (not jwt)
                              (or force-login-wall
                                  (and (router/current-activity-id)

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -138,10 +138,11 @@
                              ;; posts data are present
                              (not (nil? posts-data))
                              ;; and
-                             (or ;; the post is not present int he posts list
+                             (or ;; the post is not present in the posts list
                                  (not ((set (keys posts-data)) (router/current-activity-id)))
-                                 ;; the board of the post is wrong
-                                 (not= (:board-slug (get posts-data (router/current-activity-id)) (router/current-board-slug)))))
+                                 ;; the board of the post is wrong (with slug and uuid)
+                                 (and (not= (:board-slug (get posts-data (router/current-activity-id)) (router/current-board-slug)))
+                                      (not= (:board-uuid (get posts-data (router/current-activity-id)) (router/current-board-slug))))))
         show-login-wall (and (not jwt)
                              (or force-login-wall
                                  (and (router/current-activity-id)

--- a/src/oc/web/expo.cljs
+++ b/src/oc/web/expo.cljs
@@ -55,18 +55,6 @@
       (user-actions/deny-push-notification-permission))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Handling of user tapping on push notification
-
-(defn- ^:export on-push-notification-tapped
-  "Callback for responding to the user tapping on a native push notification. Response contains
-  a push notification payload, which is literally a Carrot notification map."
-  [json-str]
-  (when-let [notification (parse-bridge-data json-str)]
-    (let [fixed-notif (user-utils/fix-notification notification)
-          click-handler (:click fixed-notif)]
-      (click-handler))))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Grabbing the deep link origin for creating mobile URLs
 
 (def ^:private deep-link-origin (atom nil))

--- a/src/oc/web/router.cljs
+++ b/src/oc/web/router.cljs
@@ -62,10 +62,12 @@
 
 (defn rewrite-org-uuid-as-slug
   [org-uuid org-slug]
+  (timbre/info "Navigate from org" org-uuid "to slug:" org-slug)
   (nav! (cstr/replace (get-token) (re-pattern org-uuid) org-slug)))
 
 (defn rewrite-board-uuid-as-slug
   [board-uuid board-slug]
+  (timbre/info "Rewrite URL from board" board-uuid "to slug:" board-slug)
   (let [new-path (cstr/replace (get-token) (re-pattern board-uuid) board-slug)]
     (swap! path assoc :board board-slug)
     (.replaceState js/window.history #js {} js/window.title new-path)))

--- a/src/oc/web/router.cljs
+++ b/src/oc/web/router.cljs
@@ -6,7 +6,8 @@
             [goog.events.EventType :as EventType]
             [goog.history.EventType :as HistoryEventType]
             [oc.web.lib.sentry :as sentry]
-            [oc.web.lib.jwt :as jwt]))
+            [oc.web.lib.jwt :as jwt]
+            [clojure.string :as cstr]))
 
 (def path (atom {}))
 
@@ -58,6 +59,16 @@
   (timbre/info "nav!" token)
   (timbre/debug "history:" @history)
   (.setToken @history token))
+
+(defn rewrite-org-uuid-as-slug
+  [org-uuid org-slug]
+  (nav! (cstr/replace (get-token) (re-pattern org-uuid) org-slug)))
+
+(defn rewrite-board-uuid-as-slug
+  [board-uuid board-slug]
+  (let [new-path (cstr/replace (get-token) (re-pattern board-uuid) board-slug)]
+    (swap! path assoc :board board-slug)
+    (.replaceState js/window.history #js {} js/window.title new-path)))
 
 (defn redirect! [loc]
   (timbre/info "redirect!" loc)


### PR DESCRIPTION
Trello: https://trello.com/c/2IcGaZ9f/2194-modify-notification-payloads-to-contain-url-to-simplify-mobile-push-notification-tap-handling

Linked PRs:
- Mobile: https://github.com/open-company/open-company-mobile/pull/5
- Storage: https://github.com/open-company/open-company-storage/pull/221
- Notify: https://github.com/open-company/open-company-notify/pull/17

To test:
- Find the org UUID of your test org
- Navigate to `/org-uuid` in your browser
- [x] Are you correctly redirected to `/org-slug`?
- Pick a board/section, and find it's board UUID
- Navigate to `/org-slug/board-uuid` in your browser
- [x] Are you correctly redirected to `/org-slug/board-slug`?
- Navigate to `/org-uuid/board-uuid`
- [x] Are you correctly redirected to `/org-slug/board-slug`?
- Try all of the above tests with the URLs of posts and comments
- [x] Are you properly redirected to the respective slug URLs for posts/comments?
- [x] Does using the browser's back button work properly? Mainly, does it skip the UUID-based paths when navigating backwards?
- [x] Does the redirect work for public sections/posts? Try testing the redirect in an incognito browser session.

Regression:
- [x] Does navigating around the app still work (i.e. is normal routing still working)?