### PR TITLE
Set slack login redirect-uri to expo deep link when on mobile

### DIFF
--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -161,11 +161,12 @@
     (api/auth-with-email auth-link email pswd (partial login-with-email-finish email))
     (dis/dispatch! [:login-with-email])))
 
-(defn login-with-slack [auth-url]
+(defn login-with-slack [auth-url & [state-map]]
   (let [auth-url-with-redirect (user-utils/auth-link-with-state
-                                 (:href auth-url)
-                                 {:team-id "open-company-auth"
-                                  :redirect oc-urls/slack-lander-check})]
+                                (:href auth-url)
+                                (or state-map
+                                    {:team-id "open-company-auth"
+                                     :redirect oc-urls/slack-lander-check}))]
     (router/redirect! auth-url-with-redirect)
     (dis/dispatch! [:login-with-slack])))
 

--- a/src/oc/web/actions/user.cljs
+++ b/src/oc/web/actions/user.cljs
@@ -164,9 +164,9 @@
 (defn login-with-slack [auth-url & [state-map]]
   (let [auth-url-with-redirect (user-utils/auth-link-with-state
                                 (:href auth-url)
-                                (or state-map
-                                    {:team-id "open-company-auth"
-                                     :redirect oc-urls/slack-lander-check}))]
+                                (merge {:team-id "open-company-auth"
+                                        :redirect oc-urls/slack-lander-check}
+                                       state-map))]
     (router/redirect! auth-url-with-redirect)
     (dis/dispatch! [:login-with-slack])))
 

--- a/src/oc/web/components/ui/login_wall.cljs
+++ b/src/oc/web/components/ui/login_wall.cljs
@@ -62,7 +62,9 @@
                              (when-let [auth-link (utils/link-for (:links auth-settings) "authenticate" "GET"
                                                    {:auth-source "slack"})]
                                (user-actions/maybe-save-login-redirect)
-                               (user-actions/login-with-slack auth-link)))}
+                               (user-actions/login-with-slack auth-link
+                                                              (when ua/mobile-app?
+                                                                {:redirect-origin (expo/get-deep-link-origin)}))))}
                 [:div.signup-with-slack-content
                   [:div.slack-icon
                     {:aria-label "slack"}]

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -72,7 +72,9 @@
                        (.preventDefault %)
                        (when-let [auth-link (utils/link-for (:links auth-settings) "authenticate" "GET"
                                              {:auth-source "slack"})]
-                         (user-actions/login-with-slack auth-link)))}
+                         (user-actions/login-with-slack auth-link
+                                                        (when ua/mobile-app?
+                                                          {:redirect-origin (expo/get-deep-link-origin)}))))}
           "Continue with Slack"
           [:div.slack-icon
             {:aria-label "slack"}]]


### PR DESCRIPTION
Trello: https://trello.com/c/pBS3Fs5W/2257-fix-for-slack-redirect-issue

Related PR: https://github.com/open-company/open-company-mobile/pull/6

To test:
- On mobile staging, try logging in with Slack
- [x] Did you get pushed out to the native browser?
- [x] Are you properly redirected back to the app upon authentication?

Regression:
- [x] Does google login still work as expected on mobile?
- [x] Does email/pass login still work as expected on mobile? 