### PR TITLE
Preload main 4 containers

### DIFF
--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -93,8 +93,7 @@
           (let [sorted-boards (vec (sort-by :name boards))]
             (first sorted-boards)))))))
 
-(def other-resources-initial-delay 5000)
-(def other-resources-inter-delay 1000)
+(def other-resources-delay 1000)
 
 (defn org-loaded
   "Dispatch the org data into the app-state to be used by all the components.
@@ -121,20 +120,20 @@
         delay-count (atom 0)
         inbox-delay (if is-inbox?
                       0
-                      (+ other-resources-initial-delay
-                       (* other-resources-inter-delay (swap! delay-count inc))))
+                      (+ other-resources-delay
+                       (* other-resources-delay (swap! delay-count inc))))
         all-posts-delay (if is-all-posts?
                           0
-                          (+ other-resources-initial-delay
-                           (* other-resources-inter-delay (swap! delay-count inc))))
+                          (+ other-resources-delay
+                           (* other-resources-delay (swap! delay-count inc))))
         bookmarks-delay (if is-bookmarks?
                           0
-                          (+ other-resources-initial-delay
-                           (* other-resources-inter-delay (swap! delay-count inc))))
+                          (+ other-resources-delay
+                           (* other-resources-delay (swap! delay-count inc))))
         drafts-delay (if is-drafts?
                        0
-                       (+ other-resources-initial-delay
-                        (* other-resources-inter-delay (swap! delay-count inc))))]
+                       (+ other-resources-delay
+                        (* other-resources-delay (swap! delay-count inc))))]
     (when complete-refresh?
       ;; Load secure activity
       (if (router/current-secure-activity-id)

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -118,22 +118,10 @@
         is-bookmarks? (= (router/current-board-slug) "bookmarks")
         is-drafts? (= current-board-slug utils/default-drafts-board-slug)
         delay-count (atom 0)
-        inbox-delay (if is-inbox?
-                      0
-                      (+ other-resources-delay
-                       (* other-resources-delay (swap! delay-count inc))))
-        all-posts-delay (if is-all-posts?
-                          0
-                          (+ other-resources-delay
-                           (* other-resources-delay (swap! delay-count inc))))
-        bookmarks-delay (if is-bookmarks?
-                          0
-                          (+ other-resources-delay
-                           (* other-resources-delay (swap! delay-count inc))))
-        drafts-delay (if is-drafts?
-                       0
-                       (+ other-resources-delay
-                        (* other-resources-delay (swap! delay-count inc))))]
+        inbox-delay (if is-inbox? 0 (* other-resources-delay (swap! delay-count inc)))
+        all-posts-delay (if is-all-posts? 0 (* other-resources-delay (swap! delay-count inc)))
+        bookmarks-delay (if is-bookmarks? 0 (* other-resources-delay (swap! delay-count inc)))
+        drafts-delay (if is-drafts? 0 (* other-resources-delay (swap! delay-count inc)))]
     (when complete-refresh?
       ;; Load secure activity
       (if (router/current-secure-activity-id)

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -93,7 +93,8 @@
           (let [sorted-boards (vec (sort-by :name boards))]
             (first sorted-boards)))))))
 
