### PR TITLE
Reaction and comment tweaks

### DIFF
--- a/scss/partials/_reactions.scss
+++ b/scss/partials/_reactions.scss
@@ -19,7 +19,7 @@ div.reactions {
       @include OC_Body_Bold();
       box-shadow: none;
       font-size: 11px;
-      color: var(--light-color);
+      color: var(--color);
       min-width: 40px;
       border-radius: 4px;
       margin-left: 4px;
@@ -53,6 +53,7 @@ div.reactions {
         height: 15px;
         text-align: center;
         margin-left: -1px;
+        color: var(--light-color);
 
         @include mobile() {
           margin-top: 3px;

--- a/src/oc/web/components/reactions.cljs
+++ b/src/oc/web/components/reactions.cljs
@@ -22,17 +22,15 @@
                        (ui-mixins/on-window-click-mixin (fn [s e]
                         (when-not (utils/event-inside? e (rum/dom-node s))
                           (reset! (::show-picker s) false))))
-  [s {:keys [entity-data hide-last-reaction? optional-activity-data max-reactions]}]
+  [s {:keys [entity-data hide-picker optional-activity-data max-reactions]}]
   ;; optional-activity-data: is passed only when rendering the list of reactions for a comment
   ;; in that case entity-data is the comment-data. When optional-activity-data is nil it means
   ;; entity-data is the activity-data
   (let [reactions-max-count (or max-reactions default-reaction-number)
-        reactions-data (if hide-last-reaction?
-                         (vec (take (dec default-reaction-number) (:reactions entity-data)))
-                         (vec (:reactions entity-data)))
+        reactions-data (vec (take reactions-max-count (:reactions entity-data)))
         reactions-loading (:reactions-loading entity-data)
         react-link (utils/link-for (:links entity-data) "react")
-        should-show-picker? (and (not hide-last-reaction?)
+        should-show-picker? (and (not hide-picker)
                                  react-link
                                  (< (count reactions-data) reactions-max-count))
         is-mobile? (responsive/is-tablet-or-mobile?)]

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -356,7 +356,7 @@
                                  (seq (:reactions comment-data)))
                        [:div.stream-comment-reactions-footer.group
                           (reactions {:entity-data comment-data
-                                      :hide-last-reaction (zero? (count (:reactions comment-data)))
+                                      :hide-picker (zero? (count (:reactions comment-data)))
                                       :optional-activity-data activity-data})])]]]
               (when should-show-add-comment?
                 [:div.stream-comment

--- a/src/oc/web/stores/reaction.cljs
+++ b/src/oc/web/stores/reaction.cljs
@@ -231,15 +231,20 @@
           ra posts))
 
 (defmethod reducer :all-posts-get/finish
-  [db [_ {:keys [org year month from body]}]]
-  (swap! reactions-atom index-posts org (-> body :collection :items))
+  [db [_ org sort-type fixed-body]]
+  (swap! reactions-atom index-posts org (-> fixed-body :fixed-items vals))
+  db)
+
+(defmethod reducer :follow-ups-get/finish
+  [db [_ org sort-type fixed-body]]
+  (swap! reactions-atom index-posts org (-> fixed-body :fixed-items vals))
   db)
 
 (defmethod reducer :section
   [db [_ _sort-type board-data]]
   (let [org (utils/section-org-slug board-data)
         fixed-board-data (au/fix-board board-data (dispatcher/change-data db))]
-    (swap! reactions-atom index-posts org (vals (:fixed-items fixed-board-data))))
+    (swap! reactions-atom index-posts org (-> fixed-board-data :fixed-items vals)))
   db)
 
 (defmethod reducer :ws-interaction/comment-add


### PR DESCRIPTION
From [feedback card](https://trello.com/c/W3zEkMYC):
> Mobile: 2 new use same font size of the body and vertically center it
> Double check logic for mobile FoC: max 3 reactions, remove attch if there are reactions

To test:
- open mobile
- add a reaction on a post
- do you see the reaction clear? no opacity applied?
- with another user add a couple of comments on the post
- do you see the green chat icon with "2 new" besides it?
- font size is the same of the post body (17 pixels)?
- is it vertically centred?
- now add some reactions with another user
- do you see the reactions appearing live?