### PR TITLE
Collapsed interstitial

### DIFF
--- a/resources/public/img/ML/interstitial.svg
+++ b/resources/public/img/ML/interstitial.svg
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="720px" height="177px" viewBox="0 0 720 177" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="720px" height="184px" viewBox="0 0 720 184" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
-    <title>Group 10</title>
+    <title>Rectangle 13 Copy 4</title>
     <desc>Created with Sketch.</desc>
     <g id="Ghost-states" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Ghost---FoC" transform="translate(-388.000000, -224.000000)">
+        <g id="Ghost---FoC" transform="translate(-388.000000, -199.000000)">
             <g id="Group-19" transform="translate(388.000000, 160.000000)">
-                <g id="Group-12" transform="translate(0.000000, 39.000000)">
+                <g id="Group-12" transform="translate(0.000000, 38.000000)">
                     <g id="Group-10">
-                        <g stroke-width="1">
-                            <g id="Group-18" transform="translate(30.000000, 25.000000)" fill="#ECECEC">
-                                <rect id="Rectangle-13-Copy-4" x="0" y="0" width="219" height="16" rx="4"></rect>
-                                <rect id="Rectangle-13-Copy-5" x="0" y="40" width="558" height="24" rx="4"></rect>
-                                <rect id="Rectangle-13-Copy-6" x="0" y="72" width="618" height="16" rx="4"></rect>
-                                <rect id="Rectangle-13-Copy-6" x="0" y="96" width="418" height="16" rx="4"></rect>
-                                <rect id="Rectangle-13-Copy-7" x="0" y="136" width="480" height="16" rx="4"></rect>
+                        <g id="Group-18" transform="translate(0.000000, 0.740113)">
+                            <g id="Rectangle-13-Copy-4">
+                                <rect fill="#ECECEC" x="30" y="23" width="219" height="14.5536723" rx="4"></rect>
+                                <rect id="Rectangle-13-Copy-5" fill="#ECECEC" x="30" y="59.3841808" width="558" height="21.8305085" rx="4"></rect>
+                                <rect id="Rectangle-13-Copy-6" fill="#ECECEC" x="30" y="88.4915254" width="618" height="14.5536723" rx="4"></rect>
+                                <rect id="Rectangle-13-Copy-6" fill="#ECECEC" x="30" y="110.322034" width="418" height="14.5536723" rx="4"></rect>
+                                <rect id="Rectangle-13-Copy-7" fill="#ECECEC" x="30" y="146.706215" width="480" height="14.5536723" rx="4"></rect>
+                                <polygon id="Mask-Copy-8" fill-opacity="0.01" fill="#34414F" points="0 0.259887006 720 0.259887006 720 1.16949153 0 1.16949153"></polygon>
+                                <polygon id="Mask-Copy-8" fill="#34414F" opacity="0.149999991" points="0 183.259887 720 183.259887 720 184.259887 0 184.259887"></polygon>
                             </g>
-                            <polygon id="Mask-Copy-8" fill-opacity="0" fill="#34414F" opacity="0.149999991" points="0 0 720 0 720 1 0 1"></polygon>
                         </g>
-                        <polygon id="Mask-Copy-8" fill="#34414F" opacity="0.149999991" points="0 201 720 201 720 202 0 202"></polygon>
                     </g>
                 </g>
             </g>

--- a/resources/public/img/ML/interstitial@dark.svg
+++ b/resources/public/img/ML/interstitial@dark.svg
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="720px" height="177px" viewBox="0 0 720 177" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="720px" height="184px" viewBox="0 0 720 184" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
-    <title>Group 10</title>
+    <title>Rectangle 13 Copy 4</title>
     <desc>Created with Sketch.</desc>
     <g id="Ghost-states" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Ghost---FoC" transform="translate(-388.000000, -224.000000)">
+        <g id="Ghost---FoC" transform="translate(-388.000000, -199.000000)">
             <g id="Group-19" transform="translate(388.000000, 160.000000)">
-                <g id="Group-12" transform="translate(0.000000, 39.000000)">
+                <g id="Group-12" transform="translate(0.000000, 38.000000)">
                     <g id="Group-10">
