### PR TITLE
Comment box in-active state

### DIFF
--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -683,6 +683,7 @@ $h2_top_margin: 24;
     font-style: normal;
     font-size: $font-size;
     line-height: $line-height;
+    cursor: text;
   }
 
   img, a > img {

--- a/scss/partials/_add_comment.scss
+++ b/scss/partials/_add_comment.scss
@@ -2,6 +2,21 @@ div.add-comment-box-container {
   position: relative;
   width: 100%;
 
+  &.collapsed-box {
+    div.add-comment-box div.add-comment-internal {
+      height: 48px;
+      cursor: text;
+
+      div.add-comment:after {
+        cursor: text;
+      }
+
+      div.add-comment-footer {
+        display: none;
+      }
+    }
+  }
+
   @include tablet() {
     padding: 0;
     width: 100%;
@@ -16,7 +31,7 @@ div.add-comment-box-container {
       position: relative;
       border-radius: 4px;
       border: 1px solid $mid_light_grey;
-      padding: 16px;
+      padding: 13px 16px;
       background-color: white;;
 
       &.active {
@@ -104,10 +119,6 @@ div.add-comment-box-container {
 
           &:hover {
             background-color: rgba($deep_navy, 0.2);
-          }
-
-          @include mobile() {
-            display: none;
           }
         }
 

--- a/scss/partials/_add_comment.scss
+++ b/scss/partials/_add_comment.scss
@@ -6,9 +6,10 @@ div.add-comment-box-container {
     div.add-comment-box div.add-comment-internal {
       height: 48px;
       cursor: text;
+      padding: 12px 16px;
 
-      div.add-comment:after {
-        cursor: text;
+      @include mobile() {
+        padding: 11px 14px;
       }
 
       div.add-comment-footer {
@@ -32,7 +33,7 @@ div.add-comment-box-container {
       border-radius: 4px;
       border: 1px solid $mid_light_grey;
       padding: 13px 16px;
-      background-color: white;;
+      background-color: white;
 
       &.active {
         box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.07);
@@ -50,7 +51,7 @@ div.add-comment-box-container {
         left: unset;
         position: relative;
         bottom: unset;
-        padding: 9px 14px;
+        padding: 11px 14px;
         margin-left: 0;
       }
 

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -193,7 +193,8 @@
                                      ;; for the reply to comments
                                      (not parent-comment-uuid)
                                      (not @(::show-post-button s))
-                                     (not is-focused?))
+                                     (not is-focused?)
+                                     (not (seq @(::initial-add-comment s))))
         is-mobile? (responsive/is-mobile-size?)
         attachment-uploading (drv/react s :attachment-uploading)
         uploading? (and attachment-uploading

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -200,7 +200,8 @@
                         (= (:comment-parent-uuid attachment-uploading) parent-comment-uuid))
         add-comment-class (str "add-comment-" @(::add-comment-id s))]
     [:div.add-comment-box-container
-      {:class container-class}
+      {:class (utils/class-set {container-class true
+                                :collapsed-box should-hide-post-button})}
       [:div.add-comment-box
         [:div.add-comment-internal
           {:class (when-not should-hide-post-button "active")}
@@ -208,6 +209,7 @@
            {:ref "editor-node"
             :class (utils/class-set {add-comment-class true
                                      :medium-editor-placeholder-hidden @(::did-change s)
+                                     :medium-editor-placeholder (not @(::did-change s))
                                      utils/hide-class true})
             :on-focus #(focus-add-comment s)
             :on-blur #(disable-add-comment-if-needed s)
@@ -226,9 +228,16 @@
             :content-editable true
             :dangerouslySetInnerHTML #js {"__html" @(::initial-add-comment s)}}]
           [:div.add-comment-footer.group
-            (when (fn? dismiss-reply-cb)
-              [:button.mlb-reset.close-reply-bt
-                {:on-click (fn [_]
+            [:button.mlb-reset.close-reply-bt
+              {:on-click (fn [_]
+                          (let [dismiss-fn (if (fn? dismiss-reply-cb)
+                                             #(dismiss-reply-cb true)
+                                             (fn []
+                                                (set! (.-innerHTML (rum/ref-node s "editor-node")) @(::initial-add-comment s))
+                                                (disable-add-comment-if-needed s)
+                                                (reset! (::did-change s) false)
+                                                (reset! (::show-post-button s) false)
+                                                (comment-actions/add-comment-change activity-data parent-comment-uuid (:uuid edit-comment-data) "")))]
                             (if @(::did-change s)
                               (let [alert-data {:icon "/img/ML/trash.svg"
                                                 :action "cancel-comment-edit"
@@ -238,14 +247,14 @@
                                                 :solid-button-style :red
                                                 :solid-button-title "Yes"
                                                 :solid-button-cb (fn []
-                                                                  (dismiss-reply-cb true)
+                                                                  (dismiss-fn)
                                                                   (alert-modal/hide-alert))}]
                                 (alert-modal/show-alert alert-data))
-                              (dismiss-reply-cb true)))
-                 :data-toggle (if (responsive/is-tablet-or-mobile?) "" "tooltip")
-                 :data-placement "top"
-                 :data-container "body"
-                 :title (if edit-comment-data "Cancel edit" "Close")}])
+                              (dismiss-fn))))
+               :data-toggle (if (responsive/is-tablet-or-mobile?) "" "tooltip")
+               :data-placement "top"
+               :data-container "body"
+               :title (if edit-comment-data "Cancel edit" "Close")}]
             [:button.mlb-reset.send-btn
               {:on-click #(when-not @(::add-button-disabled s)
                             (send-clicked % s))


### PR DESCRIPTION
Card: https://trello.com/c/AAKr8QvE

To test:
- open staging on desktop
- click on a post
- comment field is collapsed?
- click on it
- now it's expanded?
- click out side
- is collapsed again
- click on it and add some text
- if you click outside it stays expanded?
- now click the X button
- does it ask for confirmation?
- click Yes
- comment box is collapsed again and placeholder is visible again?
- switch to mobile
- repeat the steps above