### PR TITLE
Viewers fix

### DIFF
--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -112,7 +112,7 @@
         should-show-settings-bt (and current-board-slug
                                      (not is-all-posts)
                                      (not is-follow-ups)
-                                     (not (:read-only board-data)))
+                                     (not (:read-only current-board-data)))
         cmail-state (drv/react s :cmail-state)
         _cmail-data (drv/react s :cmail-data)
         user-notifications-data (drv/react s :user-notifications)

--- a/src/oc/web/stores/org.cljs
+++ b/src/oc/web/stores/org.cljs
@@ -1,6 +1,7 @@
 (ns oc.web.stores.org
   (:require [oc.web.lib.utils :as utils]
             [taoensso.timbre :as timbre]
+            [oc.web.utils.activity :as activity-utils]
             [oc.web.dispatcher :as dispatcher]))
 
 (defn read-only-org
@@ -12,7 +13,11 @@
 (defn fix-org
   "Fix org data coming from the API."
   [org-data]
-  (read-only-org org-data))
+  (let [fixed-boards (mapv #(assoc % :read-only (-> % :links activity-utils/readonly-board?))
+                      (:boards org-data))]
+    (-> org-data
+     read-only-org
+     (assoc :boards fixed-boards))))
 
 (defmethod dispatcher/action :org-loaded
   [db [_ org-data saved? email-domain]]

--- a/src/oc/web/stores/section.cljs
+++ b/src/oc/web/stores/section.cljs
@@ -7,18 +7,6 @@
             [oc.web.lib.utils :as utils]
             [oc.web.utils.activity :as au]))
 
-;; Reducers used to watch for org/section dispatch data
-(defmulti reducer (fn [db [action-type & _]]
-                    (when-not (some #{action-type} [:update :input])
-                      (timbre/debug "Dispatching section reducer:" action-type))
-                    action-type))
-
-(def sections-dispatch
-  (flux/register
-   dispatcher/actions
-   (fn [payload]
-     (swap! dispatcher/app-state reducer payload))))
-
 (defmethod dispatcher/action :section
   [db [_ sort-type section-data]]
   (let [db-loading (if (:is-loaded section-data)
@@ -209,15 +197,6 @@
         change-key (dispatcher/change-data-key org-slug)
         old-change-data (get-in db change-key)]
     (assoc-in db change-key (update-unseen-unread-add old-change-data item-id container-id change-data))))
-
-;; Section store specific reducers
-(defmethod reducer :default [db payload]
-  ;; ignore state changes not specific to reactions
-  db)
-
-(defmethod reducer :org-loaded
-  [db [_ org-data saved?]]
-  (fix-org-section-data db org-data (dispatcher/change-data db)))
 
 (defmethod dispatcher/action :section-more
   [db [_ org-slug board-slug sort-type]]


### PR DESCRIPTION
Bug: when switching to a not yet loaded section, viewers see the section COG briefly.

To test:
- login as a viewer
- switch to a section
- do you never see the section COG? good