### PR TITLE
Fix org switch

### DIFF
--- a/src/oc/web/components/ui/org_avatar.cljs
+++ b/src/oc/web/components/ui/org_avatar.cljs
@@ -3,11 +3,7 @@
             [org.martinklepsch.derivatives :as drv]
             [oc.web.urls :as oc-urls]
             [oc.web.images :as img]
-            [oc.web.router :as router]
-            [oc.web.dispatcher :as dis]
-            [oc.web.lib.utils :as utils]
-            [oc.web.actions.user :as user-actions]
-            [oc.web.actions.routing :as routing-actions]))
+            [oc.web.lib.utils :as utils]))
 
 (def default-max-logo-height 96) ;; 32 * 3 for retina
 
@@ -59,15 +55,6 @@
                             (oc-urls/all-posts org-slug))]
           (if should-show-link
             [:a.org-link
-              {:href avatar-link
-               :on-click (fn [e]
-                           (.preventDefault e)
-                           (when should-show-link
-                             (let [current-path (str (.. js/window -location -pathname) (.. js/window -location -search))]
-                              (if (= current-path avatar-link)
-                                (do
-                                  (routing-actions/routing @router/path)
-                                  (user-actions/initial-loading true))
-                                (router/nav! avatar-link)))))}
+              {:href avatar-link}
               (internal-org-avatar s org-data show-org-avatar? show-org-name?)]
             (internal-org-avatar s org-data show-org-avatar? show-org-name?))))]))


### PR DESCRIPTION
Card: https://trello.com/c/43InZpBB

Bug: not sure how to replicate but on our call Stuart was able to switch org w/o actually reloading the app. It was using an internal navigation.
This change should make sure that never happen since it's causing some issues when receiving notification for one or the other (probably because we don't stop and restart the WS connections).

To test:
- go to Carrot AP on staging
- open Dev tools on Network tab
- make sure Preserve log is unchecked
- click on Joy restaurant
- [x] make sure all the old network requests are cleaned out
- [x] make sure the first request is a GET to /the-carrot-stand/all-posts
- [x] repeat for another org