### PR TITLE
Fix mobile login

### DIFF
--- a/scss/partials/_login_wall.scss
+++ b/scss/partials/_login_wall.scss
@@ -156,7 +156,7 @@ div.login-wall-container {
               top: 12px;
               right: 24px;
 
-              &.disabled {
+              &.disabled, &:disabled {
                 background-color: $light_ui_grey;
                 opacity: 1;
               }
@@ -319,7 +319,7 @@ div.login-wall-container {
           line-height: 23px;
           border-radius: 6px;
 
-          &.disabled {
+          &.disabled, &:disabled {
             background-color: $light_ui_grey;
           }
         }

--- a/src/oc/web/components/ui/login_wall.cljs
+++ b/src/oc/web/components/ui/login_wall.cljs
@@ -21,12 +21,10 @@
   [s {:keys [title desc]}]
   (let [auth-settings (drv/react s :auth-settings)
         login-enabled (and auth-settings
-                           (not (nil?
-                            (utils/link-for
-                             (:links auth-settings)
-                             "authenticate"
-                             "GET"
-                             {:auth-source "email"}))))
+                           (seq (utils/link-for (:links auth-settings) "authenticate" "GET"
+                            {:auth-source "email"}))
+                           (seq @(::email s))
+                           (seq @(::pswd s)))
         login-action #(when login-enabled
                         (.preventDefault %)
                         (user-actions/maybe-save-login-redirect)
@@ -129,9 +127,7 @@
                 [:button.mlb-reset.continue-btn
                   {:aria-label "Login"
                    :class (when-not login-enabled "disabled")
-                   :on-click login-action
-                   :disabled (or (not (seq @(::email s)))
-                                 (not (seq @(::pswd s))))}
+                   :on-click login-action}
                   "Continue"]
                 [:div.footer-link
                   "Don't have an account yet?"


### PR DESCRIPTION
Bug: with mobile visit /login/desktop, make sure email and password fields are empty. The blue circle button in top right corner is still enabled and if you click it you get an error for a failed attempt to login. This shouldn't happen, the button should be disabled when the bottom one is.

To test:
- go to /login/desktop
- click the top right circle button
- [ ] nothing happens?
- [ ] is it disabled?
- no enter en email and a password
- [ ] click the top right circle button
- [ ] did it work? Good
- logout and go back to /login/desktop
- try to login with the bottom button now
- [ ] did it work? Good
- logout and go back to /login/desktop
- [ ] login with Slack
- logout and go back to /login/desktop
- [ ] login with Google
