### PR TITLE
Change access roles in private section settings.

### DIFF
--- a/src/oc/web/components/ui/section_editor.cljs
+++ b/src/oc/web/components/ui/section_editor.cljs
@@ -387,7 +387,7 @@
               [:span.main-label
                 "Section members"]
               [:span.role-header
-                "Role"]])
+                "Access"]])
           (when (and (= (:access section-editing) "private")
                      (pos? (+ (count (:authors section-editing))
                               (count (:viewers section-editing)))))
@@ -401,8 +401,8 @@
                 [:div.section-editor-add-private-users-dropdown-container
                   {:style {:top (str (+ @(::show-edit-user-top s) -114) "px")
                            :display (if @(::show-edit-user-dropdown s) "block" "none")}}
-                  (dropdown-list {:items [{:value :viewer :label "Viewer"}
-                                          {:value :author :label "Contributor"}
+                  (dropdown-list {:items [{:value :viewer :label "View"}
+                                          {:value :author :label "Edit"}
                                           {:value :remove :label "Remove"}]
                                   :value user-type
                                   :on-change (fn [item]
@@ -469,13 +469,13 @@
                                    (alert-modal/hide-alert))})))}
                             "Leave section"]
                           [:div.user-type.no-dropdown
-                            "Contributor"])
+                            "Edit"])
                         [:div.user-type
                           {:class (utils/class-set {:no-dropdown (not can-change)
                                                     :active showing-dropdown})}
                           (if (= user-type :author)
-                            "Contributor"
-                            "Viewer")])]))]])
+                            "Edit"
+                            "View")])]))]])
           (when (= (:access section-editing) "private")
             [:div.section-editor-add-label
               "Personal note"])


### PR DESCRIPTION
Change access roles in the private section setting panel: Contributor -> Edit, Viewer -> View.

To test:
- add a new section
- change access to private
- do you see Access in the users list header?
- do you see Edit besides your name?
- add another user
- click on the user access (Edit)
- do you see View, Edit, Remove?
- select View
- do you see View now besides that user?
- save
- click the section COG
- still see the right access?