### PR TITLE
Store UTM creds in org

### DIFF
--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -153,7 +153,7 @@ rangy.getSelection = function(){};
 var jwt_decode = function(){};
 // CarrotGA
 var CarrotGA = function(){};
-CarrotGA.dimentions = {};
+CarrotGA.dimensions = {};
 CarrotGA.metrics = {};
 CarrotGA.init = function(){};
 CarrotGA.trackEvent = function(){};

--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -195,6 +195,7 @@ var Intercom = function(){};
 var OCWebSetupStaticPagesJS = function(){};
 var OCStaticShowAnimationLightbox = function(){};
 var OCStaticHideAnimationLightbox = function(){};
+var OCStaticDeleteCookie = function(){};
 var OCYTVideoInit = function(){};
 // Integrations panel
 var OCWebStaticOpenIntegrationsPanel = function() {};

--- a/resources/public/js/static-js.js
+++ b/resources/public/js/static-js.js
@@ -48,6 +48,10 @@ function OCStaticCookieName(name){
   return prefix + name;
 }
 
+function OCStaticDeleteCookie(name) {
+  document.cookie = OCStaticCookieName(name) + "=;expires=Thu Jan 01 1970 01:00:00 UTC;path=/;";
+}
+
 function OCStaticGetDecodedJWT(jwt) {
   if (jwt && typeof jwt_decode === "function") {
     try {

--- a/resources/public/lib/autotrack/google-analytics.js
+++ b/resources/public/lib/autotrack/google-analytics.js
@@ -168,10 +168,13 @@ var CarrotGASetCookie = function(name, value) {
 
 // Get the utm URL parameters and store them in a cookie if they exist
 var CarrotGAStoreUTMQueryParameters = function() {
-  CarrotGASetCookie('utm_source', CarrotGAGetParameterByName('utm_source'));
-  CarrotGASetCookie('utm_medium', CarrotGAGetParameterByName('utm_medium'));
-  CarrotGASetCookie('utm_term', CarrotGAGetParameterByName('utm_term'));
-  CarrotGASetCookie('utm_campaign', CarrotGAGetParameterByName('utm_campaign'));
+  function storeParameter(name) {
+    CarrotGASetCookie(OCStaticCookieName(name), CarrotGAGetParameterByName(name));
+  }
+  storeParameter('utm_source');
+  storeParameter('utm_medium');
+  storeParameter('utm_term');
+  storeParameter('utm_campaign');
 };
 
 window.CarrotGA = {

--- a/resources/public/lib/autotrack/google-analytics.js
+++ b/resources/public/lib/autotrack/google-analytics.js
@@ -2,23 +2,23 @@ var NULL_VALUE = '(not set)';
 var TRACKING_VERSION = 'dev';
 var TRACKING_ID = 'UA-113733066-1';
 
-var uuid = function b(a) {
+var CarrotGAUuid = function b(a) {
   return a ? (a ^ Math.random() * 16 >> a / 4).toString(16) :
     ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, b);
 };
 
-var getDefinitionIndex = function(definition) {
+var CarrotGAGetDefinitionIndex = function(definition) {
   +/\d+$/.exec(definition)[0];
 };
 
-var createTracker = function(version, tracking_id) {
+var CarrotGACreateTracker = function(version, tracking_id) {
   var version = version || 'dev';
   var tracking_id = tracking_id || '';
   ga('create', tracking_id, 'auto');
   ga('set', 'transport', 'beacon');
 };
 
-var trackCustomDimensions = function() {
+var CarrotGATrackCustomDimensions = function() {
   // Sets a default dimension value for all custom dimensions to ensure
   // that every dimension in every hit has *some* value. This is necessary
   // because Google Analytics will drop rows with empty dimension values
@@ -32,7 +32,7 @@ var trackCustomDimensions = function() {
     params[CarrotGA.dimensions.TRACKING_VERSION] = TRACKING_VERSION;
     CarrotGA.clientid = tracker.get('clientId');
     params[CarrotGA.dimensions.CLIENT_ID] = tracker.get('clientId');
-    params[CarrotGA.dimensions.WINDOW_ID] = uuid();
+    params[CarrotGA.dimensions.WINDOW_ID] = CarrotGAUuid();
     tracker.set(params);
   });
 
@@ -53,7 +53,7 @@ var trackCustomDimensions = function() {
   });
 };
 
-var requireAutotrackPlugins = function() {
+var CarrotGARequireAutotrackPlugins = function() {
   ga('require', 'cleanUrlTracker', {
     stripQuery: true,
     queryDimensionIndex:
@@ -85,13 +85,13 @@ var requireAutotrackPlugins = function() {
   });
 };
 
-var sendNavigationTimingMetrics = function() {
+var CarrotGASendNavigationTimingMetrics = function() {
   // Only track performance in supporting browsers.
   if (!(window.performance && window.performance.timing)) return;
 
   // If the window hasn't loaded, run this function after the `load` event.
   if (document.readyState != 'complete') {
-    window.addEventListener('load', sendNavigationTimingMetrics);
+    window.addEventListener('load', CarrotGASendNavigationTimingMetrics);
     return;
   }
 
@@ -128,7 +128,7 @@ var sendNavigationTimingMetrics = function() {
 
 // Rewrite the URL to remove any utm_* parameters
 // source: https://stackoverflow.com/questions/48506722/remove-utm-parameters-from-url
-var removeUTMQueryParameters = function() {
+var CarrotGARemoveUTMQueryParameters = function() {
   function paramIsNotUtm(param) { return param.slice(0, 4) !== 'utm_'; }
   if (history && history.replaceState && location.search) {
     var params = location.search.slice(1).split('&');
@@ -143,7 +143,7 @@ var removeUTMQueryParameters = function() {
 
 // Get URL parameters by their name
 // source: https://code.broker/en/tutorials/store-utm-and-other-tracking-links-url-parameters-in-a-cookie/
-var getParameterByName = function(name) {
+var CarrotGAGetParameterByName = function(name) {
   var params = window.location.search.substr(1).split('&');
   for (var i = 0; i < params.length; i++) {
     var p=params[i].split('=');
@@ -157,7 +157,7 @@ var getParameterByName = function(name) {
 // Given a cookie name and value, set the cookie to the value unless the cookie
 // already contains a value, or the value is null
 // source: https://stackoverflow.com/questions/32497923/how-to-get-this-cookie-to-expire-after-14-days
-var setCookie = function(name, value) {
+var CarrotGASetCookie = function(name, value) {
   if (value != null) {
     var today = new Date();
     var expire = new Date();
@@ -168,13 +168,13 @@ var setCookie = function(name, value) {
 
 // Get the utm URL parameters and store them in a cookie if they exist
 var storeUTMQueryParameters = function() {
-  setCookie('utm_source', getParameterByName('utm_source'));
-  setCookie('utm_medium', getParameterByName('utm_medium'));
-  setCookie('utm_term', getParameterByName('utm_term'));
-  setCookie('utm_campaign', getParameterByName('utm_campaign'));
+  CarrotGASetCookie('utm_source', CarrotGAGetParameterByName('utm_source'));
+  CarrotGASetCookie('utm_medium', CarrotGAGetParameterByName('utm_medium'));
+  CarrotGASetCookie('utm_term', CarrotGAGetParameterByName('utm_term'));
+  CarrotGASetCookie('utm_campaign', CarrotGAGetParameterByName('utm_campaign'));
 };
 
-var CarrotGA = {
+window.CarrotGA = {
 
   NULL_VALUE: '(not set)',
 
@@ -210,12 +210,12 @@ var CarrotGA = {
     if (tracking_id) {
       TRACKING_ID = tracking_id;
     }
-    createTracker(TRACKING_VERSION, TRACKING_ID);
-    trackCustomDimensions();
-    requireAutotrackPlugins();
-    sendNavigationTimingMetrics();
-    storeUTMQueryParameters();
-    removeUTMQueryParameters();
+    CarrotGACreateTracker(TRACKING_VERSION, TRACKING_ID);
+    CarrotGATrackCustomDimensions();
+    CarrotGARequireAutotrackPlugins();
+    CarrotGASendNavigationTimingMetrics();
+    CarrotGAStoreUTMQueryParameters();
+    CarrotGARemoveUTMQueryParameters();
   },
 
   /* Track an event */

--- a/resources/public/lib/autotrack/google-analytics.js
+++ b/resources/public/lib/autotrack/google-analytics.js
@@ -57,14 +57,14 @@ var CarrotGARequireAutotrackPlugins = function() {
   ga('require', 'cleanUrlTracker', {
     stripQuery: true,
     queryDimensionIndex:
-      getDefinitionIndex(CarrotGA.dimensions.URL_QUERY_PARAMS),
+      CarrotGAGetDefinitionIndex(CarrotGA.dimensions.URL_QUERY_PARAMS),
     trailingSlash: 'remove',
   });
   ga('require', 'maxScrollTracker', {
     sessionTimeout: 30,
     timeZone: 'America/New_York',
     maxScrollMetricIndex:
-    getDefinitionIndex(CarrotGA.metrics.MAX_SCROLL_PERCENTAGE),
+    CarrotGAGetDefinitionIndex(CarrotGA.metrics.MAX_SCROLL_PERCENTAGE),
   });
   ga('require', 'outboundLinkTracker', {
     events: ['click', 'contextmenu'],
@@ -73,8 +73,8 @@ var CarrotGARequireAutotrackPlugins = function() {
   objs[CarrotGA.dimensions.HIT_SOURCE] = 'pageVisibilityTracker';
   ga('require', 'pageVisibilityTracker', {
     sendInitialPageview: true,
-    pageLoadsMetricIndex: getDefinitionIndex(CarrotGA.metrics.PAGE_LOADS),
-    visibleMetricIndex: getDefinitionIndex(CarrotGA.metrics.PAGE_VISIBLE),
+    pageLoadsMetricIndex: CarrotGAGetDefinitionIndex(CarrotGA.metrics.PAGE_LOADS),
+    visibleMetricIndex: CarrotGAGetDefinitionIndex(CarrotGA.metrics.PAGE_VISIBLE),
     timeZone: 'America/New_York',
     fieldsObj: objs,
   });

--- a/resources/public/lib/autotrack/google-analytics.js
+++ b/resources/public/lib/autotrack/google-analytics.js
@@ -167,7 +167,7 @@ var CarrotGASetCookie = function(name, value) {
 };
 
 // Get the utm URL parameters and store them in a cookie if they exist
-var storeUTMQueryParameters = function() {
+var CarrotGAStoreUTMQueryParameters = function() {
   CarrotGASetCookie('utm_source', CarrotGAGetParameterByName('utm_source'));
   CarrotGASetCookie('utm_medium', CarrotGAGetParameterByName('utm_medium'));
   CarrotGASetCookie('utm_term', CarrotGAGetParameterByName('utm_term'));

--- a/site/oc/pages.clj
+++ b/site/oc/pages.clj
@@ -224,13 +224,13 @@
           ;; Google Analytics
           [:script {:type "text/javascript" :src "https://www.google-analytics.com/analytics.js"}]
           [:script {:type "text/javascript" :src "/lib/autotrack/autotrack.js"}]
+          ;; Static js files
+          [:script {:type "text/javascript" :src (shared/cdn "/js/static-js.js")}]
           [:script {:type "text/javascript" :src "/lib/autotrack/google-analytics.js"}]
           (google-analytics-init)
           ;; jQuery needed by Bootstrap JavaScript
           jquery
           ie-jquery-fix
-          ;; Static js files
-          [:script {:type "text/javascript" :src (shared/cdn "/js/static-js.js")}]
           ;; Truncate html string
           [:script {:type "text/javascript" :src "/lib/truncate/jquery.dotdotdot.js"}]
           ;; Rangy

--- a/site/oc/pages.clj
+++ b/site/oc/pages.clj
@@ -221,16 +221,16 @@
           [:div#oc-notifications-container]
           [:div#oc-loading]
           [:div.preload-interstitial]
-          ;; Google Analytics
-          [:script {:type "text/javascript" :src "https://www.google-analytics.com/analytics.js"}]
-          [:script {:type "text/javascript" :src "/lib/autotrack/autotrack.js"}]
-          ;; Static js files
-          [:script {:type "text/javascript" :src (shared/cdn "/js/static-js.js")}]
-          [:script {:type "text/javascript" :src "/lib/autotrack/google-analytics.js"}]
-          (google-analytics-init)
           ;; jQuery needed by Bootstrap JavaScript
           jquery
           ie-jquery-fix
+          ;; Static js files
+          [:script {:type "text/javascript" :src (shared/cdn "/js/static-js.js")}]
+          ;; Google Analytics
+          [:script {:type "text/javascript" :src "https://www.google-analytics.com/analytics.js"}]
+          [:script {:type "text/javascript" :src "/lib/autotrack/autotrack.js"}]
+          [:script {:type "text/javascript" :src "/lib/autotrack/google-analytics.js"}]
+          (google-analytics-init)
           ;; Truncate html string
           [:script {:type "text/javascript" :src "/lib/truncate/jquery.dotdotdot.js"}]
           ;; Rangy

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -339,8 +339,9 @@
         term (cook/read-cookie "utm_term")
         medium (cook/read-cookie "utm_medium")
         campaign (cook/read-cookie "utm_campaign")]
-    (doseq [name ["utm_source" "utm_term" "utm_medium" "utm_campaign"]]
-      (cook/delete-cookie! name "/" ls/web-server))
+    (doseq [c-name ["utm_source" "utm_term" "utm_medium" "utm_campaign"]]
+      (js/console.log "DBG deleting utm cookie:" c-name)
+      (js/console.log "DBG    ->" (cook/delete-cookie! c-name "/" ls/web-server)))
     (if (or source term medium campaign)
       (merge org-data {:utm-data {:utm-source (or source "")
                                   :utm-term (or term "")

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -9,7 +9,6 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
-            [oc.web.local-settings :as ls]
             [oc.web.actions.comment :as ca]
             [oc.web.actions.section :as sa]
             [oc.web.actions.activity :as aa]
@@ -335,13 +334,13 @@
   Remove utm cookies if present.
   "
   [org-data]
-  (let [source (cook/read-cookie "utm_source")
-        term (cook/read-cookie "utm_term")
-        medium (cook/read-cookie "utm_medium")
-        campaign (cook/read-cookie "utm_campaign")]
+  (let [source (cook/get-cookie "utm_source")
+        term (cook/get-cookie "utm_term")
+        medium (cook/get-cookie "utm_medium")
+        campaign (cook/get-cookie "utm_campaign")]
     (doseq [c-name ["utm_source" "utm_term" "utm_medium" "utm_campaign"]]
       (js/console.log "DBG deleting utm cookie:" c-name)
-      (js/console.log "DBG    ->" (cook/delete-cookie! c-name "/" ls/web-server)))
+      (js/console.log "DBG    ->" (cook/remove-cookie! c-name)))
     (if (or source term medium campaign)
       (merge org-data {:utm-data {:utm-source (or source "")
                                   :utm-term (or term "")

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -339,8 +339,7 @@
         medium (cook/get-cookie "utm_medium")
         campaign (cook/get-cookie "utm_campaign")]
     (doseq [c-name ["utm_source" "utm_term" "utm_medium" "utm_campaign"]]
-      (js/console.log "DBG deleting utm cookie:" c-name)
-      (js/console.log "DBG    ->" (cook/remove-cookie! c-name)))
+      (js/OCStaticDeleteCookie c-name))
     (if (or source term medium campaign)
       (merge org-data {:utm-data {:utm-source (or source "")
                                   :utm-term (or term "")

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -9,6 +9,7 @@
             [oc.web.dispatcher :as dis]
             [oc.web.lib.utils :as utils]
             [oc.web.lib.cookies :as cook]
+            [oc.web.local-settings :as ls]
             [oc.web.actions.comment :as ca]
             [oc.web.actions.section :as sa]
             [oc.web.actions.activity :as aa]
@@ -339,7 +340,7 @@
         medium (cook/read-cookie "utm_medium")
         campaign (cook/read-cookie "utm_campaign")]
     (doseq [name ["utm_source" "utm_term" "utm_medium" "utm_campaign"]]
-      (cook/delete-cookie! name))
+      (cook/delete-cookie! name "/" ls/web-server))
     (if (or source term medium campaign)
       (merge org-data {:utm-data {:utm-source (or source "")
                                   :utm-term (or term "")

--- a/src/oc/web/actions/org.cljs
+++ b/src/oc/web/actions/org.cljs
@@ -327,6 +327,26 @@
   [s n]
   (subs s 0 (min (count s) n)))
 
+(defn- add-utm-data
+  "
+  Augment org data with utm values stored in cookies.
+
+  Remove utm cookies if present.
+  "
+  [org-data]
+  (let [source (cook/read-cookie "utm_source")
+        term (cook/read-cookie "utm_term")
+        medium (cook/read-cookie "utm_medium")
+        campaign (cook/read-cookie "utm_campaign")]
+    (doseq [name ["utm_source" "utm_term" "utm_medium" "utm_campaign"]]
+      (cook/delete-cookie! name))
+    (if (or source term medium campaign)
+      (merge org-data {:utm-data {:utm-source (or source "")
+                                  :utm-term (or term "")
+                                  :utm-medium (or medium "")
+                                  :utm-campaign (or campaign "")}})
+      org-data)))
+
 (defn create-or-update-org [org-data]
   (dis/dispatch! [:input [:org-editing :error] false])
   (let [email-domain (:email-domain org-data)
@@ -341,7 +361,7 @@
       (let [org-patch-link (utils/link-for (:links (dis/org-data)) "partial-update")]
         (api/patch-org org-patch-link clean-org-data (partial org-update-cb email-domain)))
       (let [create-org-link (utils/link-for (dis/api-entry-point) "create")]
-        (api/create-org create-org-link clean-org-data (partial org-create-cb email-domain))))))
+        (api/create-org create-org-link (add-utm-data clean-org-data) (partial org-create-cb email-domain))))))
 
 ;; Org edit
 

--- a/src/oc/web/api.cljs
+++ b/src/oc/web/api.cljs
@@ -231,7 +231,7 @@
 
 ;; Allowed keys
 
-(def org-allowed-keys [:name :logo-url :logo-width :logo-height :content-visibility :why-carrot])
+(def org-allowed-keys [:name :logo-url :logo-width :logo-height :content-visibility :why-carrot :utm-data])
 
 (def entry-allowed-keys [:headline :body :abstract :attachments :video-id :video-error :board-slug :status :must-see :polls])
 

--- a/src/oc/web/lib/cookies.cljs
+++ b/src/oc/web/lib/cookies.cljs
@@ -31,8 +31,11 @@
 
 (defn delete-cookie!
   "Delete a cookie with the exact name provided."
-  [c-name]
-  (.remove cookies-static-obj c-name "/" ls/jwt-cookie-domain))
+  ([c-name]
+   (.remove cookies-static-obj c-name))
+
+  ([c-name opt-path opt-domain]
+   (.remove cookies-static-obj c-name opt-path opt-domain)))
 
 (defn remove-cookie!
   "Remove a cookie with the name provided pre-fixed by the environment."

--- a/src/oc/web/lib/cookies.cljs
+++ b/src/oc/web/lib/cookies.cljs
@@ -24,19 +24,6 @@
   [c-name]
   (.get cookies-static-obj (cookie-name c-name)))
 
-(defn ^:export read-cookie
-  "Read a cookie with the exact name provided."
-  [c-name]
-  (.get cookies-static-obj c-name))
-
-(defn ^:export delete-cookie!
-  "Delete a cookie with the exact name provided."
-  ([c-name]
-   (.remove cookies-static-obj c-name))
-
-  ([c-name opt-path opt-domain]
-   (.remove cookies-static-obj c-name opt-path opt-domain)))
-
 (defn remove-cookie!
   "Remove a cookie with the name provided pre-fixed by the environment."
   ([c-name]

--- a/src/oc/web/lib/cookies.cljs
+++ b/src/oc/web/lib/cookies.cljs
@@ -32,7 +32,7 @@
 (defn delete-cookie!
   "Delete a cookie with the exact name provided."
   [c-name]
-  (.remove cookies-static-obj c-name))
+  (.remove cookies-static-obj c-name "/" ls/jwt-cookie-domain))
 
 (defn remove-cookie!
   "Remove a cookie with the name provided pre-fixed by the environment."

--- a/src/oc/web/lib/cookies.cljs
+++ b/src/oc/web/lib/cookies.cljs
@@ -24,12 +24,12 @@
   [c-name]
   (.get cookies-static-obj (cookie-name c-name)))
 
-(defn read-cookie
+(defn ^:export read-cookie
   "Read a cookie with the exact name provided."
   [c-name]
   (.get cookies-static-obj c-name))
 
-(defn delete-cookie!
+(defn ^:export delete-cookie!
   "Delete a cookie with the exact name provided."
   ([c-name]
    (.remove cookies-static-obj c-name))

--- a/src/oc/web/lib/cookies.cljs
+++ b/src/oc/web/lib/cookies.cljs
@@ -19,11 +19,25 @@
   ([c-name c-value expiry c-path c-domain c-secure]
     (.set cookies-static-obj (cookie-name c-name) c-value expiry c-path c-domain c-secure)))
 
-(defn get-cookie [c-name]
+(defn get-cookie
+  "Get a cookie with the name provided pre-fixed by the environment."
+  [c-name]
   (.get cookies-static-obj (cookie-name c-name)))
 
+(defn read-cookie
+  "Read a cookie with the exact name provided."
+  [c-name]
+  (.get cookies-static-obj c-name))
+
+(defn delete-cookie!
+  "Delete a cookie with the exact name provided."
+  [c-name]
+  (.remove cookies-static-obj c-name))
+
 (defn remove-cookie!
+  "Remove a cookie with the name provided pre-fixed by the environment."
   ([c-name]
-    (remove-cookie! (name c-name) "/"))
+  (remove-cookie! (name c-name) "/"))
+  
   ([c-name opt-path]
-    (.remove cookies-static-obj (cookie-name c-name) opt-path ls/jwt-cookie-domain)))
+  (.remove cookies-static-obj (cookie-name c-name) opt-path ls/jwt-cookie-domain)))


### PR DESCRIPTION
This is the master PR.

Also [support](https://github.com/belucid/open-company-support/pull/3) and [storage](https://github.com/open-company/open-company-storage/pull/249).

To test:

Go to the landing page with UTM params, e.g.

`localhost:3559/?utm_campaign=foo&utm_term=bar&utm_source=foobar&utm_medium=message`

- Clean your DB
- [x] Notice that the params are written to cookies
- [x] Notice that the URL was cleaned up
- Signup a new org via Slack
- [x] Check that the UTM cookies are gone
- [x] Check the org in the DB and see the UTM values
- [x] Check stabejo and see the UTM values

- Clean your DB again
- Repeat the steps above, but with an email signup, and only some of the UTM params, e.g.

`localhost:3559/?utm_campaign=foo&utm_term=bar`

- [x] Check that the UTM cookies are gone
- [x] Check the org in the DB and see the UTM values
- [x] Check stabejo and see the UTM values


- Clean your DB again
- Repeat the steps above, but with an email signup, and no UTM params, e.g.

`localhost:3559/`

- [x] Check that there are no  UTM cookies
- [x] Check the org in the DB and see there are no UTM values
- [x] Check stabejo and see there is no mention of UTM values

- Merge branches
- Deploy
- Eat a big sandwich
