### PR TITLE
Fix signup and invite style on mobile

### DIFF
--- a/scss/partials/_onboard_wrapper.scss
+++ b/scss/partials/_onboard_wrapper.scss
@@ -165,6 +165,10 @@ div.onboard-email-container {
 div.onboard-lander {
   text-align: center;
 
+  @include mobile() {
+    padding: 104px 16px 24px;
+  }
+
   div.main-cta {
     @include mobile() {
       padding-top: 54px;
@@ -880,10 +884,6 @@ div.onboard-lander {
   }
 
   @include mobile() {
-    &.lander {
-      padding: 104px 16px 24px;
-    }
-
     div.main-cta {
       padding-top: 0;
       div.mobile-header {

--- a/scss/partials/_onboard_wrapper.scss
+++ b/scss/partials/_onboard_wrapper.scss
@@ -603,14 +603,29 @@ div.onboard-lander {
 
       &.left-half-field-label, &.right-half-field-label {
         width: calc(50% - 8px);
+
+        @include mobile() {
+          width: 100%;
+        }
       }
 
       &.left-half-field-label {
         float: left;
+
+        @include mobile() {
+          float: unset;
+        }
       }
 
       &.right-half-field-label {
         float: right;
+
+        @include mobile() {
+          &.field-label.name-fields {
+            float: unset;
+            margin-top: 24px;
+          }
+        }
       }
 
       &.email-domain-field-label {
@@ -700,14 +715,26 @@ div.onboard-lander {
 
       &.right-half-field, &.left-half-field {
         width: calc(50% - 8px);
+
+        @include mobile() {
+          width: 100%;
+        }
       }
 
       &.left-half-field {
         float: left;
+
+        @include mobile() {
+          float: unset;
+        }
       }
 
       &.right-half-field {
         float: right;
+
+        @include mobile() {
+          float: unset;
+        }
       }
     }
 
@@ -855,38 +882,41 @@ div.onboard-lander {
   @include mobile() {
     &.lander {
       padding: 104px 16px 24px;
+    }
 
-      div.main-cta {
+    div.main-cta {
+      padding-top: 0;
+      div.mobile-header {
+        height: 104px;
+        border-bottom: none;
+        position: absolute;
+
+        div.mobile-logo {
+          width: 36px;
+          height: 64px;
+          background-size: 36px 64px;
+          position: relative;
+          top: unset;
+          left: unset;
+          margin: 40px auto 0;
+        }
+      }
+
+      div.title {
         padding-top: 0;
-        div.mobile-header {
-          height: 104px;
-          border-bottom: none;
-          position: absolute;
-
-          div.mobile-logo {
-            width: 36px;
-            height: 64px;
-            background-size: 36px 64px;
-            position: relative;
-            top: unset;
-            left: unset;
-            margin: 40px auto 0;
-          } 
-        }
-
-        div.title {
-          padding-top: 0;
-          margin-top: 16px;
-          @include OC_Body_Bold();
-          font-size: 32px;
-          line-height: 41px;
-          color: $deep_navy;
-        }
+        margin-top: 16px;
+        @include OC_Body_Bold();
+        font-size: 32px;
+        line-height: 41px;
+        color: $deep_navy;
       }
     }
   }
 
   &.lander-profile {
+    @include mobile() {
+      padding: 104px 16px 24px;
+    }
     div.mobile-header {
       button.top-continue {
         color: $sea_blue;

--- a/scss/partials/_onboard_wrapper.scss
+++ b/scss/partials/_onboard_wrapper.scss
@@ -170,9 +170,6 @@ div.onboard-lander {
   }
 
   div.main-cta {
-    @include mobile() {
-      padding-top: 54px;
-    }
 
     div.mobile-header {
       display: none;
@@ -885,7 +882,6 @@ div.onboard-lander {
 
   @include mobile() {
     div.main-cta {
-      padding-top: 0;
       div.mobile-header {
         height: 104px;
         border-bottom: none;
@@ -913,10 +909,13 @@ div.onboard-lander {
     }
   }
 
-  &.lander-profile {
+  &.lander {
     @include mobile() {
-      padding: 104px 16px 24px;
+      padding: 0 0 24px;
     }
+  }
+
+  &.lander-profile {
     div.mobile-header {
       button.top-continue {
         color: $sea_blue;

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -711,9 +711,10 @@
   (let [confirm-invitation (drv/react s :confirm-invitation)]
     [:div.onboard-lander.invitee-lander
       [:div.main-cta
+        [:div.mobile-header.mobile-only
+          [:div.mobile-logo]]
         [:div.title
           "Join your team on Carrot"]
-        [:div.mobile-logo.mobile-only]
         (if (:invitation-error confirm-invitation)
           [:div.subtitle
             "An error occurred while confirming your invitation, please try again."]

--- a/src/oc/web/components/ui/onboard_wrapper.cljs
+++ b/src/oc/web/components/ui/onboard_wrapper.cljs
@@ -290,6 +290,7 @@
                        (let [org-name (clean-org-name (:name org-editing))]
                          (dis/dispatch! [:input [:org-editing :name] org-name])))]
     [:div.onboard-lander.lander-profile
+      {:class "ayo"}
       [:div.main-cta
         [:div.mobile-header.mobile-only
           [:div.mobile-logo]
@@ -311,7 +312,7 @@
           [:div.group
             [:div.field-label.left-half-field-label.name-fields
               "First name"]
-            [:div.field-label.right-half-field-label.name-fields
+            [:div.field-label.right-half-field-label.name-fields.big-web-tablet-only
               "Last name"]]
           [:div.group
             [:input.field.left-half-field.oc-input
@@ -322,6 +323,8 @@
                :max-length user-utils/user-name-max-lenth
                :value (or (:first-name user-data) "")
                :on-change #(dis/dispatch! [:input [:edit-user-profile :first-name] (.. % -target -value)])}]
+            [:div.field-label.right-half-field-label.name-fields.mobile-only
+              "Last name"]
             [:input.field.right-half-field.oc-input
               {:class utils/hide-class
                :type "text"


### PR DESCRIPTION
To test:
- signup from mobile
- [x] style of /sign-up looks good?
- [x] style of /sign-up/profile looks good?
- now invite a new user via email (an email that is not in the system already)
- use the invite link in a new window
- [ ] style of the invite page looks good?
- [x] style of the collect password page looks good?
- [x] style of the collect first/last name page looks good?
- [x] now repeat on desktop both to make sure they didn't regress