-                        <g stroke-width="1">
-                            <g id="Group-18" transform="translate(30.000000, 25.000000)" fill="#FFFFFF" fill-opacity="0.08">
-                                <rect id="Rectangle-13-Copy-4" x="0" y="0" width="219" height="16" rx="4"></rect>
-                                <rect id="Rectangle-13-Copy-5" x="0" y="40" width="558" height="24" rx="4"></rect>
-                                <rect id="Rectangle-13-Copy-6" x="0" y="72" width="618" height="16" rx="4"></rect>
-                                <rect id="Rectangle-13-Copy-6" x="0" y="96" width="418" height="16" rx="4"></rect>
-                                <rect id="Rectangle-13-Copy-7" x="0" y="136" width="480" height="16" rx="4"></rect>
+                        <g id="Group-18" transform="translate(0.000000, 0.740113)">
+                            <g id="Rectangle-13-Copy-4">
+                                <rect fill-opacity="0.08" fill="#FFFFFF" x="30" y="23" width="219" height="14.5536723" rx="4"></rect>
+                                <rect id="Rectangle-13-Copy-5" fill-opacity="0.08" fill="#FFFFFF" x="30" y="59.3841808" width="558" height="21.8305085" rx="4"></rect>
+                                <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" x="30" y="88.4915254" width="618" height="14.5536723" rx="4"></rect>
+                                <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" x="30" y="110.322034" width="418" height="14.5536723" rx="4"></rect>
+                                <rect id="Rectangle-13-Copy-7" fill-opacity="0.08" fill="#FFFFFF" x="30" y="146.706215" width="480" height="14.5536723" rx="4"></rect>
+                                <polygon id="Mask-Copy-8" fill-opacity="0.01" fill="#34414F" points="0 0.259887006 720 0.259887006 720 1.16949153 0 1.16949153"></polygon>
+                                <polygon id="Mask-Copy-8" fill-opacity="0.15" fill="#FFFFFF" points="0 183.259887 720 183.259887 720 184.259887 0 184.259887"></polygon>
                             </g>
-                            <polygon id="Mask-Copy-8" fill-opacity="0.01" fill="#34414F" opacity="0.149999991" points="0 0 720 0 720 1 0 1"></polygon>
                         </g>
-                        <polygon id="Mask-Copy-8" fill-opacity="0.16" fill="#FFFFFF" points="0 201 720 201 720 202 0 202"></polygon>
                     </g>
                 </g>
             </g>

--- a/resources/public/img/ML/interstitial@dark.svg
+++ b/resources/public/img/ML/interstitial@dark.svg
@@ -9,16 +9,16 @@
                 <g id="Group-12" transform="translate(0.000000, 39.000000)">
                     <g id="Group-10">
                         <g stroke-width="1">
-                            <g id="Group-18" transform="translate(30.000000, 25.000000)" fill="#ECECEC">
+                            <g id="Group-18" transform="translate(30.000000, 25.000000)" fill="#FFFFFF" fill-opacity="0.08">
                                 <rect id="Rectangle-13-Copy-4" x="0" y="0" width="219" height="16" rx="4"></rect>
                                 <rect id="Rectangle-13-Copy-5" x="0" y="40" width="558" height="24" rx="4"></rect>
                                 <rect id="Rectangle-13-Copy-6" x="0" y="72" width="618" height="16" rx="4"></rect>
                                 <rect id="Rectangle-13-Copy-6" x="0" y="96" width="418" height="16" rx="4"></rect>
                                 <rect id="Rectangle-13-Copy-7" x="0" y="136" width="480" height="16" rx="4"></rect>
                             </g>
-                            <polygon id="Mask-Copy-8" fill-opacity="0" fill="#34414F" opacity="0.149999991" points="0 0 720 0 720 1 0 1"></polygon>
+                            <polygon id="Mask-Copy-8" fill-opacity="0.01" fill="#34414F" opacity="0.149999991" points="0 0 720 0 720 1 0 1"></polygon>
                         </g>
-                        <polygon id="Mask-Copy-8" fill="#34414F" opacity="0.149999991" points="0 201 720 201 720 202 0 202"></polygon>
+                        <polygon id="Mask-Copy-8" fill-opacity="0.16" fill="#FFFFFF" points="0 201 720 201 720 202 0 202"></polygon>
                     </g>
                 </g>
             </g>

