### PR TITLE
Invite picker email domain

### DIFF
--- a/scss/partials/_email_domains.scss
+++ b/scss/partials/_email_domains.scss
@@ -1,0 +1,102 @@
+div.email-domain-container {
+  margin-top: 16px;
+
+  div.email-domain-title {
+    @include OC_Body_Book();
+    font-size: 14px;
+    color: var(--color);
+
+    i.mdi-information-outline {
+      margin-left: 6px;
+
+      &:before {
+        font-size: 14px;
+      }
+    }
+  }
+
+  div.email-domain-field-container {
+    margin-top: 8px;
+    height: 32px;
+    padding: 0 8px;
+    background-color: var(--opac-background-color-1);
+    border-radius: 4px;
+    border: 1px solid var(--opac-background-color-1);
+    border: none;
+    outline: none;
+    width: 100%;
+
+    &.error {
+      border: 1px solid $carrot_orange;
+    }
+
+    input.email-domain-field {
+      height: 32px;
+      background-color: transparent;
+      border-radius: 4px;
+      @include OC_Body_Book();
+      font-size: 14px;
+      color: var(--color);
+      line-height: 18px;
+      width: calc(100% - 32px);
+      border: none;
+      outline: none;
+      border: 1px solid transparent;
+      padding: 7px 0;
+      float: left;
+
+      &:focus, &:active, &.active {
+        outline: none;
+      }
+
+      @include placeholder(){
+        color: var(--light-color)
+      }
+
+      &.error {
+        border: 1px solid $carrot_orange;
+      }
+    }
+
+    button.add-email-domain-bt {
+      float: right;
+      width: auto;
+      padding: 0;
+      @include OC_Body_Bold();
+      color: $carrot_green;
+      font-size: 13px;
+      height: 18px;
+      margin-top: 7px;
+
+      &:disabled, &.disabled {
+        color: var(--light-color);
+        opacity: 1;
+      }
+    }
+  }
+
+  div.email-domain-list {
+    margin-top: 16px;
+
+    div.email-domain-row {
+      @include OC_Body_Book();
+      font-size: 14px;
+      color: var(--color);
+      margin-top: 8px;
+      line-height: 18px;
+      height: 18px;
+
+      button.remove-email-bt {
+        padding: 0;
+        float: right;
+        @include OC_Body_Book();
+        font-size: 12px;
+        color: var(--light-color);
+
+        &:hover {
+          color: var(--color);
+        }
+      }
+    }
+  }
+}

--- a/scss/partials/_invite_picker_modal.scss
+++ b/scss/partials/_invite_picker_modal.scss
@@ -106,6 +106,11 @@ div.invite-picker-modal {
           color: $carrot_green;
         }
       }
+
+      div.email-domain-container {
+        border-top: 1px solid var(--divider-line);
+        padding-top: 16px;
+      }
     }
   }
 }

--- a/scss/partials/_invite_picker_modal.scss
+++ b/scss/partials/_invite_picker_modal.scss
@@ -80,7 +80,7 @@ div.invite-picker-modal {
         margin-top: 8px;
       }
 
