### PR TITLE
Fix comment placeholder and cache

### DIFF
--- a/src/oc/web/components/expanded_post.cljs
+++ b/src/oc/web/components/expanded_post.cljs
@@ -133,7 +133,7 @@
         expand-image-src (drv/react s :expand-image-src)
         assigned-follow-up-data (first (filter #(= (-> % :assignee :user-id) current-user-id) (:follow-ups activity-data)))
         add-comment-force-update* (drv/react s :add-comment-force-update)
-        add-comment-force-update (get-in add-comment-force-update* (dis/add-comment-string-key (:uuid activity-data)))
+        add-comment-force-update (get add-comment-force-update* (dis/add-comment-string-key (:uuid activity-data)))
         has-new-comments? ;; if the post has a last comment timestamp (a comment not from current user)
                           (and @(::initial-new-at s)
                                ;; and that's after the user last read

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -156,11 +156,12 @@
                           (reset! (::add-comment-id s) (utils/activity-uuid))
                           (let [{:keys [activity-data parent-comment-uuid edit-comment-data]} (first (:rum/args s))
                                 add-comment-data @(drv/get-ref s :add-comment-data)
-                                add-comment-key (str (:uuid activity-data) "-" parent-comment-uuid "-" (:uuid edit-comment-data))
-                                activity-add-comment-data (get add-comment-data add-comment-key)
-                                add-comment-activity-data (get add-comment-data (:uuid activity-data))]
+                                add-comment-key (dis/add-comment-string-key (:uuid activity-data) parent-comment-uuid (:uuid edit-comment-data))
+                                activity-add-comment-data (get add-comment-data add-comment-key)]
                             (reset! (::initial-add-comment s) (or activity-add-comment-data ""))
-                            (reset! (::show-post-button s) (should-focus-field? s)))
+                            (reset! (::show-post-button s) (or (seq activity-add-comment-data) (should-focus-field? s)))
+                            (when (seq activity-add-comment-data)
+                              (reset! (::did-change s) true)))
                           s)
                           :did-mount (fn [s]
                            (me-media-utils/setup-editor s add-comment-did-change (me-options (:parent-comment-uuid (first (:rum/args s)))))


### PR DESCRIPTION
Card: https://trello.com/c/UQguvKbV

#To test

Issue 1:
- open a post
- focus add comment field
- type something
- post the comment
- comment field has placeholder?


Issue 2:
- open a post
- type something in the add comment field but don't post it
- click reply to another comment
- type something in but don't post it
- click back to AP
- reopen the post
- do you see the text still in the comment field?
- if you click the X do you see the alert view?
- now click reply to another comment (the same as before)
- the body is still there too?
- post it
- did it work?