--- a/resources/public/img/ML/interstitial_collapsed.svg
+++ b/resources/public/img/ML/interstitial_collapsed.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="720px" height="94px" viewBox="0 0 720 94" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
+    <title>Mask Copy 8</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Ghost-states" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Ghost---List" transform="translate(-388.000000, -220.000000)">
+            <g id="Group-12" transform="translate(388.000000, 160.000000)">
+                <g id="Mask-Copy-8" transform="translate(0.000000, 39.000000)">
+                    <polygon fill-opacity="0.01" fill="#34414F" opacity="0.149999991" points="0 0 720 0 720 1 0 1"></polygon>
+                    <polygon fill="#34414F" opacity="0.149999991" points="0 57 720 57 720 58 0 58"></polygon>
+                    <polygon id="Mask-Copy-9" fill="#34414F" opacity="0.149999991" points="0 114 720 114 720 115 0 115"></polygon>
+                    <rect id="Rectangle-13-Copy-4" fill="#ECECEC" x="16" y="21" width="24" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-8" fill="#ECECEC" x="16" y="78" width="24" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-5" fill="#ECECEC" x="48" y="21" width="200" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-9" fill="#ECECEC" x="48" y="78" width="160" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-6" fill="#ECECEC" x="256" y="21" width="344" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-10" fill="#ECECEC" x="216" y="78" width="284" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-7" fill="#ECECEC" x="640" y="21" width="80" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-11" fill="#ECECEC" x="640" y="78" width="80" height="16" rx="4"></rect>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources/public/img/ML/interstitial_collapsed@dark.svg
+++ b/resources/public/img/ML/interstitial_collapsed@dark.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="720px" height="94px" viewBox="0 0 720 94" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
+    <title>Mask Copy 8</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Ghost-states" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Ghost---List" transform="translate(-388.000000, -220.000000)">
+            <g id="Group-12" transform="translate(388.000000, 160.000000)">
+                <g id="Mask-Copy-8" transform="translate(0.000000, 39.000000)">
+                    <polygon fill-opacity="0.01" fill="#34414F" opacity="0.149999991" points="0 0 720 0 720 1 0 1"></polygon>
+                    <polygon fill-opacity="0.16" fill="#FFFFFF" points="0 57 720 57 720 58 0 58"></polygon>
+                    <polygon id="Mask-Copy-9" fill-opacity="0.16" fill="#FFFFFF" points="0 114 720 114 720 115 0 115"></polygon>
+                    <rect id="Rectangle-13-Copy-4" fill-opacity="0.08" fill="#FFFFFF" x="16" y="21" width="24" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-8" fill-opacity="0.08" fill="#FFFFFF" x="16" y="78" width="24" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-5" fill-opacity="0.08" fill="#FFFFFF" x="48" y="21" width="200" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-9" fill-opacity="0.08" fill="#FFFFFF" x="48" y="78" width="160" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" x="256" y="21" width="344" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-10" fill-opacity="0.08" fill="#FFFFFF" x="216" y="78" width="284" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-7" fill-opacity="0.08" fill="#FFFFFF" x="640" y="21" width="80" height="16" rx="4"></rect>
+                    <rect id="Rectangle-13-Copy-11" fill-opacity="0.08" fill="#FFFFFF" x="640" y="78" width="80" height="16" rx="4"></rect>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources/public/img/ML/interstitial_mobile.svg
+++ b/resources/public/img/ML/interstitial_mobile.svg
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="375px" height="202px" viewBox="0 0 375 202" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="375px" height="201px" viewBox="0 0 375 201" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
-    <title>Group 2</title>
+    <title>Group-9</title>
     <desc>Created with Sketch.</desc>