-      button {
+      & > button {
         color: $carrot_green;
         text-decoration: none;
         @include OC_Body_Book();

--- a/scss/partials/_invite_slack_modal.scss
+++ b/scss/partials/_invite_slack_modal.scss
@@ -145,7 +145,7 @@ div.invite-slack-modal {
         }
 
         div.invites-list-title {
-          @include OC_Body_Book();
+          @include OC_Body_Bold();
           font-size: 14px;
           color: var(--color);
           letter-spacing: .1px;

--- a/scss/partials/_org_settings_modal.scss
+++ b/scss/partials/_org_settings_modal.scss
@@ -139,21 +139,6 @@ div.org-settings-modal {
       margin-top: 16px;
       border-top: 1px solid var(--divider-line);
 
-      div.org-settings-label {
-        @include OC_Body_Book();
-        font-size: 14px;
-        color: var(--color);
-        margin-top: 16px;
-
-        i.mdi-information-outline {
-          margin-left: 6px;
-
-          &:before {
-            font-size: 14px;
-          }
-        }
-      }
-
       div.org-settings-field-container {
         margin-top: 8px;
         height: 32px;
@@ -175,22 +160,6 @@ div.org-settings-modal {
           float: left;
           width: calc(100% - 32px);
           margin-top: 0;
-        }
-
-        button.add-email-domain-bt {
-          float: right;
-          width: auto;
-          padding: 0;
-          @include OC_Body_Bold();
-          color: $carrot_green;
-          font-size: 13px;
-          height: 18px;
-          margin-top: 7px;
-
-          &:disabled, &.disabled {
-            color: var(--light-color);
-            opacity: 1;
-          }
         }
       }
 
@@ -220,11 +189,6 @@ div.org-settings-modal {
         &.error {
           border: 1px solid $carrot_orange;
         }
-
-        &.email-domain-field {
-          background-color: transparent;
-          border: 1px solid transparent;
-        }
       }
 
       div.error {
@@ -240,31 +204,6 @@ div.org-settings-modal {
         @include OC_Body_Book();
         font-size: 14px;
         color: var(--light-color);
-      }
-
-      div.org-settings-email-domains {
-        margin-top: 16px;
-
-        div.org-settings-email-domain-row {
-          @include OC_Body_Book();
-          font-size: 14px;
-          color: var(--color);
-          margin-top: 8px;
-          line-height: 18px;
-          height: 18px;
-
-          button.remove-email-bt {
-            padding: 0;
-            float: right;
-            @include OC_Body_Book();
-            font-size: 12px;
-            color: var(--light-color);
-
-            &:hover {
-              color: var(--color);
-            }
-          }
-        }
       }
     }
 

--- a/scss/public/css/app.main.scss
+++ b/scss/public/css/app.main.scss
@@ -107,3 +107,4 @@
 @import "partials/_invite_slack_modal";
 @import "partials/_theme_settings_modal";
 @import "partials/_covid_banner";
+@import "partials/_email_domains";

--- a/src/oc/web/components/invite_picker_modal.cljs
+++ b/src/oc/web/components/invite_picker_modal.cljs
@@ -6,7 +6,8 @@
             [oc.web.dispatcher :as dis]
             [oc.web.actions.org :as org-actions]
             [oc.web.actions.team :as team-actions]
-            [oc.web.actions.nav-sidebar :as nav-actions]))
+            [oc.web.actions.nav-sidebar :as nav-actions]
+            [oc.web.components.ui.email-domains :refer (email-domains)]))
 
 
 (rum/defcs invite-picker-modal <
@@ -63,4 +64,5 @@
               [:button.mlb-reset.invite-slack-bt
                 {:on-click #(org-actions/bot-auth team-data current-user-data (str (router/get-token) "?org-settings=invite-picker"))}
                 [:span.disabled "Invite via Slack"]
-                [:span.enabled "(add Slack)"]]))]]]))
+                [:span.enabled "(add Slack)"]]))
+          (email-domains)]]]))

--- a/src/oc/web/components/invite_picker_modal.cljs
+++ b/src/oc/web/components/invite_picker_modal.cljs
@@ -4,6 +4,7 @@
             [oc.web.lib.jwt :as jwt]
             [oc.web.router :as router]
             [oc.web.dispatcher :as dis]
+            [oc.web.stores.user :as user-store]
             [oc.web.actions.org :as org-actions]
             [oc.web.actions.team :as team-actions]
             [oc.web.actions.nav-sidebar :as nav-actions]
@@ -31,8 +32,10 @@
       (team-actions/teams-get))
     s)}
   [s]
-  (let [team-data (drv/react s :team-data)
-        current-user-data (drv/react s :current-user-data)]
+  (let [org-data (drv/react s :org-data)
+        team-data (drv/react s :team-data)
+        current-user-data (drv/react s :current-user-data)
+        user-role (user-store/user-role org-data current-user-data)]
     [:div.invite-picker-modal
       [:button.mlb-reset.modal-close-bt
         {:on-click nav-actions/close-all-panels}]
@@ -65,4 +68,5 @@
                 {:on-click #(org-actions/bot-auth team-data current-user-data (str (router/get-token) "?org-settings=invite-picker"))}
                 [:span.disabled "Invite via Slack"]
                 [:span.enabled "(add Slack)"]]))
-          (email-domains)]]]))
+          (when (= user-role :admin)
+            (email-domains))]]]))

--- a/src/oc/web/components/org_settings_modal.cljs
+++ b/src/oc/web/components/org_settings_modal.cljs
@@ -16,6 +16,7 @@
             [oc.web.components.ui.alert-modal :as alert-modal]
             [oc.web.components.ui.org-avatar :refer (org-avatar)]
             [oc.web.actions.notifications :as notification-actions]
+            [oc.web.components.ui.email-domains :refer (email-domains)]
             [oc.web.components.ui.carrot-checkbox :refer (carrot-checkbox)]))
 
 (defn close-clicked [s dismiss-action]
@@ -96,35 +97,6 @@
     nil
     (fn [err]
       (logo-add-error nil))))
