### PR TITLE
Fix timezone error

### DIFF
--- a/scss/partials/_user_profile_modal.scss
+++ b/scss/partials/_user_profile_modal.scss
@@ -247,7 +247,7 @@ div.user-profile-modal-container {
           outline: none;
 
           @include placeholder(){
-            color: var(--light-color);
+            color: var(--ultralight-color);
           }
 
           &:focus, &:active {

--- a/src/oc/web/components/user_profile_modal.cljs
+++ b/src/oc/web/components/user_profile_modal.cljs
@@ -141,7 +141,9 @@
    :title
    "CEO, CTO, Designer, Engineer..."
    :location
-   "ie: New York, NY"
+   "e.g. New York, NY"
+   :blurb
+   "Fascinating facts..."
    ""))
 
 (defn- default-value [k]

--- a/src/oc/web/components/user_profile_modal.cljs
+++ b/src/oc/web/components/user_profile_modal.cljs
@@ -141,7 +141,7 @@
    :title
    "CEO, CTO, Designer, Engineer..."
    :location
-   "New York, NY"
+   "ie: New York, NY"
    ""))
 
 (defn- default-value [k]
@@ -189,6 +189,7 @@
         current-user-data (:user-data user-profile-data)
         user-for-avatar (merge current-user-data {:avatar-url edit-user-profile-avatar})
         timezones (.names (.-tz js/moment))
+        guessed-timezone (.. js/moment -tz guess)
         show-password? (= (:auth-source current-user-data) "email")
         links-tab-index (atom 5)]
     [:div.user-profile-modal-container
@@ -314,7 +315,7 @@
                  :tab-index 5
                  :on-change #(change! s [:timezone] (.. % -target -value))}
                 ;; Promoted timezones
-                (for [t ["US/Eastern" "US/Central" "US/Mountain" "US/Pacific"]]
+                (for [t (remove nil? ["US/Eastern" "US/Central" "US/Mountain" "US/Pacific" guessed-timezone])]
                   [:option
                     {:key (str "timezone-" t "-promoted")
                      :value t} t])

--- a/src/oc/web/utils/user.cljs
+++ b/src/oc/web/utils/user.cljs
@@ -183,18 +183,21 @@
     (utils/time-without-leading-zeros localized-time)))
 
 (defn timezone-location-string [user-data & [local-time-string?]]
-  (str
-   (when-let [twt (time-with-timezone (:timezone user-data))]
-     (str
-      twt
-      (when local-time-string?
-        " local time")))
-   (if (seq (:location user-data))
-     (if (seq (:timezone user-data))
-       (str " (" (:location user-data) ")")
-       (:location user-data))
-     (when (seq (:timezone user-data))
-       (str (:timezone user-data))))))
+  (let [twt (time-with-timezone (:timezone user-data))]
+    (str
+     (when (seq twt)
+       (str
+        twt
+        (when local-time-string?
+          " local time")))
+     (if (seq (:location user-data))
+       (if (seq twt)
+         (str " (" (:location user-data) ")")
+         (:location user-data))
+       (when (seq (:timezone user-data))
+         (if (seq twt)
+           (str " (" (:timezone user-data) ")")
+           (str (:timezone user-data))))))))
 
 (defun active?
   ([user :guard map?] (active? (:status user)))

--- a/src/oc/web/utils/user.cljs
+++ b/src/oc/web/utils/user.cljs
@@ -169,12 +169,15 @@
 
 (defn time-with-timezone [timezone]
   (utils/time-without-leading-zeros
-    (.toLocaleTimeString (js/Date.)
-     (.. js/window -navigator -language)
-     #js {:hour "2-digit"
-          :minute "2-digit"
-          :format "hour:minute"
-          :timeZone timezone})))
+    (try
+     (.toLocaleTimeString (js/Date.)
+      (.. js/window -navigator -language)
+      #js {:hour "2-digit"
+           :minute "2-digit"
+           :format "hour:minute"
+           :timeZone timezone})
+     (catch :default e
+      nil))))
 
 (defn timezone-location-string [user-data & [local-time-string?]]
   (str

--- a/src/oc/web/utils/user.cljs
+++ b/src/oc/web/utils/user.cljs
@@ -167,31 +167,34 @@
     (.. parsed-url -searchParams (set "state" new-state-string))
     (str parsed-url)))
 
+(defn- localized-time [tz]
+  (try
+   (.toLocaleTimeString (js/Date.)
+    (.. js/window -navigator -language)
+    #js {:hour "2-digit"
+         :minute "2-digit"
+         :format "hour:minute"
+         :timeZone tz})
+   (catch :default e
+    nil)))
+
 (defn time-with-timezone [timezone]
-  (utils/time-without-leading-zeros
-    (try
-     (.toLocaleTimeString (js/Date.)
-      (.. js/window -navigator -language)
-      #js {:hour "2-digit"
-           :minute "2-digit"
-           :format "hour:minute"
-           :timeZone timezone})
-     (catch :default e
-      nil))))
+  (when-let [localized-time (localized-time timezone)]
+    (utils/time-without-leading-zeros localized-time)))
 
 (defn timezone-location-string [user-data & [local-time-string?]]
   (str
-   (when (:timezone user-data)
+   (when-let [twt (time-with-timezone (:timezone user-data))]
      (str
-      (time-with-timezone (:timezone user-data))
+      twt
       (when local-time-string?
         " local time")))
-   (if (:location user-data)
-     (if (:timezone user-data)
+   (if (seq (:location user-data))
+     (if (seq (:timezone user-data))
        (str " (" (:location user-data) ")")
        (:location user-data))
-     (when (:timezone user-data)
-       (str " (" (:timezone user-data) ")")))))
+     (when (seq (:timezone user-data))
+       (str (:timezone user-data))))))
 
 (defun active?
   ([user :guard map?] (active? (:status user)))


### PR DESCRIPTION
To test:
- open AP
- check you can see the info popup of a few users
- check you can open the profile for them too
- now change your timezone to `US/Eastern` (this is the failing one that caused the GamerCraft issue)
- now open AP
- hover on your user
- open your profile page