-    <g id="Styles-&amp;-states" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Section-loading-state-(mobile)" transform="translate(0.000000, -173.000000)">
-            <g id="Group-2" transform="translate(0.000000, 173.000000)">
-                <polygon id="Background" fill="#EEEAE9" opacity="0.01" points="0 0 375 0 375 1 0 1"></polygon>
-                <g id="Group" transform="translate(0.000000, 25.000000)">
-                    <g id="Group-9" transform="translate(16.000000, 0.000000)" fill="#ECECEC">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="interstitial_mobile" transform="translate(0.000000, -1.000000)">
+            <g id="Group" transform="translate(0.000000, 1.000000)">
+                <g id="Group-9">
+                    <g stroke-width="1" fill-rule="evenodd" transform="translate(16.000000, 24.000000)" fill="#34414F" fill-opacity="0.15">
                         <rect id="Rectangle-13-Copy-4" x="0" y="0" width="219" height="16" rx="4"></rect>
                         <rect id="Rectangle-13-Copy-5" x="0" y="40" width="279" height="24" rx="4"></rect>
                         <rect id="Rectangle-13-Copy-6" x="0" y="72" width="325" height="16" rx="4"></rect>
                         <rect id="Rectangle-13-Copy-6" x="0" y="96" width="180" height="16" rx="4"></rect>
                         <rect id="Rectangle-13-Copy-7" x="0" y="136" width="240" height="16" rx="4"></rect>
                     </g>
-                    <polygon id="Background" fill="#EEEAE9" points="0 176 375 176 375 177 0 177"></polygon>
+                    <polygon id="Rectangle" fill-opacity="0.01" fill="#D8D8D8" fill-rule="nonzero" points="16 1.66533454e-16 375 0 375 24 16 24"></polygon>
+                    <polygon id="Background" fill-opacity="0.15" fill="#34414F" fill-rule="evenodd" points="0 200 375 200 375 201 0 201"></polygon>
                 </g>
             </g>
         </g>

--- a/resources/public/img/ML/interstitial_mobile.svg
+++ b/resources/public/img/ML/interstitial_mobile.svg
@@ -1,23 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="375px" height="201px" viewBox="0 0 375 201" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="375px" height="173px" viewBox="0 0 375 173" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
-    <title>Group-9</title>
+    <title>interstitial_mobile</title>
     <desc>Created with Sketch.</desc>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="interstitial_mobile" transform="translate(0.000000, -1.000000)">
-            <g id="Group" transform="translate(0.000000, 1.000000)">
-                <g id="Group-9">
-                    <g stroke-width="1" fill-rule="evenodd" transform="translate(16.000000, 24.000000)" fill="#34414F" fill-opacity="0.15">
-                        <rect id="Rectangle-13-Copy-4" x="0" y="0" width="219" height="16" rx="4"></rect>
-                        <rect id="Rectangle-13-Copy-5" x="0" y="40" width="279" height="24" rx="4"></rect>
-                        <rect id="Rectangle-13-Copy-6" x="0" y="72" width="325" height="16" rx="4"></rect>
-                        <rect id="Rectangle-13-Copy-6" x="0" y="96" width="180" height="16" rx="4"></rect>
-                        <rect id="Rectangle-13-Copy-7" x="0" y="136" width="240" height="16" rx="4"></rect>
-                    </g>
-                    <polygon id="Rectangle" fill-opacity="0.01" fill="#D8D8D8" fill-rule="nonzero" points="16 1.66533454e-16 375 0 375 24 16 24"></polygon>
-                    <polygon id="Background" fill-opacity="0.15" fill="#34414F" fill-rule="evenodd" points="0 200 375 200 375 201 0 201"></polygon>
-                </g>
+        <g id="interstitial_mobile">
+            <g id="Group" transform="translate(16.000000, 20.545659)" fill="#34414F" fill-opacity="0.15">
+                <rect id="Rectangle-13-Copy-4" x="0" y="0" width="219" height="13.6971059" rx="4"></rect>
+                <rect id="Rectangle-13-Copy-5" x="0" y="34.2427647" width="279" height="20.5456587" rx="4"></rect>
+                <rect id="Rectangle-13-Copy-6" x="0" y="61.6369764" width="325" height="13.6971059" rx="4"></rect>
+                <rect id="Rectangle-13-Copy-6" x="0" y="82.1826352" width="180" height="13.6971059" rx="4"></rect>
+                <rect id="Rectangle-13-Copy-7" x="0" y="116.425399" width="240" height="13.6971059" rx="4"></rect>
             </g>
+            <polygon id="Rectangle" fill-opacity="0.01" fill="#D8D8D8" points="16 1.42564147e-16 375 0 375 20.5456587 16 20.5456587"></polygon>
+            <polygon id="Background" fill-opacity="0.15" fill="#34414F" points="0 171.213823 375 171.213823 375 172.069893 0 172.069893"></polygon>
         </g>
     </g>
 </svg>

