### PR TITLE
Fix dark mode notifications

### DIFF
--- a/src/oc/web/components/ui/notifications.cljs
+++ b/src/oc/web/components/ui/notifications.cljs
@@ -123,11 +123,14 @@
                            rum/reactive
                            (drv/drv :notifications-data)
                            (drv/drv :panel-stack)
+                           (drv/drv :ui-theme)
   [s]
   (let [notifications-data (drv/react s :notifications-data)
         panel-stack (drv/react s :panel-stack)
-        has-open-panel? (pos? (count panel-stack))]
+        {:keys [computed-value]} (drv/react s :ui-theme)
+        light-theme? (or (pos? (count panel-stack))
+                         (= computed-value :dark))]
     [:div.notifications
       (for [idx (range (count notifications-data))
             :let [n (nth notifications-data idx)]]
-        (rum/with-key (notification n has-open-panel?) (str "notif-" (:id n))))]))
+        (rum/with-key (notification n light-theme?) (str "notif-" (:id n))))]))


### PR DESCRIPTION
Bug: when dark mode is enabled notifications are still shown with dark bg so they are less visible.

Fix: use the inverted color scheme not only when a setting panel is open but also when in dark mode (don't invert colors when in dark mode with setting panel open since the bg is still pretty dark).

Test command from js console (works only locally): `oc.web.actions.notifications.show_notification(cljs.core.js__GT_clj({"id": "test", "title": "My message", "description": "Body here goes you", "expire": 5}, cljs.core.keyword("keywordize-keys"), true))`

To test:
- with light theme
- show a notification
- is it "white-on-black"?
- now open a setting panel
- show a notification
- is it "black-on-white"?
- close setting panel
- switch to dark mode
- show a notification
- is it "black-on-white"?
- now open a setting panel
- show a notification
- is it "black-on-white"?