-
-(defn email-domain-removed [success?]
-  (notification-actions/show-notification
-   {:title (if success? "Email domain successfully removed" "Error")
-    :description (when-not success? "An error occurred while removing the email domain, please try again.")
-    :expire 3
-    :id (if success? :email-domain-remove-success :email-domain-remove-error)
-    :dismiss true}))
-
-(defn email-domain-added [success?]
-  (notification-actions/show-notification
-   {:title (if success? "Email domain successfully added" "Error")
-    :description (when-not success? "An error occurred while adding the email domain, please try again.")
-    :expire 3
-    :id (if success? :email-domain-add-success :email-domain-add-error)
-    :dismiss true}))
-
-(defn remove-email-domain-prompt [domain]
-  (let [alert-data {:icon "/img/ML/trash.svg"
-                    :action "org-email-domain-remove"
-                    :message "Are you sure you want to remove this email domain?"
-                    :link-button-title "Keep"
-                    :link-button-cb #(alert-modal/hide-alert)
-                    :solid-button-style :red
-                    :solid-button-title "Yes"
-                    :solid-button-cb #(do
-                                        (alert-modal/hide-alert)
-                                        (team-actions/remove-team (:links domain) email-domain-removed))}]
-    (alert-modal/show-alert alert-data)))
 
 (rum/defcs org-settings-modal <
   ;; Mixins
@@ -214,42 +186,7 @@
                                                                                       :rand (rand 1000)})]))}]
             (when (:error org-editing)
               [:div.error "Must be between 3 and 50 characters"])
-            [:div.org-settings-label
-              "Allowed email domains"
-              [:i.mdi.mdi-information-outline
-                {:title "Any user that signs up with an allowed email domain and verifies their email address will have contributor access to your team."
-                 :data-toggle (when-not is-tablet-or-mobile? "tooltip")
-                 :data-placement "top"
-                 :data-container "body"}]]
-            [:div.org-settings-field-container.oc-input.group
-              [:input.org-settings-field.email-domain-field
-                {:type "text"
-                 :placeholder "@domain.com"
-                 :auto-capitalize "none"
-                 :value (:domain um-domain-invite)
-                 :pattern "@?[a-z0-9.-]+\\.[a-z]{2,4}$"
-                 :on-change #(dis/dispatch! [:input [:um-domain-invite :domain] (.. % -target -value)])
-                 :on-key-press (fn [e]
-                                 (when (= (.-key e) "Enter")
-                                   (let [domain (:domain um-domain-invite)]
-                                     (when (utils/valid-domain? domain)
-                                       (team-actions/email-domain-team-add domain email-domain-added)))))}]
-              [:button.mlb-reset.add-email-domain-bt
-                {:disabled (not (utils/valid-domain? (:domain um-domain-invite)))
-                 :on-click (fn [e]
-                             (let [domain (:domain um-domain-invite)]
-                               (when (utils/valid-domain? domain)
-                                 (team-actions/email-domain-team-add domain email-domain-added))))}
-                "Add"]]
-            [:div.org-settings-email-domains
-              (for [domain (:email-domains team-data)]
-                [:div.org-settings-email-domain-row
-                  {:key (str "org-settings-domain-" domain)}
-                  (str "@" (:domain domain))
-                  (when (utils/link-for (:links domain) "remove")
-                    [:button.mlb-reset.remove-email-bt
-                      {:on-click #(remove-email-domain-prompt domain)}
-                      "Remove"])])]]
+            (email-domains)]
           (if-not @(::show-advanced-settings s)
             [:div.org-settings-advanced
               [:button.mlb-reset.advanced-settings-bt

--- a/src/oc/web/components/ui/email_domains.cljs
+++ b/src/oc/web/components/ui/email_domains.cljs
@@ -4,6 +4,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.mixins.ui :as ui-mixins]
+            [oc.web.lib.responsive :as responsive]
             [oc.web.actions.team :as team-actions]
             [oc.web.components.ui.alert-modal :as alert-modal]
             [oc.web.actions.notifications :as notification-actions]))
@@ -41,13 +42,14 @@
                            (drv/drv :org-settings-team-management)
                            ui-mixins/refresh-tooltips-mixin
   [s]
