### PR TITLE
What's new widget (desktop)

### DIFF
--- a/src/oc/web/components/ui/menu.cljs
+++ b/src/oc/web/components/ui/menu.cljs
@@ -191,8 +191,10 @@
         (when-not is-mobile?
           [:div.oc-menu-separator])
         [:a.whats-new-link
-          {:href "https://carrot.news/"
+          (if ua/mobile?
+            {:href "https://carrot.news/"
              :target "_blank"}
+            {:on-click (partial whats-new-click s)})
           [:div.oc-menu-item.whats-new
             "What’s new"]]
         [:a

--- a/src/oc/web/lib/whats_new.cljs
+++ b/src/oc/web/lib/whats_new.cljs
@@ -50,4 +50,5 @@
 
 (defn show []
   (when @initialized
-    (.show js/Headway)))
+    (.show js/Headway)
+    (utils/after 1000 check-whats-new-badge)))


### PR DESCRIPTION
Use the What's new widget on desktop instead of opening carrot.news

To test:
- on desktop
- login
- open the menu
- click on whats new
- [x] do you see the widget opening in the app? No redirect?
- close the widget
- [x] do you NOT see the green dot on the user avatar anymore (if there was one before)?
- on mobile web
- login
- open the menu
- click on whats new
- [x] a new tab open and show you carrot.news?
- on mobile app
- login
- open the menu
- click on whats new
- [x] mobile browser opens and show you carrot.news?