### PR TITLE
Fix time format

### DIFF
--- a/src/oc/web/lib/utils.cljs
+++ b/src/oc/web/lib/utils.cljs
@@ -139,10 +139,12 @@
     (if (and (= (.getFullYear past-js-date) (.getFullYear now-date))
              (= (.getMonth past-js-date) (.getMonth now-date))
              (= (.getDate past-js-date) (.getDate now-date)))
-      (s/lower
-       (.toLocaleTimeString past-js-date (.. js/window -navigator -language) #js {:hour "2-digit"
-                                                                                  :minute "2-digit"
-                                                                                  :format "hour:minute"}))
+      (s/upper
+       (.replace
+        (.toLocaleTimeString past-js-date (.. js/window -navigator -language) #js {:hour "2-digit"
+                                                                                   :minute "2-digit"
+                                                                                   :format "hour:minute"})
+        (js/RegExp. "^0(?:0:0?)?" "ig") ""))
       (time-since past-date (concat flags [:short])))))
 
 (defn class-set


### PR DESCRIPTION
Card: https://trello.com/c/kQeLIQIf

To test:
- add a new post
- [ ] check in FoC that you see the publish time and not a relative time (1:12 AM instead of 2h)
- [ ] make sure you don't see a leading zero before in the hour
- [ ] make sure AM/PM are uppercase
- [ ] from REPL make sure that `oc.web.lib.utils/foc-date-time` return the time without the initial zero for today's hours with a single digit and that 2 digits are returned for 11 and 12
- [ ] also make sure AM/PM are always upper case