### PR TITLE
Fix invite rows

### DIFF
--- a/src/oc/web/components/invite_settings_modal.cljs
+++ b/src/oc/web/components/invite_settings_modal.cljs
@@ -144,7 +144,10 @@
                                                                            :primary-bt-inline true
                                                                            :id :invites-sent}))
                                 (reset! (::send-bt-cta s) "Send"))))))))
-                  s)}
+                  s)
+    :did-update (fn [s]
+                 (setup-initial-rows s)
+                 s)}
   [s]
   (let [org-data (drv/react s :org-data)
         invite-users-data (drv/react s :invite-data)


### PR DESCRIPTION
Card: https://trello.com/c/CvUeAvJR

To test:
- go to Invite panel
- add a few invites (email or Slack, doesn't matter)
- send the invites
- [ ] when the invites are sent do you see the invites being cleared out?
- [ ] when the notification appear do you see an empty line being reset in the panel?