### PR TITLE
Add to Slack fix

### DIFF
--- a/src/oc/web/components/integrations_settings_modal.cljs
+++ b/src/oc/web/components/integrations_settings_modal.cljs
@@ -50,7 +50,7 @@
         [:div.integrations-settings-body
           (when (utils/link-for (:links team-data) "authenticate" "GET" {:auth-source "slack"})
             [:button.btn-reset.add-slack-team-bt
-              {:on-click #(team-actions/slack-team-add cur-user-data (str (router/get-token) "?org-settings=integrations"))}
+              {:on-click #(org-actions/bot-auth team-data cur-user-data (str (router/get-token) "?org-settings=integrations"))}
               [:div.slack-icon]
               "Add to Slack"])
           (when-not (zero? slack-teams-count)


### PR DESCRIPTION
Card: https://trello.com/c/gHTmpJir

To test:
- signup via email
- go to integrations
- click on Add to Slack
- grant permissions
- [x] do you see the bot already enabled when you land back to the integrations panel?
- now signup via Slack
- open Integrations panel
- click the button to add the bot
- [x] did it work?

@belucid assigned this to you since the testing is a bit delicate, code change is really small though