### PR TITLE
Production dev tools

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -251,7 +251,6 @@
 (deftask prod-build
   "OC Production build."
   []
-  (set-env! :dependencies #(into % '[[binaryage/devtools "0.9.8"]]))
   (comp (from-jars)
         (sass :output-style :compressed)
         (build-prod-site)
@@ -259,12 +258,7 @@
               :optimizations :advanced
               :source-map true
               :compiler-options {:parallel-build true
-                                 :externs ["public/js/externs.js"]
-                                 :preloads '[devtools.preload]
-                                 :external-config {
-                                  :devtools/config {
-                                    :print-config-overrides true
-                                    :disable-advanced-mode-check true}}})))
+                                 :externs ["public/js/externs.js"]})))
 
 (deftask check-sources!
   "Check source files with yagni, eastwood, kibit and bikeshed."


### PR DESCRIPTION
Some time ago we had some issues for which we needed to be able to debug the app-state on production.
Now it's been some time that we don't need it so i decided to remove the dev tools to speed up things a bit.
It won't change much probably but still a good thing for performance.

To test:
- try deploying `staging-dev-tools` branch to staging
- make sure everything works as expected (now if you try `OCWebPrintAppState()` from the console you don't see the clojurescript object value printed out but the javascript wrapper of the object)
- deploy `merge-branch` back to staging (so we have dev tools back on staging)
- merge
- deploy to prod
- delete `staging-dev-tools` branch from this repo