### PR TITLE
Fix the comment mobile menu.

### DIFF
--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -231,18 +231,19 @@
                     (when-not is-editing?
                       (if (responsive/is-tablet-or-mobile?)
                         [:div.stream-comment-mobile-menu
-                          (more-menu comment-data nil {:external-share false
-                                                       :entity-type "comment"
-                                                       :show-edit? true
-                                                       :edit-cb (partial start-editing s)
-                                                       :show-delete? true
-                                                       :delete-cb (partial delete-clicked s activity-data)
-                                                       :can-comment-share? true
-                                                       :comment-share-cb #(share-clicked comment-data)
-                                                       :can-react? true
-                                                       :react-cb #(reset! (::show-picker s) (:uuid comment-data))
-                                                       :can-reply? true
-                                                       :reply-cb #(reply-to s (:reply-parent comment-data))})
+                          (more-menu {:entity-data comment-data
+                                      :external-share false
+                                      :entity-type "comment"
+                                      :show-edit? true
+                                      :edit-cb (partial start-editing s)
+                                      :show-delete? true
+                                      :delete-cb (partial delete-clicked s activity-data)
+                                      :can-comment-share? true
+                                      :comment-share-cb #(share-clicked comment-data)
+                                      :can-react? true
+                                      :react-cb #(reset! (::show-picker s) (:uuid comment-data))
+                                      :can-reply? true
+                                      :reply-cb #(reply-to s (:reply-parent comment-data))})
                           (when showing-picker?
                             (emoji-picker-container s comment-data))]
                         [:div.stream-comment-floating-buttons


### PR DESCRIPTION
Bug: right now the ellipses menu besides each comment on mobile is broken.

To test:
- expand a post on mobile
- [ ] do you see ellipses menu on comments from other users?
- [ ] does it NOT have edit/delete buttons?
- [ ] other buttons work?
- [ ] do you see ellipses menu on comments from your user?
- [ ] does it have edit/delete buttons?
- [ ] other buttons work?