### PR TITLE
Fix WRT count

### DIFF
--- a/src/oc/web/components/dashboard_layout.cljs
+++ b/src/oc/web/components/dashboard_layout.cljs
@@ -51,6 +51,7 @@
                               (drv/drv :mobile-user-notifications)
                               (drv/drv :activity-data)
                               (drv/drv :foc-layout)
+                              (drv/drv :activities-read)
                               ;; Mixins
                               ui-mixins/strict-refresh-tooltips-mixin
                               {:before-render (fn [s]
@@ -72,6 +73,7 @@
         container-data (drv/react s :container-data)
         posts-data (drv/react s :filtered-posts)
         foc-layout (drv/react s :foc-layout)
+        _activities-read (drv/react s :activities-read)
         current-board-slug (router/current-board-slug)
         ;; Board data used as fallback until the board is completely loaded
         org-board-data (first (filter #(= (:slug %) current-board-slug) (:boards org-data)))


### PR DESCRIPTION
Card: https://trello.com/c/5sNHBWCp

Bug:
- open Unread
- nav to AP,
- check Viewers is show for some posts (those that were not visible in Unread)
- nav to Bookmarks
- back to AP
- now you can see the counts

Problem is that the stream-item component doesn't get updated when the read counts are loaded.

To test:
- repeat the steps above
- confirm the bug is solved
- check switch to collapsed item for regressions
- check mobile for regressions
- merge