--- a/resources/public/img/ML/interstitial_mobile@dark.svg
+++ b/resources/public/img/ML/interstitial_mobile@dark.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="375px" height="201px" viewBox="0 0 375 201" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
+    <title>Rectangle-13-Copy-4</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="interstitial_mobile" transform="translate(0.000000, -1.000000)">
+            <g id="Group" transform="translate(0.000000, 1.000000)">
+                <g id="Group-9">
+                    <g id="Rectangle-13-Copy-4">
+                        <rect fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="24" width="219" height="16" rx="4"></rect>
+                        <rect id="Rectangle-13-Copy-5" fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="64" width="279" height="24" rx="4"></rect>
+                        <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="96" width="325" height="16" rx="4"></rect>
+                        <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="120" width="180" height="16" rx="4"></rect>
+                        <rect id="Rectangle-13-Copy-7" fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="160" width="240" height="16" rx="4"></rect>
+                        <polygon id="Rectangle" fill-opacity="0.01" fill="#D8D8D8" fill-rule="nonzero" points="16 1.66533454e-16 375 0 375 24 16 24"></polygon>
+                        <polygon id="Background" fill-opacity="0.16" fill="#FFFFFF" fill-rule="evenodd" points="0 200 375 200 375 201 0 201"></polygon>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources/public/img/ML/interstitial_mobile@dark.svg
+++ b/resources/public/img/ML/interstitial_mobile@dark.svg
@@ -1,23 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="375px" height="201px" viewBox="0 0 375 201" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="375px" height="173px" viewBox="0 0 375 173" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
-    <title>Rectangle-13-Copy-4</title>
+    <title>interstitial_mobile@dark</title>
     <desc>Created with Sketch.</desc>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="interstitial_mobile" transform="translate(0.000000, -1.000000)">
-            <g id="Group" transform="translate(0.000000, 1.000000)">
-                <g id="Group-9">
-                    <g id="Rectangle-13-Copy-4">
-                        <rect fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="24" width="219" height="16" rx="4"></rect>
-                        <rect id="Rectangle-13-Copy-5" fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="64" width="279" height="24" rx="4"></rect>
-                        <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="96" width="325" height="16" rx="4"></rect>
-                        <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="120" width="180" height="16" rx="4"></rect>
-                        <rect id="Rectangle-13-Copy-7" fill-opacity="0.08" fill="#FFFFFF" fill-rule="evenodd" x="16" y="160" width="240" height="16" rx="4"></rect>
-                        <polygon id="Rectangle" fill-opacity="0.01" fill="#D8D8D8" fill-rule="nonzero" points="16 1.66533454e-16 375 0 375 24 16 24"></polygon>
-                        <polygon id="Background" fill-opacity="0.16" fill="#FFFFFF" fill-rule="evenodd" points="0 200 375 200 375 201 0 201"></polygon>
-                    </g>
-                </g>
-            </g>
+        <g id="interstitial_mobile@dark">
+            <rect id="Rectangle" fill-opacity="0.08" fill="#FFFFFF" x="16" y="20.5456588" width="219" height="13.6971059" rx="4"></rect>
+            <rect id="Rectangle-13-Copy-5" fill-opacity="0.08" fill="#FFFFFF" x="16" y="54.7884234" width="279" height="20.5456588" rx="4"></rect>
+            <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" x="16" y="82.1826353" width="325" height="13.6971059" rx="4"></rect>
+            <rect id="Rectangle-13-Copy-6" fill-opacity="0.08" fill="#FFFFFF" x="16" y="102.728294" width="180" height="13.6971059" rx="4"></rect>
+            <rect id="Rectangle-13-Copy-7" fill-opacity="0.08" fill="#FFFFFF" x="16" y="136.971059" width="240" height="13.6971059" rx="4"></rect>
+            <polygon id="Rectangle" fill-opacity="0.01" fill="#D8D8D8" points="16 1.42564147e-16 375 0 375 20.5456588 16 20.5456588"></polygon>
+            <polygon id="Background" fill-opacity="0.16" fill="#FFFFFF" points="0 171.213823 375 171.213823 375 172.069892 0 172.069892"></polygon>
         </g>
     </g>
 </svg>

