### PR TITLE
Missing link on get-board error

### DIFF
--- a/src/oc/web/actions/section.cljs
+++ b/src/oc/web/actions/section.cljs
@@ -196,18 +196,6 @@
           (utils/after 0 #(router/nav! redirect-url))
           (dispatcher/dispatch! [:private-section-kick-out-self/finish success])))))))
 
-(defn ws-comment-add
-  [interaction-data]
-  (let [org-slug   (router/current-org-slug)
-        board-slug (router/current-board-slug)
-        activity-uuid (:resource-uuid interaction-data)
-        entry-data (dispatcher/activity-data org-slug activity-uuid)]
-    (when-not entry-data
-      (let [board-data (dispatcher/board-data)
-            sort-type (router/current-sort-type)
-            link-rel (if (= sort-type :recent-activity) "activity" ["item" "self"])]
-        (section-get sort-type (utils/link-for (:links board-data) link-rel "GET"))))))
-
 (defn ws-change-subscribe []
   (ws-cc/subscribe :container/status
     (fn [data]
@@ -249,10 +237,6 @@
         (when (= change-type :move)
           (dispatcher/dispatch! [:item-move (router/current-org-slug) change-data])
           (section-change section-uuid))))))
-
-(defn ws-interaction-subscribe []
-  (ws-ic/subscribe :interaction-comment/add
-                   #(ws-comment-add (:data %))))
 
 ;; Section editing
 

--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -636,7 +636,6 @@
   ;; Subscribe to websocket client events
   (aa/ws-change-subscribe)
   (sa/ws-change-subscribe)
-  (sa/ws-interaction-subscribe)
   (oa/subscribe)
   (ra/subscribe)
   (ca/subscribe)


### PR DESCRIPTION
Bug:
- to open AP with user A
- open Board 1 with user B
- comment on a post of Board 1 with user B
- :boom: user A sees the error

To test:
- [x] test the above on mainline scenario and make sure you see an error in the console and the red banner is shown
- switch to this
- repeat the above steps
- [x] no errors? every good?
- click on the notification and open the entry
- [x] can you see the entry?
- now comment on an entry that user A is seeing in AP
- [x] FoC updates as expected?

Labeling this as urgent but except showing the red banner it's not causing any other issue in the client.