### PR TITLE
Hide thumbnails from mobile FoC

### DIFF
--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -322,6 +322,8 @@ div.stream-item {
         @include mobile() {
           width: 95px;
           top: 0;
+          // Remove thumbnails from mobile for now
+          display: none;
 
           img.body-thumbnail {
             max-height: 72px;
@@ -362,19 +364,13 @@ div.stream-item {
         min-height: 80px;
 
         @include mobile() {
-          width: calc(100% - 106px - 16px);
+          width: 100%;
         }
       }
 
       @include tablet() {
         width: 100%;
         margin: 0;
-      }
-
-      &.has-thumbnail {
-        @include tablet() {
-          width: calc(100% - 106px - 16px);
-        }
       }
 
       &.has-video {


### PR DESCRIPTION
Card: https://trello.com/c/nwg6rvxo

To test:
- add a few posts, some with an image, other with a video etc..
- [ ] check that you see the thumbnail on desktop
- [ ] check that you don't see the thumbnails on mobile
- check that everything is ok in expanded post page