### PR TITLE
Comments cache bug

### DIFF
--- a/src/oc/web/actions/comment.cljs
+++ b/src/oc/web/actions/comment.cljs
@@ -28,6 +28,9 @@
   ;; Save the comment change in the app state to remember it
   (dis/dispatch! [:add-comment-change (router/current-org-slug) (:uuid activity-data) parent-comment-uuid comment-uuid comment-body]))
 
+(defn add-comment-reset [activity-uuid parent-comment-uuid comment-uuid]
+  (dis/dispatch! [:add-comment-reset (router/current-org-slug) activity-uuid parent-comment-uuid comment-uuid]))
+
 (defn add-comment [activity-data comment-body parent-comment-uuid save-done-cb]
   (add-comment-blur)
   (let [org-slug (router/current-org-slug)

--- a/src/oc/web/components/stream_comments.cljs
+++ b/src/oc/web/components/stream_comments.cljs
@@ -131,6 +131,7 @@
 
 (rum/defcs stream-comments < rum/reactive
                              (drv/drv :add-comment-focus)
+                             (drv/drv :add-comment-data)
                              (drv/drv :team-roster)
                              (rum/local false ::last-focused-state)
                              (rum/local nil ::editing?)
@@ -161,6 +162,15 @@
                                     (when is-self-focused?
                                       (scroll-to-bottom s))))
                                s)
+                             :will-mount (fn [s]
+                              (let [add-comment-data @(drv/get-ref s :add-comment-data)
+                                    {:keys [activity-data comments-data]} (-> s :rum/args first)]
+                                (mapv (fn [comment]
+                                        (let [comment-key (dis/add-comment-string-key (:uuid activity-data) (:uuid comment))]
+                                          (when (seq (get add-comment-data comment-key))
+                                            (swap! (::replying-to s) #(conj % (:uuid comment))))))
+                                 (filter (comp nil? :parent-uuid) comments-data)))
+                              s)
                              :did-mount (fn [s]
                               (maybe-highlight-comment s)
                               (try (js/emojiAutocomplete)

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -109,6 +109,30 @@
       (utils/after 0
        #(utils/to-end-of-content-editable add-comment-node)))))
 
+(defn- close-reply-clicked [s]
+  (let [{:keys [activity-data parent-comment-uuid dismiss-reply-cb edit-comment-data]} (-> s :rum/args first)
+        dismiss-fn (fn []
+                    (set! (.-innerHTML (rum/ref-node s "editor-node")) @(::initial-add-comment s))
+                    (disable-add-comment-if-needed s)
+                    (reset! (::did-change s) false)
+                    (reset! (::show-post-button s) false)
+                    (comment-actions/add-comment-reset (:uuid activity-data) parent-comment-uuid (:uuid edit-comment-data))
+                    (when (fn? dismiss-reply-cb)
+                      (dismiss-reply-cb true)))]
+    (if @(::did-change s)
+      (let [alert-data {:icon "/img/ML/trash.svg"
+                        :action "cancel-comment-edit"
+                        :message "Are you sure you want to cancel? All your changes to this comment will be lost."
+                        :link-button-title "Keep"
+                        :link-button-cb #(alert-modal/hide-alert)
+                        :solid-button-style :red
+                        :solid-button-title "Yes"
+                        :solid-button-cb (fn []
+                                          (dismiss-fn)
+                                          (alert-modal/hide-alert))}]
+        (alert-modal/show-alert alert-data))
+      (dismiss-fn))))
+
 (rum/defcs add-comment < rum/reactive
                          ;; Locals
                          (rum/local nil :me/editor)
@@ -244,31 +268,7 @@
             :dangerouslySetInnerHTML #js {"__html" @(::initial-add-comment s)}}]
           [:div.add-comment-footer.group
             [:button.mlb-reset.close-reply-bt
-              {:on-click (fn [_]
-                          (let [dismiss-fn (if (fn? dismiss-reply-cb)
-                                             #(do
-                                                (reset! (::did-change s) false)
-                                                (reset! (::show-post-button s) false)
-                                                (dismiss-reply-cb true))
-                                             (fn []
-                                                (set! (.-innerHTML (rum/ref-node s "editor-node")) @(::initial-add-comment s))
-                                                (disable-add-comment-if-needed s)
-                                                (reset! (::did-change s) false)
-                                                (reset! (::show-post-button s) false)
-                                                (comment-actions/add-comment-change activity-data parent-comment-uuid (:uuid edit-comment-data) "")))]
-                            (if @(::did-change s)
-                              (let [alert-data {:icon "/img/ML/trash.svg"
-                                                :action "cancel-comment-edit"
-                                                :message "Are you sure you want to cancel? All your changes to this comment will be lost."
-                                                :link-button-title "Keep"
-                                                :link-button-cb #(alert-modal/hide-alert)
-                                                :solid-button-style :red
-                                                :solid-button-title "Yes"
-                                                :solid-button-cb (fn []
-                                                                  (dismiss-fn)
-                                                                  (alert-modal/hide-alert))}]
-                                (alert-modal/show-alert alert-data))
-                              (dismiss-fn))))
+              {:on-click #(close-reply-clicked s)
                :data-toggle (if (responsive/is-tablet-or-mobile?) "" "tooltip")
                :data-placement "top"
                :data-container "body"

--- a/src/oc/web/stores/comment.cljs
+++ b/src/oc/web/stores/comment.cljs
@@ -52,9 +52,13 @@
 (defmethod dispatcher/action :add-comment-reset
   [db [_ org-slug activity-uuid parent-comment-uuid comment-uuid]]
   (let [add-comment-key (dispatcher/add-comment-key org-slug)
-        comment-key (dispatcher/add-comment-string-key activity-uuid parent-comment-uuid comment-uuid)]
+        comment-key (dispatcher/add-comment-string-key activity-uuid parent-comment-uuid comment-uuid)
+        add-comment-activity-key (dispatcher/add-comment-activity-key org-slug comment-key)]
     (-> db
+      ;; Lose the cached body
       (update-in add-comment-key dissoc comment-key)
+      ;; Lose focus on the field
+      (dissoc :add-comment-focus)
       ;; Force refresh of the add comment field to remove the body
       (assoc-in (dispatcher/add-comment-force-update-key comment-key) (utils/activity-uuid)))))
 


### PR DESCRIPTION
Bug: comments cache is never cleaned up for replies.

To test:
- open a post with a couple of root comments
- type some text in the main add comment field
- type some text in the reply of a thread
- type some text in the reply of another thread
- go back to stream
- reopen the post
- do you see the main add comment field with the text you typed before?
- the replies with a typed comment are already expanded?
- now click the X on one of the replies (not the first)
- go back to the stream
- reopen the post
- do you NOT see the third cached body anymore?
- click X on the other 2 too
- check they are empty when you come back