--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -18,7 +18,7 @@ div.dashboard-layout {
   }
 
   @include mobile() {
-    background-color: var(--mobile-background-color); // FIXME: rgba($deep_navy, 0.05);
+    background-color: var(--opac-background-color-05);
 
     &.sticky-board-name {
       padding-top: 48px;
@@ -261,7 +261,7 @@ div.dashboard-layout {
         height: 40px;
         // Use 0.19 opacity on this to make it look like the rest of the lines
         // that are on a darker background
-        border-bottom: 1px solid var(--ultralight-color); // FIXME rgba($deep_navy, 0.19);
+        border-bottom: 1px solid var(--divider-line);
 
         @include mobile() {
           height: 50px;
@@ -498,8 +498,8 @@ div.dashboard-layout {
           @include mobile () {
             float: unset;
             height: 50px;
-            background-color: rgba($deep_navy, 0.05);
-            border-bottom: 1px solid rgba($deep_navy, 0.15);
+            background-color: var(--mobile-background-color);
+            border-bottom: 1px solid var(--divider-line);
           }
 
           button.complete-all-bt {

--- a/scss/partials/_dashboard_layout.scss
+++ b/scss/partials/_dashboard_layout.scss
@@ -267,6 +267,7 @@ div.dashboard-layout {
           height: 50px;
           border-bottom: none;
           padding: 0;
+          background-color: var(--mobile-background-color);
 
           &.drafts-board {
             height: 0;
@@ -498,7 +499,7 @@ div.dashboard-layout {
           @include mobile () {
             float: unset;
             height: 50px;
-            background-color: var(--mobile-background-color);
+            background-color: var(--mobile-foc-background-color);
             border-bottom: 1px solid var(--divider-line);
           }
 

--- a/scss/partials/_lazy_stream.scss
+++ b/scss/partials/_lazy_stream.scss
@@ -38,7 +38,7 @@ div.lazy-stream {
       margin-top: 0;
       background-image: cdnUrl("/img/ML/interstitial_mobile.svg");
       min-height: calc(100vh - #{$mobile_navbar_height}px - 8px);
-      background-size: 100% auto;
+      background-size: 100% 173px;
 
       @include dark_mode() {
         background-image: cdnUrl("/img/ML/interstitial_mobile@dark.svg");

--- a/scss/partials/_lazy_stream.scss
+++ b/scss/partials/_lazy_stream.scss
@@ -15,16 +15,16 @@ div.lazy-stream {
     background-position: 0 0;
 
     @include big_web() {
-      margin-top: 10px;
       min-height: calc(100vh - 140px);
       background-image: cdnUrl("/img/ML/interstitial.svg");
-      background-size: #{$board_container_width}px 202px;
+      background-size: #{$board_container_width}px 185px;
 
       @include dark_mode() {
         background-image: cdnUrl("/img/ML/interstitial@dark.svg");
       }
 
       &.collapsed {
+        margin-top: 10px;
         background-image: cdnUrl("/img/ML/interstitial_collapsed.svg");
         background-size: #{$board_container_width}px 115px;
 

--- a/scss/partials/_lazy_stream.scss
+++ b/scss/partials/_lazy_stream.scss
@@ -11,29 +11,64 @@ div.lazy-stream {
   div.lazy-stream-interstitial {
     width: 100%;
     height: 100%;
-    min-height: calc(100vh - 140px);
-    background-image: cdnUrl("/img/ML/interstitial.svg");
-    background-size: #{$board_container_width}px 218px;
     background-repeat: repeat-y;
     background-position: 0 0;
 
+    @include big_web() {
+      margin-top: 10px;
+      min-height: calc(100vh - 140px);
+      background-image: cdnUrl("/img/ML/interstitial.svg");
+      background-size: #{$board_container_width}px 202px;
+
+      @include dark_mode() {
+        background-image: cdnUrl("/img/ML/interstitial@dark.svg");
+      }
+
+      &.collapsed {
+        background-image: cdnUrl("/img/ML/interstitial_collapsed.svg");
+        background-size: #{$board_container_width}px 115px;
+
+        @include dark_mode() {
+          background-image: cdnUrl("/img/ML/interstitial_collapsed@dark.svg");
+        }
+      }
+    }
+
     @include mobile() {
-      background-image: cdnUrl("/img/ML/interstitial_mobile.svg");
-      min-height: casl(100vh - #{$mobile_navbar_height}px - 8px);
+      margin-top: 0;
+      background-image: cdnUrl("/img/ML/interstitial_mobile1.svg");
+      min-height: calc(100vh - #{$mobile_navbar_height}px - 8px);
       background-size: 100% auto;
+
+      @include dark_mode() {
+        background-image: cdnUrl("/img/ML/interstitial_mobile@dark.svg");
+      }
     }
   }
 }
 
-div.preload-interstitial {
-  @include preload_image(cdnUrl("/img/ML/interstitial.svg"));
-  @include mobile() {
-    @include preload_image(cdnUrl("/img/ML/interstitial_mobile.svg"));
-  }
+html:not(.theme-mode-dark) {
+  div.preload-interstitial {
+    @include big_web() {
+      @include preload_image(cdnUrl("/img/ML/interstitial.svg"));
+      @include preload_image(cdnUrl("/img/ML/interstitial_collapsed.svg"), "before");
+    }
+
+    @include mobile() {
+      @include preload_image(cdnUrl("/img/ML/interstitial_mobile1.svg"));
+    }
+  }  
 }
 
-@include dark_mode(){
-  div.lazy-stream div.lazy-stream-interstitial {
-    opacity: 0.2;
-  }
+html.theme-mode-dark {
+  div.preload-interstitial {
+    @include big_web() {
+      @include preload_image(cdnUrl("/img/ML/interstitial@dark.svg"));
+      @include preload_image(cdnUrl("/img/ML/interstitial_collapsed@dark.svg"), "before");
+    }
+
+    @include mobile() {
+      @include preload_image(cdnUrl("/img/ML/interstitial_mobile@dark.svg"));
+    }
+  }  
 }

--- a/scss/partials/_lazy_stream.scss
+++ b/scss/partials/_lazy_stream.scss
@@ -36,7 +36,7 @@ div.lazy-stream {
 
     @include mobile() {
       margin-top: 0;
-      background-image: cdnUrl("/img/ML/interstitial_mobile1.svg");
+      background-image: cdnUrl("/img/ML/interstitial_mobile.svg");
       min-height: calc(100vh - #{$mobile_navbar_height}px - 8px);
       background-size: 100% auto;
 
@@ -55,7 +55,7 @@ html:not(.theme-mode-dark) {
     }
 
     @include mobile() {
-      @include preload_image(cdnUrl("/img/ML/interstitial_mobile1.svg"));
+      @include preload_image(cdnUrl("/img/ML/interstitial_mobile.svg"));
     }
   }  
 }

--- a/src/oc/web/components/ui/lazy_stream.cljs
+++ b/src/oc/web/components/ui/lazy_stream.cljs
@@ -10,6 +10,7 @@
                          (drv/drv :board-data)
                          (drv/drv :container-data)
                          (drv/drv :activity-data)
+                         (drv/drv :foc-layout)
                          {:did-mount (fn [s]
                            (utils/scroll-to-y (:scroll-y @router/path) 0)
                            s)}
@@ -17,6 +18,7 @@
   (let [board-data (drv/react s :board-data)
         container-data (drv/react s :container-data)
         activity-data (drv/react s :activity-data)
+        foc-layout (drv/react s :foc-layout)
         is-container? (dis/is-container? (router/current-board-slug))
         loading? (or ;; Board specified
                      (and (not (router/current-activity-id))
@@ -35,7 +37,8 @@
       (if-not loading?
         (stream-comp)
         [:div.lazy-stream-interstitial
-          {:style {:height (str (+ (:scroll-y @router/path)
+          {:class (when (= foc-layout dis/other-foc-layout) "collapsed")
+           :style {:height (str (+ (:scroll-y @router/path)
                                    (or (.. js/document -documentElement -clientHeight)
                                        (.-innerHeight js/window)))
                              "px")}}])]))


### PR DESCRIPTION
Add interstitial for collapsed FoC and update the old ones for desktop, mobile and dark mode.

To test:
- check ghost screen FoC expanded on desktop light
- check ghost screen FoC expanded on desktop dark
- check ghost screen FoC collapsed on desktop light
- check ghost screen FoC collapsed on desktop dark
- check ghost screen FoC on mobile light
- check ghost screen FoC on mobile dark