### PR TITLE
Invite only verified

### DIFF
--- a/src/main/oc/web/components/team_management_modal.cljs
+++ b/src/main/oc/web/components/team_management_modal.cljs
@@ -94,7 +94,9 @@
             (if is-admin?
               "Manage team"
               "View team")]
-          (when is-admin-or-author?
+          (when (and org-data
+                     is-admin-or-author?
+                     (team-actions/invite-user-link))
             [:button.mlb-reset.save-bt
               {:on-click #(nav-actions/show-org-settings :invite-picker)}
               "Invite"])


### PR DESCRIPTION
Part of: https://trello.com/c/YBJz95A6

Review with: https://github.com/open-company/open-company-auth/pull/110

NB: this is already live on production

Description:
This was a quick change needed to avoid "hackers" (if we can call them such) send tons of invites to potentially non-existing email addresses via our UI.
Until now you could sign up on Carrot and start inviting people, initially it was good to decrease our user's friction but now it revealed to be a security hole since it can get our SES account suspended.

To test:
- signup on carrot using your gmail address (not yet in system)
- do not verify the email just yet
- get inside carrot
- try to invite someone
- [ ] did you get the prompt to verify email? Good
- [ ] did it had a button to re-send verification email? Good
- click re-send verification email
- [ ] did you get the verification email?
- [ ] now if you click Invite again the re-send button is gone? Good
- now login with your stoatlabs or carrot account (it should be verified since it came in via Slack most probably which is verifying it for us)
- [ ] do you see the invite button in the menu?
- [ ] can you invite people? Good