### PR TITLE
Fix activity 404

### DIFF
--- a/src/oc/web/actions/activity.cljs
+++ b/src/oc/web/actions/activity.cljs
@@ -381,7 +381,9 @@
         (fn [{:keys [status success body]}]
           (if (and (= status 404)
                    (= (:uuid entry-data) (router/current-activity-id)))
-            (routing-actions/maybe-404)
+            (do
+              (dis/dispatch! [:activity-get/not-found (router/current-org-slug) (:uuid entry-data) nil])
+              (routing-actions/maybe-404))
             (dis/dispatch! [:activity-get/finish status (router/current-org-slug) (json->cljs body)
              nil])))))))
 

--- a/src/oc/web/actions/cmail.cljs
+++ b/src/oc/web/actions/cmail.cljs
@@ -73,7 +73,8 @@
 (defn get-entry-with-uuid [board-slug activity-uuid & [loaded-cb]]
   (api/get-current-entry (router/current-org-slug) board-slug activity-uuid
    (fn [{:keys [status success body]}]
-    (when-not (= status 404)
+    (if (= status 404)
+      (dis/dispatch! [:activity-get/not-found (router/current-org-slug) activity-uuid nil])
       (dis/dispatch! [:activity-get/finish status (router/current-org-slug) (when success (json->cljs body)) nil]))
     (when (fn? loaded-cb)
       (utils/after 100 #(loaded-cb success status))))))

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -280,7 +280,8 @@
               (empty-org)
               ;; Expanded post
               (and current-activity-id
-                   activity-data)
+                   activity-data
+                   (not= activity-data :404))
               (expanded-post)
               ;; Empty board
               empty-board?

--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -114,15 +114,21 @@
         _cmail-data (drv/react s :cmail-data)
         user-notifications-data (drv/react s :user-notifications)
         showing-mobile-user-notifications (drv/react s :mobile-user-notifications)
-        no-phisical-home-button (js/isiPhoneWithoutPhysicalHomeBt)]
+        no-phisical-home-button (js/isiPhoneWithoutPhysicalHomeBt)
+        show-expanded-post (and current-activity-id
+                                activity-data
+                                (not= activity-data :404)
+                                ;; Do not show the post under the wrong board slug/uuid
+                                (or (= (:board-slug activity-data) (router/current-board-slug))
+                                    (= (:board-uuid activity-data) (router/current-board-slug))))]
       ;; Entries list
       [:div.dashboard-layout.group
-        {:class (when current-activity-id "expanded-post-view")}
+        {:class (when show-expanded-post "expanded-post-view")}
         [:div.dashboard-layout-container.group
           {:class (when (drv/react s :hide-left-navbar) "hide-left-navbar")}
           (navigation-sidebar)
           (when (and is-mobile?
-                     (not current-activity-id)
+                     (not show-expanded-post)
                      (or (:collapsed cmail-state)
                          (not cmail-state))
                      (jwt/user-is-part-of-the-team (:team-id org-data)))
@@ -168,7 +174,7 @@
             (when (and (not is-mobile?)
                        can-compose?)
                (cmail))
-            (when-not current-activity-id
+            (when-not show-expanded-post
               ;; Board name row: board name, settings button and say something button
               [:div.board-name-container.group
                 {:class (when is-drafts-board "drafts-board")}
@@ -249,7 +255,7 @@
                                          "decisions to keep you and your team pulling in the same direction.")
                   is-second-user (= add-post-tooltip :is-second-user)]
               (when (and (not is-drafts-board)
-                         (not current-activity-id)
+                         (not show-expanded-post)
                          add-post-tooltip)
                 [:div.add-post-tooltip-container.group
                   [:button.mlb-reset.add-post-tooltip-dismiss
@@ -279,9 +285,7 @@
               (zero? (count (:boards org-data)))
               (empty-org)
               ;; Expanded post
-              (and current-activity-id
-                   activity-data
-                   (not= activity-data :404))
+              show-expanded-post
               (expanded-post)
               ;; Empty board
               empty-board?

--- a/src/oc/web/components/org_dashboard.cljs
+++ b/src/oc/web/components/org_dashboard.cljs
@@ -103,19 +103,19 @@
                                (not= (router/current-board-slug) "must-see")
                                (not= (router/current-board-slug) "follow-ups")
                                (not ((set (map :slug (:boards org-data))) (router/current-board-slug))))
+        current-activity-data (when (router/current-activity-id)
+                                (get posts-data (router/current-activity-id)))
         entry-not-found (and ;; org is present
                              (not org-not-found)
                              ;; section is present
                              (not section-not-found)
-                             ;; a post id is specified
-                             (router/current-activity-id)
-                             ;; posts data are present
-                             (not (nil? posts-data))
-                             ;; and
-                             (or ;; the post is not present in the posts list
-                                 (not ((set (keys posts-data)) (router/current-activity-id)))
-                                 ;; the board of the post is wrong (with slug and uuid)
-                                 (not= (:board-slug (get posts-data (router/current-activity-id)) (router/current-board-slug)))))
+                             ;; route is for a single post and it's been loaded
+                             current-activity-data
+                             ;; post wasn't found
+                             (or (= current-activity-data :404)
+                                 ;; route has wrong board slug/uuid for the current post
+                                 (and (not= (:board-slug current-activity-data) (router/current-board-slug))
+                                      (not= (:board-uuid current-activity-data) (router/current-board-slug)))))
         show-login-wall (and (not jwt)
                              (or force-login-wall
                                  (and (router/current-activity-id)

--- a/src/oc/web/stores/activity.cljs
+++ b/src/oc/web/stores/activity.cljs
@@ -258,12 +258,16 @@
   ;; do nothing for now
   db)
 
+(defmethod dispatcher/action :activity-get/not-found
+  [db [_ org-slug activity-uuid secure-uuid]]
+  (let [activity-key (if secure-uuid
+                       (dispatcher/secure-activity-key org-slug secure-uuid)
+                       (dispatcher/activity-key org-slug activity-uuid))]
+    (assoc-in db activity-key :404)))
+
 (defmethod dispatcher/action :activity-get/finish
   [db [_ status org-slug activity-data secure-uuid]]
-  (let [next-db (if (= status 404)
-                  (dissoc db :latest-entry-point)
-                  db)
-        activity-uuid (:uuid activity-data)
+  (let [activity-uuid (:uuid activity-data)
         board-data (au/board-by-uuid (:board-uuid activity-data))
         activity-key (if secure-uuid
                        (dispatcher/secure-activity-key org-slug secure-uuid)


### PR DESCRIPTION
Bug: sometimes the activity not found dialog is show briefly before a post becomes visible. This is because we check if the post exists in the app-state. Since we added board pagination this check has become unreliable since the post could be in a page we haven't loaded yet.

Fix: when loading a post if we get a 404 set `:404` in the app-state to the activity key. Show the post not found only when there is this keyword is found instead of the post data.

To test:
- when logged in
- go to AP
- expand a post in a normal section
- refresh the post page
- go back to AP
- expand a post in a private section
- refresh the post page
- expand a post in a public section
- refresh the post page
- now get the link of a post in a team section and change the activity uuid to get a 404
- access that URL, make sure it shows the post not found
- repeat for a public section
- repeat for a private section
- now get the link of a post in a team section and change the board slug to get a 404
- access that URL, make sure it shows the post not found and the post is not visible below the dialog
- load a secure post url while logged in (copy public url from share)
- repeat all the above while logged out (you should get the login wall instead of the post not found in all cases, except for the public post url and the secure post url)

NB: this should also fix the briefly activity not found wall shown when opening a push notification on mobile