### PR TITLE
Stream closing icon tweaks

### DIFF
--- a/scss/partials/_paginated_stream.scss
+++ b/scss/partials/_paginated_stream.scss
@@ -31,33 +31,28 @@ div.paginated-stream {
       }
     }
 
+    div.carrot-close {
+      text-align: center;
+      height: 60px;
+      background-image: cdnUrl("/img/ML/closing_carrot.svg");
+      background-size: 14px 24px;
+      background-position: center;
+      background-repeat: no-repeat;
+      opacity: 0.2;
+
+      @include dark_mode() {
+        background-image: cdnUrl("/img/ML/closing_carrot@dark.svg");
+      }
+    }
+
     div.paginated-stream-cards-inner {
       position: relative;
       overflow: visible !important;
-      padding-bottom: 48px;
+      padding-bottom: 24px;
 
       .ReactVirtualized__Grid.ReactVirtualized__List,
       .ReactVirtualized__Grid.ReactVirtualized__List .ReactVirtualized__Grid__innerScrollContainer {
         overflow: visible !important;
-      }
-
-      &.closing-carrot:after {
-        content: "";
-        background-image: cdnUrl("/img/ML/closing_carrot.svg");
-        background-size: 14px 24px;
-        background-position: center;
-        background-repeat: no-repeat;
-        width: 100%;
-        height: 24px;
-        margin-top: 24px;
-        opacity: 0.2;
-        position: absolute;
-        bottom: 0;
-        left: 0;
-
-        @include dark_mode() {
-          background-image: cdnUrl("/img/ML/closing_carrot@dark.svg");
-        }
       }
 
       div.activities-overlay {

--- a/src/oc/web/components/paginated_stream.cljs
+++ b/src/oc/web/components/paginated_stream.cljs
@@ -119,11 +119,17 @@
     {:style style}
     "Loading more posts..."])
 
+(rum/defc carrot-close < rum/static
+  [{:keys [style]}]
+  [:div.carrot-close
+    {:style style}])
+
 (rum/defc virtualized-stream < rum/static
   [{:keys [items
            activities-read
            foc-layout
-           show-loading-more]
+           show-loading-more
+           show-carrot-close]
     :as derivatives}
    virtualized-props]
   (let [{:keys [height
@@ -141,19 +147,27 @@
                                      style] :as row-props} (js->clj row-props :keywordize-keys true)
                              loading-more? (and show-loading-more
                                                 (= index (count items)))
-                             entry (when-not loading-more? (nth items index))
-                             reads-data (get activities-read (:uuid entry))]
-                         (if loading-more?
-                           (rum/with-key
-                             (load-more row-props)
-                             key)
+                             carrot-close? (and show-carrot-close
+                                                (not loading-more?)
+                                                (= index (count items)))
+                             entry (when (and (not loading-more?)
+                                              (not carrot-close?))
+                                     (nth items index))
+                             reads-data (get activities-read (:uuid entry))
+                             row-key (str key-prefix "-" key)]
+                         (cond
+                          carrot-close?
+                           (rum/with-key (carrot-close row-props) row-key)
+                          loading-more?
+                           (rum/with-key (load-more row-props) row-key)
+                           :else
                            (rum/with-key
                             (wrapped-stream-item row-props (merge derivatives
                                                                  {:entry entry
                                                                   :reads-data reads-data
                                                                   :foc-layout foc-layout
                                                                   :is-mobile is-mobile?}))
-                            (str key-prefix "-" key)))))]
+                            row-key))))]
     [:div.virtualized-list-container
       {:ref registerChild
        :key (str "virtualized-list-" key-prefix)}
@@ -164,12 +178,20 @@
                                   720)
                          :isScrolling isScrolling
                          :onScroll onChildScroll
-                         :rowCount (if show-loading-more (inc (count items)) (count items))
+                         :rowCount (if (or show-loading-more
+                                           show-carrot-close)
+                                     (inc (count items))
+                                     (count items))
                          :rowHeight (fn [params]
                                       (let [{:keys [index]} (js->clj params :keywordize-keys true)]
-                                        (if (and show-loading-more
-                                                 (= index (count items)))
+                                        (cond
+                                          (and (= index (count items))
+                                               show-loading-more)
                                           (if is-mobile? 44 60)
+                                          (and (= index (count items))
+                                               show-carrot-close)
+                                          72
+                                          :else
                                           (calc-card-height is-mobile? foc-layout))))
                          :rowRenderer row-renderer
                          :scrollTop scrollTop
@@ -238,7 +260,6 @@
     [:div.paginated-stream.group
       [:div.paginated-stream-cards
         [:div.paginated-stream-cards-inner.group
-         {:class (when-not @(::has-next s) "closing-carrot")}
          (window-scroller
           {}
           (partial virtualized-stream {:org-data org-data
@@ -247,4 +268,6 @@
                                        :activities-read activities-read
                                        :editable-boards editable-boards
                                        :foc-layout foc-layout
-                                       :show-loading-more @(::bottom-loading s)}))]]]))
+                                       :show-loading-more @(::bottom-loading s)
+                                       :show-carrot-close (and (not @(::bottom-loading s))
+                                                               (> (count items) 10))}))]]]))

--- a/src/oc/web/components/paginated_stream.cljs
+++ b/src/oc/web/components/paginated_stream.cljs
@@ -270,4 +270,5 @@
                                        :foc-layout foc-layout
                                        :show-loading-more @(::bottom-loading s)
                                        :show-carrot-close (and (not @(::bottom-loading s))
+                                                               (not @(::has-next s))
                                                                (> (count items) 10))}))]]]))


### PR DESCRIPTION
From [feedback card](https://trello.com/c/W3zEkMYC):
> Only show the Carrot end of feed icon on page 2 and beyond

To test:
- check a stream/board with less than 10 posts
- do you NOT see the closing carrot?
- check a stream/board with exactly 10 posts
- do you NOT see the closing carrot?
- check a stream/board with more than 10 posts
- do you see loading more when you scroll?
- do you see the carrot icon at the bottom when you scroll?
- does the carrot icon looks good in light/dark both?
- make sure you never see the loading more and the carrot icon together