### PR TITLE
Live update user's post

### DIFF
--- a/src/oc/web/core.cljs
+++ b/src/oc/web/core.cljs
@@ -34,6 +34,7 @@
             [oc.web.actions.comment :as ca]
             [oc.web.actions.reaction :as ra]
             [oc.web.actions.section :as sa]
+            [oc.web.actions.contributions :as contrib-actions]
             [oc.web.actions.nux :as na]
             [oc.web.actions.jwt :as ja]
             [oc.web.actions.user :as user-actions]
@@ -664,6 +665,7 @@
   ;; Subscribe to websocket client events
   (aa/ws-change-subscribe)
   (sa/ws-change-subscribe)
+  (contrib-actions/subscribe)
   (oa/subscribe)
   (ra/subscribe)
   (ca/subscribe)

--- a/src/oc/web/stores/activity.cljs
+++ b/src/oc/web/stores/activity.cljs
@@ -82,6 +82,31 @@
       (assoc-in db bm-key next-bm-data))
     db))
 
+(defn add-remove-item-from-contributions
+  "Given an activity map adds or remove it from it's contributions' list of posts depending on the activity status"
+  [db org-slug activity-data]
+  (let [data-key (dispatcher/contributions-data-key org-slug (-> activity-data :publisher :user-id))]
+    (if (and (:uuid activity-data)
+             (= (:status activity-data) "published")
+             (contains? (get db (butlast data-key)) (last data-key)))
+      (let [;; Add/remove item from AP
+            publisher (:publisher activity-data)
+            data-key (dispatcher/contributions-data-key org-slug (:user-id publisher))
+            old-data (get-in db data-key)
+            old-data-posts (get old-data :posts-list)
+            without-uuid (utils/vec-dissoc old-data-posts (:uuid activity-data))
+            new-uuids (vec (conj without-uuid (:uuid activity-data)))
+            new-data-posts (map #(dispatcher/activity-data org-slug % db) new-uuids)
+            sorted-new-posts (reverse (sort-by :published-at new-data-posts))
+            sorted-new-uuids (mapv :uuid sorted-new-posts)
+            grouped-uuids (if (au/show-separators? (:board-slug activity-data))
+                            (au/grouped-posts (assoc old-data :posts-list sorted-new-uuids))
+                            sorted-new-uuids)
+            next-data (merge old-data {:posts-list sorted-new-uuids
+                                       :items-to-render grouped-uuids})]
+        (assoc-in db data-key next-data))
+      db)))
+
 (defmethod dispatcher/action :entry-edit/dismiss
   [db [_]]
   (-> db
@@ -175,6 +200,7 @@
       (add-remove-item-from-all-posts org-slug with-published-at)
       (add-remove-item-from-bookmarks org-slug with-published-at)
       (add-remove-item-from-board org-slug with-published-at)
+      (add-remove-item-from-contributions org-slug with-published-at)
       (assoc-in dispatcher/force-list-update-key (utils/activity-uuid))
       (update-in [edit-key] dissoc :publishing)
       (dissoc :entry-toggle-save-on-exit))))
@@ -207,6 +233,21 @@
                                        (get-in next-ndb (conj base-container-key :posts-list))))))
                                db
                                (keys (get-in db containers-key)))
+        ;; Remove the post from contributors lists
+        contributions-list-key (dispatcher/contributions-list-key org-slug)
+        with-fixed-contribs (reduce
+                             (fn [ndb ckey]
+                               (let [base-contributions-key (dispatcher/contributions-key org-slug ckey)
+                                     next-ndb (update-in ndb (conj base-contributions-key :posts-list)
+                                               (fn [posts-list]
+                                                 (filterv #(not= % (:uuid activity-data)) posts-list)))
+                                     items-to-render-key (conj base-contributions-key :items-to-render)]
+                                  (assoc-in next-ndb items-to-render-key
+                                   (if (au/show-separators? ckey)
+                                     (au/grouped-posts (get-in next-ndb base-contributions-key))
+                                     (get-in next-ndb (conj base-contributions-key :posts-list))))))
+                             db
+                             (keys (get-in with-fixed-containers contributions-list-key)))
         ;; Remove the post from all the boards posts list too
         boards-key (dispatcher/boards-key org-slug)
         with-fixed-boards (reduce
@@ -220,7 +261,7 @@
                                  (if (au/show-separators? ckey)
                                    (au/grouped-posts (get-in next-ndb base-board-key))
                                    (get-in next-ndb (conj base-board-key :posts-list))))))
-                           with-fixed-containers
+                           with-fixed-contribs
                            (keys (get-in db boards-key)))]
     ;; Now if the post is the one being edited in cmail let's remove it from there too
     (if (= (get-in db [:cmail-data :uuid]) (:uuid activity-data))


### PR DESCRIPTION
Card: https://trello.com/c/ZXCx6M2G

Right now if a user's list of post is shown live updates are not handled. Messages from CS comes in but they are not accounted for this kind of stream.

NB: to avoid automatic posts refresh on focus open 2 different windows with 2 different sessions of Carrot: user A from org 1 and user B from org 2. Make them visible w/o switching window (to avoid auto-refresh when you focus on a window).

To test:
- user A
- user B
- user A opens B's list of posts
- user B creates a new draft in QP
- user A sees nothing different
- user B publishes the post
- user A sees the post appear
- user A opens the post
- user B sees viewers count increment
- user A goes back to AP
- user B updates the post title and/or body
- user A sees the post changing
- user B delete the post
- user A sees the post disappearing
