### PR TITLE
Item move fix

### DIFF
--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -245,7 +245,10 @@
                    (not= (:user-id change-data) (jwt/user-id)))
           (dispatcher/dispatch! [:item-add/unseen (router/current-org-slug) change-data]))
         (when (= change-type :delete)
-          (dispatcher/dispatch! [:item-delete/unseen (router/current-org-slug) change-data]))))))
+          (dispatcher/dispatch! [:item-delete/unseen (router/current-org-slug) change-data]))
+        (when (= change-type :move)
+          (dispatcher/dispatch! [:item-move (router/current-org-slug) change-data])
+          (section-change section-uuid))))))
 
 (defn ws-interaction-subscribe []
   (ws-ic/subscribe :interaction-comment/add


### PR DESCRIPTION
Related PR: https://github.com/open-company/open-company-change/pull/22

With the above PR we are introducing a new type for the `item/change` event. It's the `:move` type. It's used when a post is moved from a container to another.
The client reacts to this event moving the status of that item from the old container to the new one.
The old container uuid is passed in the payload with the `:old-container-id` key.

To test:
- user A on AP
- user B on section X
- user A add a new Post 1 to section Y
- user B sees section Y bold
- user A moves Post 1 from section Y to section Z
- user B sees section Y unbold
- user B sees section Z bold
- user B goes to AP
- user B open Post 1
- user B sees section Z unbold
- user B goes to section X
- user A moves Post 1 from section Z to section Y
- user B doesn't have any bold section