### PR TITLE
Mark as unread

### DIFF
--- a/scss/partials/_more_menu.scss
+++ b/scss/partials/_more_menu.scss
@@ -349,12 +349,12 @@ div.more-menu {
     }
 
     &.has-mark-unread {
-      width: 138px;
+      width: 134px;
 
       @include mobile() {
         left: unset;
         right: 0;
-        width: 138px;
+        width: 134px;
       } 
     }
 

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -969,3 +969,13 @@
 (defn request-reads-count [item-ids]
   (when (seq item-ids)
     (ws-cc/who-read-count item-ids)))
+
+;; Change service http
+
+(defn mark-unread [mark-unread-link container-id callback]
+  (if mark-unread-link
+    (change-http (method-for-link mark-unread-link) (relative-href mark-unread-link)
+     {:headers (headers-for-link mark-unread-link)
+      :body container-id}
+     callback)
+    (handle-missing-link "mark-unread" mark-unread-link callback)))

--- a/src/oc/web/components/stream_collapsed_item.cljs
+++ b/src/oc/web/components/stream_collapsed_item.cljs
@@ -116,6 +116,6 @@
                   :external-follow (not is-mobile?)
                   :show-edit? true
                   :show-delete? true
-                  :show-unread (not is-inbox?)
+                  :show-unread (not (:unread activity-data))
                   :show-move? (not is-mobile?)
                   :show-inbox? is-inbox?})]))

--- a/src/oc/web/components/stream_item.cljs
+++ b/src/oc/web/components/stream_item.cljs
@@ -193,7 +193,7 @@
                            :external-follow (not is-mobile?)
                            :show-edit? true
                            :show-delete? true
-                           :show-unread (not is-inbox?)
+                           :show-unread (not (:unread activity-data))
                            :show-move? (not is-mobile?)
                            :show-inbox? is-inbox?
                            :will-close (fn [] (reset! (::force-show-menu s) false))

--- a/src/oc/web/components/ui/more_menu.cljs
+++ b/src/oc/web/components/ui/more_menu.cljs
@@ -86,12 +86,12 @@
              tooltip-position show-edit? show-delete? edit-cb delete-cb show-move? show-unread
              can-comment-share? comment-share-cb can-react? react-cb can-reply?
              reply-cb external-bookmark remove-bookmark-title
-             show-inbox? force-show-menu capture-clicks external-follow mobile-tray-menu]}]
+             show-inbox? force-show-menu capture-clicks external-follow mobile-tray-menu
+             mark-unread-cb]}]
   (let [delete-link (utils/link-for (:links entity-data) "delete")
         edit-link (utils/link-for (:links entity-data) "partial-update")
         share-link (utils/link-for (:links entity-data) "share")
         inbox-unread-link (utils/link-for (:links entity-data) "unread")
-        mark-unread-link (utils/link-for (:links entity-data) "mark-unread")
         is-mobile? (responsive/is-tablet-or-mobile?)
         add-bookmark-link (utils/link-for (:links entity-data) "bookmark" "POST")
         remove-bookmark-link (when (:bookmarked entity-data)
@@ -221,7 +221,9 @@
                               (reset! (::showing-menu s) false)
                               (when (fn? will-close)
                                 (will-close))
-                              (activity-actions/mark-unread entity-data))}
+                              (activity-actions/mark-unread entity-data)
+                              (when (fn? mark-unread-cb)
+                                (mark-unread-cb)))}
                 "Mark as unread"])
             (when (or is-mobile?
                       (not external-follow))

--- a/src/oc/web/components/ui/more_menu.cljs
+++ b/src/oc/web/components/ui/more_menu.cljs
@@ -90,7 +90,8 @@
   (let [delete-link (utils/link-for (:links entity-data) "delete")
         edit-link (utils/link-for (:links entity-data) "partial-update")
         share-link (utils/link-for (:links entity-data) "share")
-        mark-unread-link (utils/link-for (:links entity-data) "unread")
+        inbox-unread-link (utils/link-for (:links entity-data) "unread")
+        mark-unread-link (utils/link-for (:links entity-data) "mark-unread")
         is-mobile? (responsive/is-tablet-or-mobile?)
         add-bookmark-link (utils/link-for (:links entity-data) "bookmark" "POST")
         remove-bookmark-link (when (:bookmarked entity-data)
@@ -102,21 +103,21 @@
                                 can-reply?
                                 (and (not external-share)
                                      share-link)
-                                (and mark-unread-link
+                                (and inbox-unread-link
                                      show-unread))
         inbox-follow-link (utils/link-for (:links entity-data) "follow")
         inbox-unfollow-link (utils/link-for (:links entity-data) "unfollow")
         show-menu (or @(::showing-menu s) force-show-menu)]
     (when (or edit-link
               share-link
-              mark-unread-link
+              inbox-unread-link
               delete-link
               can-comment-share?
               can-react?
               can-reply?
               add-bookmark-link
               remove-bookmark-link
-              mark-unread-link)
+              inbox-unread-link)
       [:div.more-menu
         {:ref "more-menu"
          :class (utils/class-set {:menu-expanded (or @(::move-activity s)
@@ -156,7 +157,7 @@
                                       :has-add-bookmark (and remove-bookmark-link
                                                              (or is-mobile?
                                                                  (not external-bookmark)))
-                                      :has-mark-unread mark-unread-link})}
+                                      :has-mark-unread inbox-unread-link})}
             (when (and edit-link
                        show-edit?)
               [:li.edit.top-rounded
@@ -196,7 +197,7 @@
             (when (and (not external-share)
                        share-link)
               [:li.share
-                {:class (when (and (not mark-unread-link)
+                {:class (when (and (not inbox-unread-link)
                                    (not (or is-mobile?
                                             (not external-follow)))
                                    (not (or is-mobile?
@@ -208,7 +209,7 @@
                                 (will-close))
                               (activity-actions/activity-share-show entity-data share-container-id))}
                 "Share"])
-            (when (and mark-unread-link
+            (when (and inbox-unread-link
                        show-unread)
               [:li.unread
                 {:class (when (and (not (or is-mobile?
@@ -220,8 +221,8 @@
                               (reset! (::showing-menu s) false)
                               (when (fn? will-close)
                                 (will-close))
-                              (activity-actions/inbox-unread entity-data))}
-                "Add to Unread"])
+                              (activity-actions/mark-unread entity-data))}
+                "Mark as unread"])
             (when (or is-mobile?
                       (not external-follow))
               (if inbox-follow-link


### PR DESCRIPTION
Card: https://trello.com/c/o0tmirRa

Related PRs:
- [Storage](https://github.com/open-company/open-company-storage/pull/240)
- [Change](https://github.com/open-company/open-company-change/pull/26)

Add delete API call to Change service to delete the current user's read record, keep also the action to inbox to move it to unread. This way the post will be in Unread with white bg.

To test TBD