### PR TITLE
Fix word wrapping

### DIFF
--- a/scss/mixins/_activity.scss
+++ b/scss/mixins/_activity.scss
@@ -134,6 +134,8 @@ $h2_top_margin: 24;
   font-size: $font_size;
   color: var(--color);
   line-height: $line_height;
+  white-space: normal;
+  overflow-wrap: break-word;
 
   .emojione {
     @include emoji-size(22);
@@ -145,6 +147,8 @@ $h2_top_margin: 24;
   font-size: $font_size;
   color: var(--color);
   line-height: $line_height;
+  white-space: normal;
+  overflow-wrap: break-word;
 
   i {
     @include OC_Body_Bold_Italic();
@@ -185,6 +189,8 @@ $h2_top_margin: 24;
   font-size: 22px;
   color: var(--color);
   line-height: 28px;
+  white-space: normal;
+  overflow-wrap: break-word;
 
   .emojione {
     @include emoji-size(18);
@@ -224,7 +230,7 @@ $h2_top_margin: 24;
   font-size: #{$font_size}px;
   line-height: #{$line_height}px;
   color: $color;
-  white-space: pre-wrap;
+  white-space: normal;
   overflow-wrap: break-word;
 
   p, ul > li, i {
@@ -405,6 +411,8 @@ $h2_top_margin: 24;
     background-color: #F0EFEA; // FIXME
     border-radius: 4px;
     margin-top: 4px;
+    white-space: normal;
+    overflow-wrap: break-word;
 
     & > * {
       opacity: 0.8;
@@ -524,7 +532,7 @@ $h2_top_margin: 24;
   @include OC_Body_Book();
   font-size: $font-size;
   color: var(--color);
-  white-space: pre-wrap;
+  white-space: normal;
   overflow-wrap: break-word;
   line-height: $line-height;
 

--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -792,7 +792,7 @@ div.cmail-outer {
           cursor: text;
           @include activity-title(14px, 18px);
           color: var(--color);
-          white-space: pre-wrap;
+          white-space: normal;
           overflow-wrap: break-word;
           min-height: 18px;
           line-height: 18px;

--- a/scss/partials/_expanded_post.scss
+++ b/scss/partials/_expanded_post.scss
@@ -242,8 +242,8 @@ div.expanded-post {
           overflow: hidden;
           max-width: 100%;
           text-overflow: ellipsis;
-          white-space: pre-wrap;
-          word-break: break-word;
+          white-space: normal;
+          overflow-wrap: break-word;
         }
       }
 
@@ -260,8 +260,8 @@ div.expanded-post {
           overflow: hidden;
           max-width: 100%;
           text-overflow: ellipsis;
-          white-space: pre-wrap;
-          word-break: break-word;
+          white-space: normal;
+          overflow-wrap: break-word;
         }
       }
     }
@@ -271,8 +271,8 @@ div.expanded-post {
     @include activity-abstract(17px, 22px);
     margin: 16px 0 24px;
     @include OC_Body_Bold();
-    white-space: pre-wrap;
-    word-break: break-word;
+    white-space: normal;
+    overflow-wrap: break-word;
 
     // Abstract is bold only in expanded post view
     // we need to make sure italic doesn't override

--- a/scss/partials/_stream_item.scss
+++ b/scss/partials/_stream_item.scss
@@ -307,6 +307,7 @@ div.stream-item {
             margin-right: 8px;
             margin-left: 6px;
             overflow: visible;
+            white-sapce: nowrap;
 
             &:before {
               content: "";
@@ -321,7 +322,6 @@ div.stream-item {
 
             @include mobile() {
               display: block;
-              white-space: nowrap;
               float: left;
               line-height: 24px;
             }
@@ -548,7 +548,12 @@ div.stream-item {
         overflow: hidden;
         text-overflow: ellipsis;
         max-width: 100%;
-        white-space: nowrap;
+
+        @include mobile() {
+          margin-top: 2px;
+          height: 23px;
+          @include activity-title(18px, 23px);
+        }
       }
 
       div.stream-item-body {
@@ -557,8 +562,6 @@ div.stream-item {
         @include OC_Body_Book();
         line-height: 22px;
         overflow: hidden;
-        white-space: pre-wrap;
-        word-break: break-word;
 
         max-height: #{22 * 2}px;
 


### PR DESCRIPTION
Found out that W3C recommends the use of `overflow-wrap` for english aphabet languages, and the use of `word-wrap` for non-english ones.

To test:
- add a post with a very long single word in title, post and abstract
- check it's displayed fine in: stream, collapsed stream, expanded post
- add a comment with a very long single word
- check that the comment is displayed without issues
- copy the publish share url of the post
- open in incognito
- check is displayed fine there too