### PR TITLE
Mobile new comment label fix

### DIFF
--- a/scss/partials/_stream_comments.scss
+++ b/scss/partials/_stream_comments.scss
@@ -367,22 +367,6 @@ div.stream-comments {
           }
         }
 
-        div.stream-comment-author-right  {
-          float: left;
-          max-width: 80%;
-
-          @include preload_image(cdnUrl("/img/ML/comment_reply.svg"));
-
-          div.stream-comment-author-name {
-            @include OC_Body_Bold();
-            font-size: 14px;
-            color: $deep_navy;
-            line-height: 16px;
-            float: left;
-            @include preload_image(cdnUrl("/img/ML/comment_share.svg"));
-          }
-        }
-
         div.stream-comment-author-avatar {
           float: left;
           width: 32px;
@@ -402,9 +386,10 @@ div.stream-comments {
 
           @include preload_image(cdnUrl("/img/ML/comment_more.svg"));
 
-          div.stream-comment-author-right  {
+          div.stream-comment-author-right {
             float: left;
-            max-width: 80%;
+
+            @include preload_image(cdnUrl("/img/ML/comment_reply.svg"));
 
             div.stream-comment-author-name {
               @include OC_Body_Bold();
@@ -412,6 +397,43 @@ div.stream-comments {
               color: $deep_navy;
               line-height: 16px;
               float: left;
+              @include preload_image(cdnUrl("/img/ML/comment_share.svg"));
+            }
+
+            @include mobile() {
+              max-width: 80%;
+            }
+
+            div.stream-comment-author-right-group {
+              width: 100%;
+              float: left;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              align-items: flex-start;
+
+              &.new-comment {
+                width: calc(100% - 50px);
+              }
+
+              div.stream-comment-author-name {
+                flex: 1 1 1;
+              }
+
+              div.stream-comment-author-timestamp {
+                flex: 0 0 1;
+              }
+            }
+
+            div.stream-comment-author-name {
+              @include OC_Body_Bold();
+              font-size: 14px;
+              color: $deep_navy;
+              line-height: 16px;
+              float: left;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
             }
 
             div.stream-comment-author-timestamp {

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -202,7 +202,10 @@
                                                  (not (:is-emoji comment-data)))
                       can-show-delete-bt? (:can-delete comment-data)
                       showing-picker? (and (seq @(::show-picker s))
-                                           (= @(::show-picker s) (:uuid comment-data)))]]
+                                           (= @(::show-picker s) (:uuid comment-data)))
+                      new-comment? (and (not= (-> comment-data :author :user-id) current-user-id)
+                                        (< (.getTime (utils/js-date last-read-at))
+                                           (.getTime (utils/js-date (:created-at comment-data)))))]]
             (if is-editing?
               [:div.stream-comment-outer
                 {:key (str "stream-comment-" (:created-at comment-data))
@@ -265,13 +268,13 @@
                       [:div.stream-comment-header.group
                         {:class utils/hide-class}
                         [:div.stream-comment-author-right
-                          [:div.stream-comment-author-name
-                            (:name (:author comment-data))]
-                          [:div.stream-comment-author-timestamp
-                            (utils/foc-date-time (:created-at comment-data))]
-                          (when (and (not= (-> comment-data :author :user-id) current-user-id)
-                                     (< (.getTime (utils/js-date last-read-at))
-                                        (.getTime (utils/js-date (:created-at comment-data)))))
+                          [:div.stream-comment-author-right-group
+                            {:class (when new-comment? "new-comment")}
+                            [:div.stream-comment-author-name
+                              (:name (:author comment-data))]
+                            [:div.stream-comment-author-timestamp
+                              (utils/foc-date-time (:created-at comment-data))]]
+                          (when new-comment?
                             [:div.new-comment-tag "(NEW)"])
                           (when-not is-editing?
                             (if (responsive/is-mobile-size?)


### PR DESCRIPTION
Card: https://trello.com/c/W3cCNPaC

To test:
- change your user name to a very long name
- with another user add a few comments to a post
- open the post on mobile
- do you see the user name truncated so the timestamp and NEW can fit on a single line?
- repeat on desktop