### PR TITLE
Optimize Slack and FileStack image URLs where appropriate

### DIFF
--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -2,6 +2,7 @@
   (:require [rum.core :as rum]
             [org.martinklepsch.derivatives :as drv]
             [clojure.contrib.humanize :refer (filesize)]
+            [oc.web.images :as img]
             [oc.web.lib.jwt :as jwt]
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
@@ -190,7 +191,10 @@
                 {:class (:type (:body-thumbnail activity-data))}
                 [:img.body-thumbnail
                   {:data-image (:thumbnail (:body-thumbnail activity-data))
-                   :src (:thumbnail (:body-thumbnail activity-data))}]]))
+                   :src (-> activity-data
+                            :body-thumbnail
+                            :thumbnail
+                            (img/optimize-image-url 102))}]]))
           [:div.stream-body-left.group
             {:class (utils/class-set {:has-thumbnail (:has-thumbnail activity-data)
                                       :has-video (:fixed-video-id activity-data)

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -194,7 +194,7 @@
                    :src (-> activity-data
                             :body-thumbnail
                             :thumbnail
-                            (img/optimize-image-url 102))}]]))
+                            (img/optimize-image-url (* 102 3)))}]]))
           [:div.stream-body-left.group
             {:class (utils/class-set {:has-thumbnail (:has-thumbnail activity-data)
                                       :has-video (:fixed-video-id activity-data)

--- a/src/oc/web/components/ui/org_avatar.cljs
+++ b/src/oc/web/components/ui/org_avatar.cljs
@@ -2,6 +2,7 @@
   (:require [rum.core :as rum]
             [org.martinklepsch.derivatives :as drv]
             [oc.web.urls :as oc-urls]
+            [oc.web.images :as img]
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
@@ -16,7 +17,7 @@
     {:class (utils/class-set {:no-avatar (not show-org-avatar?)})}
     (when show-org-avatar?
       [:img.org-avatar-img
-        {:src (:logo-url org-data)
+       {:src (-> org-data :logo-url (img/optimize-image-url default-max-logo-height))
          :on-error #(reset! (::img-load-failed s) true)}])
     (when show-org-name?
       [:span.org-name

--- a/src/oc/web/components/ui/org_avatar.cljs
+++ b/src/oc/web/components/ui/org_avatar.cljs
@@ -9,7 +9,7 @@
             [oc.web.actions.user :as user-actions]
             [oc.web.actions.routing :as routing-actions]))
 
-(def default-max-logo-height 42)
+(def default-max-logo-height 96) ;; 32 * 3 for retina
 
 (defn internal-org-avatar
   [s org-data show-org-avatar? show-org-name?]

--- a/src/oc/web/components/ui/org_avatar.cljs
+++ b/src/oc/web/components/ui/org_avatar.cljs
@@ -17,7 +17,7 @@
     {:class (utils/class-set {:no-avatar (not show-org-avatar?)})}
     (when show-org-avatar?
       [:img.org-avatar-img
-       {:src (-> org-data :logo-url (img/optimize-image-url default-max-logo-height))
+       {:src (-> org-data :logo-url (img/optimize-org-avatar-url default-max-logo-height))
          :on-error #(reset! (::img-load-failed s) true)}])
     (when show-org-name?
       [:span.org-name

--- a/src/oc/web/components/ui/user_avatar.cljs
+++ b/src/oc/web/components/ui/user_avatar.cljs
@@ -5,7 +5,8 @@
             [oc.web.lib.utils :as utils]
             [oc.web.stores.user :as store]
             [oc.web.mixins.ui :as ui-mixins]
-            [oc.web.lib.responsive :as responsive]))
+            [oc.web.lib.responsive :as responsive]
+            [oc.web.images :as img]))
 
 (rum/defcs user-avatar-image < rum/static
                                (rum/local false ::use-default)
@@ -15,7 +16,7 @@
         default-avatar (store/user-icon (:user-id user-data))
         user-avatar-url (if (or use-default (empty? (:avatar-url user-data)))
                          (utils/cdn default-avatar)
-                         (:avatar-url user-data))]
+                         (-> user-data :avatar-url (img/optimize-image-url 24)))]
     [:div.user-avatar-img-container
       {:data-user-id (:user-id user-data)
        :data-intercom-target "User avatar dropdown"

--- a/src/oc/web/components/ui/user_avatar.cljs
+++ b/src/oc/web/components/ui/user_avatar.cljs
@@ -16,7 +16,7 @@
         default-avatar (store/user-icon (:user-id user-data))
         user-avatar-url (if (or use-default (empty? (:avatar-url user-data)))
                          (utils/cdn default-avatar)
-                         (-> user-data :avatar-url (img/optimize-image-url 24)))]
+                         (-> user-data :avatar-url (img/optimize-image-url 72)))]
     [:div.user-avatar-img-container
       {:data-user-id (:user-id user-data)
        :data-intercom-target "User avatar dropdown"

--- a/src/oc/web/components/ui/user_avatar.cljs
+++ b/src/oc/web/components/ui/user_avatar.cljs
@@ -16,7 +16,7 @@
         default-avatar (store/user-icon (:user-id user-data))
         user-avatar-url (if (or use-default (empty? (:avatar-url user-data)))
                          (utils/cdn default-avatar)
-                         (-> user-data :avatar-url (img/optimize-image-url 72)))]
+                         (-> user-data :avatar-url (img/optimize-user-avatar-url 72)))]
     [:div.user-avatar-img-container
       {:data-user-id (:user-id user-data)
        :data-intercom-target "User avatar dropdown"

--- a/src/oc/web/images.cljs
+++ b/src/oc/web/images.cljs
@@ -13,7 +13,7 @@
       url
       (let [cur-path    (.getPath uri)
             resize-frag (str "resize=height:" preferred-height)
-            new-path    (str resize-frag "/" cur-path)
+            new-path    (str resize-frag cur-path)
             new-uri     (.setPath uri new-path)]
         (str new-uri)))))
 

--- a/src/oc/web/images.cljs
+++ b/src/oc/web/images.cljs
@@ -1,0 +1,42 @@
+(ns oc.web.images
+  (:require [clojure.string :as cstr])
+  (:import [goog Uri]))
+
+(defn- is-filestack?
+  [uri]
+  (= (.getDomain uri) "cdn.filestackcontent.com"))
+
+(defn optimize-filestack-image-url
+  [url preferred-height]
+  (let [uri (Uri. url)]
+    (if-not (is-filestack? uri)
+      url
+      (let [cur-path    (.getPath uri)
+            resize-frag (str "resize=height:" preferred-height)
+            new-path    (str resize-frag "/" cur-path)
+            new-uri     (.setPath uri new-path)]
+        (str new-uri)))))
+
+(defn- is-slack?
+  [uri]
+  (= (.getDomain uri) "avatars.slack-edge.com"))
+
+(defn optimize-slack-image-url
+  [url preferred-height]
+  (let [uri (Uri. url)]
+    (if-not (is-slack? uri)
+      url
+      (let [cur-path (.getPath uri)
+            re       #"_(\d{2,3})\.([a-z]+)$"
+            template (str "_" preferred-height ".$2")
+            new-path (cstr/replace cur-path re template)
+            new-uri  (.setPath uri new-path)]
+        (str new-uri)))))
+
+(defn optimize-image-url
+  [url preferred-height]
+  (let [uri (Uri. url)]
+    (cond
+      (is-filestack? uri) (optimize-filestack-image-url url preferred-height)
+      (is-slack? uri)     (optimize-slack-image-url url preferred-height)
+      :default            url)))

--- a/src/oc/web/images.cljs
+++ b/src/oc/web/images.cljs
@@ -2,11 +2,14 @@
   (:require [clojure.string :as cstr])
   (:import [goog Uri]))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; FileStack
+
 (defn- is-filestack?
   [uri]
   (= (.getDomain uri) "cdn.filestackcontent.com"))
 
-(defn optimize-filestack-image-url
+(defn- optimize-filestack-image-url
   [url preferred-height]
   (let [uri (Uri. url)]
     (if-not (is-filestack? uri)
@@ -17,11 +20,14 @@
             new-uri     (.setPath uri new-path)]
         (str new-uri)))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Slack
+
 (defn- is-slack?
   [uri]
   (= (.getDomain uri) "avatars.slack-edge.com"))
 
-(defn- approximate-slack-height
+(defn- approximate-slack-org-height
   [pref-height]
   (cond
     (<= pref-height 34)  34
@@ -29,27 +35,55 @@
     (<= pref-height 68)  68
     (<= pref-height 88)  88
     (<= pref-height 102) 102
-    (<= pref-height 132) 132
-    :default             230
+    :default             132
     ))
 
-(defn optimize-slack-image-url
-  [url preferred-height]
+(defn- approximate-slack-user-height
+  [pref-height]
+  (cond
+    (<= pref-height 24)  24
+    (<= pref-height 32)  32
+    (<= pref-height 48)  48
+    (<= pref-height 72)  72
+    (<= pref-height 192) 192
+    :default             512
+    ))
+
+(defn- optimize-slack-avatar
+  [url approx-height]
   (let [uri (Uri. url)]
     (if-not (is-slack? uri)
       url
       (let [cur-path      (.getPath uri)
             re            #"_(\d{2,3})\.([a-z]+)$"
-            approx-height (approximate-slack-height preferred-height)
             template      (str "_" approx-height ".$2")
             new-path      (cstr/replace cur-path re template)
             new-uri       (.setPath uri new-path)]
         (str new-uri)))))
 
+(defn- optimize-slack-org-avatar
+  [url preferred-height]
+  (optimize-slack-avatar url (approximate-slack-org-height preferred-height)))
+
+(defn- optimize-slack-user-avatar
+  [url preferred-height]
+  (optimize-slack-avatar url (approximate-slack-user-height preferred-height)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Image optimization API
+
 (defn optimize-image-url
   [url preferred-height]
-  (let [uri (Uri. url)]
-    (cond
-      (is-filestack? uri) (optimize-filestack-image-url url preferred-height)
-      (is-slack? uri)     (optimize-slack-image-url url preferred-height)
-      :default            url)))
+  (optimize-filestack-image-url url preferred-height))
+
+(defn optimize-user-avatar-url
+  [url preferred-height]
+  (-> url
+      (optimize-slack-user-avatar preferred-height)
+      (optimize-filestack-image-url preferred-height)))
+
+(defn optimize-org-avatar-url
+  [url preferred-height]
+  (-> url
+      (optimize-slack-org-avatar preferred-height)
+      (optimize-filestack-image-url preferred-height)))

--- a/src/oc/web/images.cljs
+++ b/src/oc/web/images.cljs
@@ -26,9 +26,11 @@
   (cond
     (<= pref-height 34)  34
     (<= pref-height 44)  44
+    (<= pref-height 68)  68
     (<= pref-height 88)  88
+    (<= pref-height 102) 102
     (<= pref-height 132) 132
-    :default 230
+    :default             230
     ))
 
 (defn optimize-slack-image-url

--- a/src/oc/web/images.cljs
+++ b/src/oc/web/images.cljs
@@ -21,16 +21,27 @@
   [uri]
   (= (.getDomain uri) "avatars.slack-edge.com"))
 
+(defn- approximate-slack-height
+  [pref-height]
+  (cond
+    (<= pref-height 34)  34
+    (<= pref-height 44)  44
+    (<= pref-height 88)  88
+    (<= pref-height 132) 132
+    :default 230
+    ))
+
 (defn optimize-slack-image-url
   [url preferred-height]
   (let [uri (Uri. url)]
     (if-not (is-slack? uri)
       url
-      (let [cur-path (.getPath uri)
-            re       #"_(\d{2,3})\.([a-z]+)$"
-            template (str "_" preferred-height ".$2")
-            new-path (cstr/replace cur-path re template)
-            new-uri  (.setPath uri new-path)]
+      (let [cur-path      (.getPath uri)
+            re            #"_(\d{2,3})\.([a-z]+)$"
+            approx-height (approximate-slack-height preferred-height)
+            template      (str "_" approx-height ".$2")
+            new-path      (cstr/replace cur-path re template)
+            new-uri       (.setPath uri new-path)]
         (str new-uri)))))
 
 (defn optimize-image-url

--- a/src/oc/web/images.cljs
+++ b/src/oc/web/images.cljs
@@ -35,7 +35,8 @@
     (<= pref-height 68)  68
     (<= pref-height 88)  88
     (<= pref-height 102) 102
-    :default             132
+    (<= pref-height 132) 132
+    :default             nil
     ))
 
 (defn- approximate-slack-user-height
@@ -46,7 +47,8 @@
     (<= pref-height 48)  48
     (<= pref-height 72)  72
     (<= pref-height 192) 192
-    :default             512
+    (<= pref-height 512) 512
+    :default             nil
     ))
 
 (defn- optimize-slack-avatar
@@ -63,11 +65,15 @@
 
 (defn- optimize-slack-org-avatar
   [url preferred-height]
-  (optimize-slack-avatar url (approximate-slack-org-height preferred-height)))
+  (if-let [approx-height (approximate-slack-org-height preferred-height)]
+    (optimize-slack-avatar url approx-height)
+    url))
 
 (defn- optimize-slack-user-avatar
   [url preferred-height]
-  (optimize-slack-avatar url (approximate-slack-user-height preferred-height)))
+  (if-let [approx-height (approximate-slack-user-height preferred-height)]
+    (optimize-slack-avatar url approx-height)
+    url))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Image optimization API


### PR DESCRIPTION
Trello: https://trello.com/c/7tWvpn1L/2268-optimize-user-avatars-and-filestack-thumbnails

To test:
- Log in with Slack user
- [x] Inspect user avatar. Properly loaded 72px image?
- Upload a custom avatar (i.e. FileStack avatar)
- [x] Inspect your user avatar in the feed. Properly loaded 72px image?
- Create a new post containing a modestly sized image (> 500px)
- [x] Thumbnail image in feed loaded 102px high image?
- Upload a custom org avatar
- [x] Thumbnail image in top-left is pulling from optimized url?