### PR TITLE
Fix pricing box layout

### DIFF
--- a/scss/partials/_static_pages.scss
+++ b/scss/partials/_static_pages.scss
@@ -614,6 +614,11 @@ div.pricing-table {
   margin: 40px auto 0;
   padding: 40px;
   position: relative;
+  min-height: 240px;
+  display: flex;
+  flex-direction: row;
+  align-items: normal;
+  align-content: flex-start;
 
   @include mobile() {
     margin-top: 24px;
@@ -621,12 +626,8 @@ div.pricing-table {
   }
 
   div.pricing-table-left {
-    width: 255px;
-    position: absolute;
-    left: 40px;
-    top: 50%;
-    transform: translateY(-50%);
-    padding-right: 60px;
+    width: 195px;
+    flex: 0 0 195px;
 
     @include mobile() {
       position: initial;
@@ -655,11 +656,22 @@ div.pricing-table {
     }
   }
 
+  div.pricing-table-divider-line {
+    width: 1px;
+    min-height: 100%;
+    flex: 0 0 1px;
+    background-color: rgba(white, 0.2);
+    margin: 0 60px;
+  }
+
   div.pricing-table-right {
     float: right;
-    width: 71%;
-    border-left: 1px solid rgba(white, 0.2);
-    padding-left: 60px;
+    width: auto;
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-content: flex-start;
 
     @include mobile() {
       float: unset;
@@ -697,7 +709,7 @@ div.pricing-table {
       font-size: 18px;
       line-height: 23px;
       padding: 16px 26px;
-      float: left;
+      width: 205px;
 
       @include mobile() {
         float: unset;

--- a/site/oc/pages/shared.clj
+++ b/site/oc/pages/shared.clj
@@ -272,6 +272,7 @@
         "$0"]
       [:div.pricing-table-left-subprice
         "for teams of up to 20 people"]]
+    [:div.pricing-table-divider-line]
     [:div.pricing-table-right.group
       [:div.pricing-table-right-copy
         (str


### PR DESCRIPTION
Bug:
- login
- visit /pricing
- see the dark pricing box is broken?

<img src="https://user-images.githubusercontent.com/642704/76439262-69e77780-63bc-11ea-9612-da928cb25be4.png" width="600">

This fixes the above issue using flex layout.

To test:
- repeat the steps above
- confirm it's fixed
- make sure the box looks good when you are logged out