### PR TITLE
Fix save to new board

### DIFF
--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -401,6 +401,8 @@
                       (reset! (::initial-uuid s) (:uuid cmail-data))
                       (reset! (::abstract-length s) (count abstract-text))
                       (reset! (::abstract-exceeds-limit s) abstract-exceeds)
+                      (reset! (::saving s) (:loading cmail-data))
+                      (reset! (::publishing s) (:publishing cmail-data))
                       (reset! (::post-button-title s)
                         (cond
                           abstract-exceeds :abstract
@@ -459,7 +461,7 @@
                     s)
                    :before-render (fn [s]
                     ;; Handle saving/publishing states to dismiss the component
-                    (let [cmail-data @(drv/get-ref s :cmail-data)]
+                    (when-let [cmail-data @(drv/get-ref s :cmail-data)]
                       ;; Did activity get removed in another client?
                       (when (and @(::deleting s)
                                  (:delete cmail-data))


### PR DESCRIPTION
Bug: edit a published post, change board, click Save. Since the url has changed the cmail component is being unmounted and mounted again, with this action we lose the local flag saved in `::saving` that means we need to close the cmail component if saving succeed.

To test:
- on desktop
- expand a post
- edit post
- change board
- save
- [x] cmail dismissed?
- [x] url has changed to the new board slug?
- [x] repeat on mobile

Regression test:
- on desktop
- expand a post
- change the headline or body
- save
- [x] cmail dismissed?
- [x] url didn't change?
- [x] repeat on mobile
- [x] repeat on desktop from AP/FU/section
- on desktop
- go to AP
- expand QP
- add title and body
- wait autosave
- [x] publish
- refresh AP
- click New post
- enter headline and abstract
- wait autosave
- change board
- wait autosave
- publish
- [x] did it work?
- [x] cmail was dismissed?
- [x] post appear in feed?
