### PR TITLE
Remove comments pre-load

### DIFF
--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -43,11 +43,6 @@
   (when (responsive/is-tablet-or-mobile?)
     (reset! (::mobile-video-height s) (utils/calc-video-height (win-width)))))
 
-(defn- item-mounted [s]
-  (let [activity-data (first (:rum/args s))
-        comments-data @(drv/get-ref s :comments-data)]
-    (comment-actions/get-comments-if-needed activity-data comments-data)))
-
 (rum/defcs stream-item < rum/static
                          rum/reactive
                          ;; Derivatives
@@ -64,12 +59,6 @@
                          (mention-mixins/oc-mentions-hover)
                          {:will-mount (fn [s]
                            (calc-video-height s)
-                           s)
-                          :did-mount (fn [s]
-                           (item-mounted s)
-                           s)
-                          :did-remount (fn [_ s]
-                           (item-mounted s)
                            s)}
   [s activity-data read-data]
   (let [org-data (drv/react s :org-data)


### PR DESCRIPTION
Card: https://trello.com/c/tt5cbC8k

### Review after https://github.com/open-company/open-company-storage/pull/220
NB: you need to review this after the Storage #220 to make sure the comments are shown in the right order when the client has only the first 10 comments Storage send.
That fix adds the parent-uuid which is needed to correctly sort the comments on the client. Without that you can see all comments as root instead of replies.

To test:
- go to All Posts
- scroll down
- [x] no GET requests ending with /comments to Interaction Service in the network tab? Good
- now expand a few posts
- [x] the comments GET request appear when you expand the post?
- re-expand at least one post you already expanded before
- [x] the comments GET request is re-started to force refresh comments on expand?
- now expand a post
- add a comment with another user to it
- [x] do you see the comment coming in live?
- [x] does it highlight?
- go to a section
- [x] repeat the above
- copy the digest URL of a post with the id-token in it
- open it in incognito
- [x] comments are all loaded and displayed?