-(def other-resources-delay 10000)
+(def other-resources-initial-delay 5000)
+(def other-resources-inter-delay 1000)
 
 (defn org-loaded
   "Dispatch the org data into the app-state to be used by all the components.
@@ -109,11 +110,31 @@
   (let [boards (:boards org-data)
         current-board-slug (router/current-board-slug)
         inbox-link (utils/link-for (:links org-data) "inbox")
-        activity-link (utils/link-for (:links org-data) "activity")
+        all-posts-link (utils/link-for (:links org-data) "activity")
         bookmarks-link (utils/link-for (:links org-data) "bookmarks-activity")
+        drafts-board (some #(when (= (:slug %) utils/default-drafts-board-slug) %) boards)
+        drafts-link (utils/link-for (:links drafts-board) ["self" "item"] "GET")
         is-inbox? (= current-board-slug "inbox")
         is-all-posts? (= current-board-slug "all-posts")
-        is-bookmarks? (= (router/current-board-slug) "bookmarks")]
+        is-bookmarks? (= (router/current-board-slug) "bookmarks")
+        is-drafts? (= current-board-slug utils/default-drafts-board-slug)
+        delay-count (atom 0)
+        inbox-delay (if is-inbox?
+                      0
+                      (+ other-resources-initial-delay
+                       (* other-resources-inter-delay (swap! delay-count inc))))
+        all-posts-delay (if is-all-posts?
+                          0
+                          (+ other-resources-initial-delay
+                           (* other-resources-inter-delay (swap! delay-count inc))))
+        bookmarks-delay (if is-bookmarks?
+                          0
+                          (+ other-resources-initial-delay
+                           (* other-resources-inter-delay (swap! delay-count inc))))
+        drafts-delay (if is-drafts?
+                       0
+                       (+ other-resources-initial-delay
+                        (* other-resources-inter-delay (swap! delay-count inc))))]
     (when complete-refresh?
       ;; Load secure activity
       (if (router/current-secure-activity-id)
@@ -123,24 +144,23 @@
           (when (router/current-activity-id)
             (cmail-actions/get-entry-with-uuid current-board-slug (router/current-activity-id)))
           ;; Load inbox data
-          (when (and inbox-link
-                     is-inbox?)
-            (aa/inbox-get org-data))
+          (when inbox-link
+            (utils/maybe-after inbox-delay #(aa/inbox-get org-data)))
           ;; Load all posts data
-          (when (and activity-link
-                     is-all-posts?)
-            (aa/activity-get org-data))
+          (when all-posts-link
+            (utils/maybe-after all-posts-delay #(aa/activity-get org-data)))
           ;; Preload bookmarks data
-          (when (and bookmarks-link
-                     is-bookmarks?)
-            (aa/bookmarks-get org-data)))))
+          (when bookmarks-link
+            (utils/maybe-after bookmarks-delay #(aa/bookmarks-get org-data)))
+          (when drafts-link
+            (utils/maybe-after drafts-delay #(sa/section-get drafts-link))))))
     (cond
       ;; If it's all posts page or must see, loads AP and must see for the current org
       (dis/is-container? current-board-slug)
       (when (or (and is-inbox?
                       (not inbox-link))
                  (and is-all-posts?
-                      (not activity-link))
+                      (not all-posts-link))
                  (and is-bookmarks?
                       (not bookmarks-link)))
         (check-org-404))
@@ -149,16 +169,17 @@
       current-board-slug
       (if-let [board-data (first (filter #(or (= (:slug %) current-board-slug)
                                               (= (:uuid %) current-board-slug)) boards))]
-        ; Load the board data since there is a link to the board in the org data
-        (do
+        ;; Load the board data except for drafts if there is a link in the boards list
+        ;; except for drafts which is preloaded with the rest
+        (when-not is-drafts?
           ;; Rewrite the URL in case it's using the board UUID instead of the slug
           (when (= (:uuid board-data) current-board-slug)
             (router/rewrite-board-uuid-as-slug current-board-slug (:slug board-data)))
-          (when-let* [board-rel (if (= current-board-slug utils/default-drafts-board-slug) ["item" "self"] "activity")
+          (when-let* [board-rel (if is-drafts? ["item" "self"] "activity")
                       board-link (utils/link-for (:links board-data) board-rel "GET")]
             (sa/section-get board-link)))
         ; The board wasn't found, showing a 404 page
-        (if (= current-board-slug utils/default-drafts-board-slug)
+        (if is-drafts?
           (utils/after 100 #(sa/section-get-finish utils/default-drafts-board))
           (when-not (router/current-activity-id) ;; user is not asking for a specific post
             (routing-actions/maybe-404))))


### PR DESCRIPTION
#### Review after #1093 

Re-add sections preload but only for Unread, All Posts, Bookmarks and Drafts.

To test:
- go to Unread
- do you see the post appear w/o any special delay?
- do you see AP, Bookmarks and Drafts being loaded with a small delay (5 seconds plus 1 seconds btw each other)
- go to AP
- do you see the post appear w/o any special delay?
- do you see Unread, Bookmarks and Drafts being loaded with a small delay (5 seconds plus 1 seconds btw each other)
- go to Bookmarks
- do you see the post appear w/o any special delay?
- do you see Unread, All Posts and Drafts being loaded with a small delay (5 seconds plus 1 seconds btw each other)
- go to Drafts
- do you see the post appear w/o any special delay?
- do you see Unread, All Posts and Drafts being loaded with a small delay (5 seconds plus 1 seconds btw each other)
- do you NOT see those sections being preloaded again when you do internal nav?