-  (let [{:keys [um-domain-invite team-data]} (drv/react s :org-settings-team-management)]
+  (let [{:keys [um-domain-invite team-data]} (drv/react s :org-settings-team-management)
+        is-mobile? (responsive/is-mobile-size?)]
     [:div.email-domain-container
       [:div.email-domain-title
         "Allowed email domains"
         [:i.mdi.mdi-information-outline
           {:title "Any user that signs up with an allowed email domain and verifies their email address will have contributor access to your team."
-           :data-toggle (when-not is-tablet-or-mobile? "tooltip")
+           :data-toggle (when-not is-mobile? "tooltip")
            :data-placement "top"
            :data-container "body"}]]
       [:div.email-domain-field-container.oc-input.group

--- a/src/oc/web/components/ui/email_domains.cljs
+++ b/src/oc/web/components/ui/email_domains.cljs
@@ -1,0 +1,81 @@
+(ns oc.web.components.ui.email-domains
+  (:require [rum.core :as rum]
+            [org.martinklepsch.derivatives :as drv]
+            [oc.web.dispatcher :as dis]
+            [oc.web.lib.utils :as utils]
+            [oc.web.mixins.ui :as ui-mixins]
+            [oc.web.actions.team :as team-actions]
+            [oc.web.components.ui.alert-modal :as alert-modal]
+            [oc.web.actions.notifications :as notification-actions]))
+
+(defn email-domain-removed [success?]
+  (notification-actions/show-notification
+   {:title (if success? "Email domain successfully removed" "Error")
+    :description (when-not success? "An error occurred while removing the email domain, please try again.")
+    :expire 3
+    :id (if success? :email-domain-remove-success :email-domain-remove-error)
+    :dismiss true}))
+
+(defn email-domain-added [success?]
+  (notification-actions/show-notification
+   {:title (if success? "Email domain successfully added" "Error")
+    :description (when-not success? "An error occurred while adding the email domain, please try again.")
+    :expire 3
+    :id (if success? :email-domain-add-success :email-domain-add-error)
+    :dismiss true}))
+
+(defn remove-email-domain-prompt [domain]
+  (let [alert-data {:icon "/img/ML/trash.svg"
+                    :action "org-email-domain-remove"
+                    :message "Are you sure you want to remove this email domain?"
+                    :link-button-title "Keep"
+                    :link-button-cb #(alert-modal/hide-alert)
+                    :solid-button-style :red
+                    :solid-button-title "Yes"
+                    :solid-button-cb #(do
+                                        (alert-modal/hide-alert)
+                                        (team-actions/remove-team (:links domain) email-domain-removed))}]
+    (alert-modal/show-alert alert-data)))
+
+(rum/defcs email-domains < rum/reactive
+                           (drv/drv :org-settings-team-management)
+                           ui-mixins/refresh-tooltips-mixin
+  [s]
+  (let [{:keys [um-domain-invite team-data]} (drv/react s :org-settings-team-management)]
+    [:div.email-domain-container
+      [:div.email-domain-title
+        "Allowed email domains"
+        [:i.mdi.mdi-information-outline
+          {:title "Any user that signs up with an allowed email domain and verifies their email address will have contributor access to your team."
+           :data-toggle (when-not is-tablet-or-mobile? "tooltip")
+           :data-placement "top"
+           :data-container "body"}]]
+      [:div.email-domain-field-container.oc-input.group
+        [:input.email-domain-field
+          {:type "text"
+           :placeholder "@domain.com"
+           :auto-capitalize "none"
+           :value (:domain um-domain-invite)
+           :pattern "@?[a-z0-9.-]+\\.[a-z]{2,4}$"
+           :on-change #(dis/dispatch! [:input [:um-domain-invite :domain] (.. % -target -value)])
+           :on-key-press (fn [e]
+                           (when (= (.-key e) "Enter")
+                             (let [domain (:domain um-domain-invite)]
+                               (when (utils/valid-domain? domain)
+                                 (team-actions/email-domain-team-add domain email-domain-added)))))}]
+        [:button.mlb-reset.add-email-domain-bt
+          {:disabled (not (utils/valid-domain? (:domain um-domain-invite)))
+           :on-click (fn [e]
+                       (let [domain (:domain um-domain-invite)]
+                         (when (utils/valid-domain? domain)
+                           (team-actions/email-domain-team-add domain email-domain-added))))}
+          "Add"]]
+      [:div.email-domain-list
+        (for [domain (:email-domains team-data)]
+          [:div.email-domain-row
+            {:key (str "org-settings-domain-" domain)}
+            (str "@" (:domain domain))
+            (when (utils/link-for (:links domain) "remove")
+              [:button.mlb-reset.remove-email-bt
+                {:on-click #(remove-email-domain-prompt domain)}
+                "Remove"])])]]))


### PR DESCRIPTION
Card: https://trello.com/c/6PCsVUP9

To test:
- open menu
- click on Admin settings
- check you can add an email domain
- check you can delete an email domain
- now from the menu click on Invite people
- check you can add/delete email domains from here too
- open Invite via Slack
- is "Invite someone with a specific role" bold?
- same for Invite via email?