### PR TITLE
Fix FoC menu

### DIFF
--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -58,8 +58,12 @@ div.stream-item {
     @include big_web() {
       &:hover {
         div.stream-item-header {
-          div.more-menu button {
-            display: initial;
+          div.more-menu {
+            display: block;
+
+            button {
+              display: initial;
+            }
           }
         }
       }
@@ -78,8 +82,12 @@ div.stream-item {
       border: 1px solid var(--foc-hover-border-color);
 
       div.stream-item-header {
-        div.more-menu button {
-          display: initial;
+        div.more-menu {
+          display: block;
+
+          button {
+            display: initial;
+          }
         }
       }
     }
@@ -111,6 +119,16 @@ div.stream-item {
         padding: #{24 + $foc_hover_extra_padding)}px #{32 + $foc_hover_extra_padding}px;
         width: #{$board_container_width + ($foc_hover_extra_padding * 2)}px;
         height: #{$foc_height + ($foc_hover_extra_padding * 2)}px;
+
+        div.stream-item-header {
+          div.more-menu {
+            display: block;
+
+            button {
+              display: initial;
+            }
+          }
+        }
       }
     }
   }
@@ -331,6 +349,11 @@ div.stream-item {
       height: 32px;
 
       @include big_web() {
+        display: none;
+        position: absolute;
+        right: -12px;
+        top: -4px;
+
         &:not(.menu-expanded) button {
           display: none;
         }
@@ -396,7 +419,7 @@ div.stream-item {
     }
 
     div.thumbnail-container {
-      min-height: 88px;
+      min-height: 84px;
       position: relative;
       cursor: pointer;
 


### PR DESCRIPTION
When in FoC if you click on the ... menu and then move the cursor out of the post tile, the menu gets cut off.

To test:
- on desktop with expanded FoC
- open the menu
- move cursor out of the post tile
- menu is hidden?
- the FoC buttons (bookmark, follow, share) have the same space from right and top border of the tile?
- on desktop with collapsed FoC
- open the menu
- move cursor out of the post tile
- menu is hidden?
- on mobile
- check you can still open the menu with swipe or long press