### PR TITLE
Fix disappearing placeholder

### DIFF
--- a/scss/partials/_add_comment.scss
+++ b/scss/partials/_add_comment.scss
@@ -8,6 +8,10 @@ div.add-comment-box-container {
       cursor: text;
       padding: 12px 16px;
 
+      p:first-child {
+        display: none;
+      }
+
       @include mobile() {
         padding: 11px 14px;
       }

--- a/scss/partials/_cmail.scss
+++ b/scss/partials/_cmail.scss
@@ -91,6 +91,10 @@ div.cmail-outer {
               div.rich-body-editor {
                 margin-top: 0;
                 min-height: 24px;
+
+                p:first-child {
+                  display: none;
+                }
               }
             }
           }

--- a/src/oc/web/components/cmail.cljs
+++ b/src/oc/web/components/cmail.cljs
@@ -401,7 +401,7 @@
                           cmail-state @(drv/get-ref s :cmail-state)
                           initial-body (if (seq (:body cmail-data))
                                          (:body cmail-data)
-                                         "")
+                                         dom-utils/empty-body-html)
                           initial-headline (utils/emojify
                                              (if (seq (:headline cmail-data))
                                                (:headline cmail-data)

--- a/src/oc/web/components/ui/add_comment.cljs
+++ b/src/oc/web/components/ui/add_comment.cljs
@@ -55,7 +55,7 @@
         save-done-cb (fn [success]
                       (if success
                         (when add-comment-div
-                          (set! (.-innerHTML add-comment-div) ""))
+                          (set! (.-innerHTML add-comment-div) dom-utils/empty-body-html))
                         (notification-actions/show-notification
                          {:title "An error occurred while saving your comment."
                           :description "Please try again"
@@ -63,7 +63,7 @@
                           :expire 3
                           :id (if edit-comment-data :update-comment-error :add-comment-error)})))]
     (reset! (::add-button-disabled s) true)
-    (set! (.-innerHTML add-comment-div) "")
+    (set! (.-innerHTML add-comment-div) dom-utils/empty-body-html)
     (if edit-comment-data
       (comment-actions/save-comment activity-data edit-comment-data comment-body save-done-cb)
       (comment-actions/add-comment activity-data comment-body parent-comment-uuid save-done-cb))
@@ -160,7 +160,7 @@
                          (drv/drv :attachment-uploading)
                          ;; Locals
                          (rum/local true ::add-button-disabled)
-                         (rum/local "" ::initial-add-comment)
+                         (rum/local dom-utils/empty-body-html ::initial-add-comment)
                          (rum/local false ::did-change)
                          (rum/local false ::show-post-button)
                          (rum/local false ::last-add-comment-focus)
@@ -185,7 +185,7 @@
                                 add-comment-data @(drv/get-ref s :add-comment-data)
                                 add-comment-key (dis/add-comment-string-key (:uuid activity-data) parent-comment-uuid (:uuid edit-comment-data))
                                 activity-add-comment-data (get add-comment-data add-comment-key)]
-                            (reset! (::initial-add-comment s) (or activity-add-comment-data ""))
+                            (reset! (::initial-add-comment s) (or activity-add-comment-data dom-utils/empty-body-html))
                             (reset! (::show-post-button s) (or (seq activity-add-comment-data) (should-focus-field? s)))
                             (when (seq activity-add-comment-data)
                               (reset! (::did-change s) true)))
@@ -234,7 +234,7 @@
                                      (not parent-comment-uuid)
                                      (not @(::show-post-button s))
                                      (not is-focused?)
-                                     (not (seq @(::initial-add-comment s))))
+                                     (= @(::initial-add-comment s) dom-utils/empty-body-html))
         is-mobile? (responsive/is-mobile-size?)
         attachment-uploading (drv/react s :attachment-uploading)
         uploading? (and attachment-uploading

--- a/src/oc/web/utils/dom.cljs
+++ b/src/oc/web/utils/dom.cljs
@@ -33,3 +33,5 @@
       (and (>= (+ (.-top rect) fixed-offset) responsive/navbar-height)
            ;; and less than the screen height
            (< (- (.-top rect) fixed-offset) win-height))))
+
+(def empty-body-html "<p><br/></>")


### PR DESCRIPTION
Card: https://trello.com/c/2ISZFUiS

Not really "urgent" since it's not blocking or causing big issues. It's just annoying that drafts are automatically auto-saved when you expand QP (meaning you are going to have a lot more drafts than you would expect).

NB: this is causing also another issue: when you click on QP to start writing it saves right away. It happens because the initial body is empty (ie: "") but as soon as you focus it ME initialize it with an empty paragraph which is seen as a change action.
Initializing the editor with an empty paragraph from the beginning prevents this behavior.

To test QP:
- open app
- do you see the placeholder on QP?
- do you see the MediaPicker buttons?
- click on QP
- did it expand?
- placeholder still visible?
- did it NOT autosave?
- type something
- did it autosave?
- placeholder went away?
- test a few things like: board switching, add media, fullscreen switching/editing, publish etc

To test add comment field:
- open app
- click on a post
- is add comment visible but collapsed?
- do you see the placeholder?
- click on it
- placeholder still visible?
- type something
- placeholder went away
- type some more
- click back arrow
- re-open the same post
- do you see your typed comment still in the field?
- is the add comment expanded (post button is visible)?
- post a comment
- repeat the cache test with a reply field
- do some more testing around comments: comment/reply with media, post, edit, delete etc...