### PR TITLE
Delete comment thread

### DIFF
--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -43,10 +43,12 @@
     (reset! (::show-more-menu s) nil)
     (reset! (::editing? s) (:uuid comment-data))))
 
-(defn delete-clicked [e activity-data comment-data]
+(defn delete-clicked [e activity-data has-children? comment-data]
   (let [alert-data {:icon "/img/ML/trash.svg"
                     :action "delete-comment"
-                    :message (str "Delete this comment?")
+                    :message (if has-children?
+                               "Delete this comment thread?"
+                               "Delete this comment?")
                     :link-button-title "No"
                     :link-button-cb #(alert-modal/hide-alert)
                     :solid-button-style :red
@@ -195,6 +197,9 @@
                                                         (utils/in? @(::replying-to s) (:uuid comment-data)))
                                                    (and (not= (:parent-uuid next-comment-data) (:parent-uuid comment-data))
                                                         (utils/in? @(::replying-to s) (:parent-uuid comment-data))))
+                      has-children? (and (not is-indented-comment?)
+                                         next-comment-data
+                                         (= (:parent-uuid next-comment-data) (:uuid comment-data)))
                       needs-left-border? (or is-indented-comment?
                                              (= (:parent-uuid next-comment-data) (:uuid comment-data))
                                              should-show-add-comment?)
@@ -257,7 +262,7 @@
                                     :show-edit? true
                                     :edit-cb (partial start-editing s)
                                     :show-delete? true
-                                    :delete-cb (partial delete-clicked s activity-data)
+                                    :delete-cb (partial delete-clicked s activity-data has-children?)
                                     :can-comment-share? true
                                     :comment-share-cb #(share-clicked comment-data)
                                     :can-react? true
@@ -296,7 +301,7 @@
                                                              :show-edit? true
                                                              :edit-cb (partial start-editing s)
                                                              :show-delete? true
-                                                             :delete-cb (partial delete-clicked s activity-data)
+                                                             :delete-cb (partial delete-clicked s activity-data has-children?)
                                                              :can-comment-share? true
                                                              :comment-share-cb #(share-clicked comment-data)
                                                              :can-react? true
@@ -325,7 +330,7 @@
                                         (when can-show-delete-bt?
                                           [:button.mlb-reset.delete-bt
                                             {:on-click (fn [_]
-                                                        (delete-clicked s activity-data comment-data))}
+                                                        (delete-clicked s activity-data has-children? comment-data))}
                                             "Delete"])
                                         (when can-show-edit-bt?
                                           [:button.mlb-reset.edit-bt

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -220,6 +220,7 @@
               [:div.stream-comment-outer
                 {:key (str "stream-comment-" (:created-at comment-data))
                  :data-comment-uuid (:uuid comment-data)
+                 :data-children-count (:children-count comment-data)
                  :class (utils/class-set {:not-highlighted (not (utils/in? @(::highlighting-comments s) (:uuid comment-data)))
                                           :highlighted (utils/in? @(::highlighting-comments s) (:uuid comment-data))
                                           :left-border needs-left-border?
@@ -238,6 +239,7 @@
               [:div.stream-comment-outer
                 {:key (str "stream-comment-" (:created-at comment-data))
                  :data-comment-uuid (:uuid comment-data)
+                 :data-children-count (:children-count comment-data)
                  :class (utils/class-set {:not-highlighted (not (utils/in? @(::highlighting-comments s) (:uuid comment-data)))
                                           :highlighted (utils/in? @(::highlighting-comments s) (:uuid comment-data))
                                           :left-border needs-left-border?

--- a/src/oc/web/stores/comment.cljs
+++ b/src/oc/web/stores/comment.cljs
@@ -142,7 +142,8 @@
   [db [_ activity-uuid comment-data comments-key]]
   (let [item-uuid (:uuid comment-data)
         comments-data (get-in db comments-key)
-        new-comments-data (remove #(= item-uuid (:uuid %)) comments-data)]
+        new-comments-data (filterv #(and (not= item-uuid (:uuid %)) (not= item-uuid (:parent-uuid %)))
+                           comments-data)]
     (assoc-in db comments-key new-comments-data)))
 
 (defmethod dispatcher/action :comment-reaction-toggle

--- a/src/oc/web/utils/comment.cljs
+++ b/src/oc/web/utils/comment.cljs
@@ -110,8 +110,10 @@
   ([comments :guard sequential?]
    (let [root-comments (filterv (comp empty? :parent-uuid) comments)
          sorted-roots (sort-comments root-comments nil)
-         all-comments-seqs (mapv #(vec (concat [%] (sort-comments comments (:uuid %)))) sorted-roots)]
-     (vec (apply concat all-comments-seqs))))
+         all-comments-seqs (mapv #(vec (concat [%] (sort-comments comments (:uuid %)))) sorted-roots)
+         all-sorted-comments (vec (apply concat all-comments-seqs))
+         with-children-count (mapv #(assoc % :children-count (count (filter (fn [c] (= (:parent-uuid c) (:uuid %))) all-sorted-comments))) all-sorted-comments)]
+     with-children-count))
   ([comments :guard sequential? parent-uuid]
    (let [check-fn (if parent-uuid #(-> % :parent-uuid (= parent-uuid)) (comp empty? :parent-uuid))
          filtered-comments (filterv check-fn comments)

--- a/src/oc/web/utils/comment.cljs
+++ b/src/oc/web/utils/comment.cljs
@@ -110,8 +110,7 @@
   ([comments :guard sequential?]
    (let [root-comments (filterv (comp empty? :parent-uuid) comments)
          sorted-roots (sort-comments root-comments nil)
-         all-comments-seqs (mapv #(vec (concat [%] (sort-comments comments (:uuid %)))) sorted-roots)
-         all-sorted-comments (vec (apply concat all-comments-seqs))
+         all-sorted-comments (vec (mapcat #(vec (concat [%] (sort-comments comments (:uuid %)))) sorted-roots))
          with-children-count (mapv #(assoc % :children-count (count (filter (fn [c] (= (:parent-uuid c) (:uuid %))) all-sorted-comments))) all-sorted-comments)]
      with-children-count))
   ([comments :guard sequential? parent-uuid]


### PR DESCRIPTION
Card: https://trello.com/c/erqv5ixY

Review with:
- [Interaction](https://github.com/open-company/open-company-interaction/pull/41)

To test:
- open a post
- add some comments
- add some replies
- delete a comment w/o replies
- no other comment disappear?
- delete a reply only
- the thread is still there except the deleted comment?
- delete a root comment with replies
- all the replies disappear?